### PR TITLE
adding update asset/shot data whitout deleting not provided keys

### DIFF
--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -108,6 +108,24 @@ def new_asset(project, asset_type, name, description=""):
     ), data)
 
 
+def update_asset(asset):
+    """
+    Save given asset data into the API.
+    """
+    return client.put('data/entities/%s' % asset["id"], asset)
+
+
+def update_asset_data(asset, data={}):
+    """
+    Update the data for the provided asset.
+    Keys not provided are not updated while update_assset() delete them
+    """
+    current_asset = get_asset(asset["id"])
+    updated_asset = {'id': current_asset['id'], 'data': current_asset['data']}
+    updated_asset['data'].update(data)
+    update_asset(updated_asset)
+
+
 def remove_asset(asset):
     """
     Remove given asset from database.

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -181,6 +181,17 @@ def update_shot(shot):
     return client.put('data/entities/%s' % shot["id"], shot)
 
 
+def update_shot_data(shot, data={}):
+    """
+    Update the data for the provided shot.
+    Keys not provided are not updated while update_shot() delete them
+    """
+    current_shot = get_shot(shot["id"])
+    updated_shot = {'id': current_shot['id'], 'data': current_shot['data']}
+    updated_shot['data'].update(data)
+    update_shot(updated_shot)
+
+
 def new_scene(
     project,
     sequence,


### PR DESCRIPTION
**Problem**
- There was no function to update an asset
- There was not function to simply update the data dict of a shot or asset without deleting unprovided keys

**Solution**
- Create an update_asset function
- Create a specific function for both asset and shots that get the current data dict of the entity, update it with the provided values, and save it
