### PR TITLE
Come back to previous configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.7"
   - "3.6"
 install: 
-  - "pip install -e .[test]"
+  - "pip install -r requirements.txt"
+  - "pip install -r requirements_test.txt"
 script: py.test

--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -1,3 +1,14 @@
+from . import client
+from . import context
+from . import project
+from . import person
+from . import task
+from . import shot
+from . import asset
+from . import files
+from . import user
+
+
 from .exception import AuthFailedException
 
 __version__ = '0.3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
--e .[dev,test]
+requests
+cachecontrol

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+requests_mock
+pytest
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,71 @@
 #!/usr/bin/env python
-from setuptools import setup
 
-setup()
+import os
+import re
+import sys
+
+from setuptools import setup, find_packages
+
+
+def get_requirements_list(file_name):
+    requires = open(file_name).read().split("\n")
+    return [x for x in requires if len(x) > 0]
+
+
+if sys.argv[-1] == "publish":
+    os.system("python setup.py sdist upload")
+    sys.exit()
+
+packages = [
+    "gazu",
+]
+requires = get_requirements_list("requirements.txt")
+test_requirements = get_requirements_list("requirements_test.txt")
+
+with open("README.md", "r") as fd:
+    readme = fd.read()
+
+with open("gazu/__init__.py", "r") as fd:
+    version = re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+        fd.read(),
+        re.MULTILINE
+    ).group(1)
+
+if not version:
+    raise RuntimeError("Cannot find version information")
+
+setup(
+    name="Gazu",
+    version=version,
+    description="Gazu is a client for Zou, the API store the data of your CG production.",
+    long_description=readme,
+    author="CG Wire",
+    author_email="frank@cg-wire.com",
+    url="https://cg-wire.com",
+    packages=find_packages(),
+    package_data={"": ["LICENSE"]},
+    package_dir={"gazu": "gazu"},
+    include_package_data=True,
+    install_requires=requires,
+    license="LGPL",
+    zip_safe=False,
+    classifiers=(
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)"
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy"
+    ),
+    test_suite="test",
+    tests_require=test_requirements,
+    extras_require={},
+)


### PR DESCRIPTION
**Problem**

The new configuration aimed at making the package publishable on Pypi breaks previous behaviour (install via git and gazu import). 

**Solution**

Come back to previous configuration until I find how to make a backward compatible migration.