### PR TITLE
Various improvements

### DIFF
--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -8,6 +8,17 @@ from .cache import cache
 
 
 @cache
+def all_assets_for_open_projects():
+    """
+    Retrieve all assets stored in the database or for open projects.
+    """
+    all_assets = []
+    for project in pipeline_project.all_open_projects():
+        all_assets.extend(pipeline_asset.all_assets_for_project(project))
+    return sort_by_name(all_assets)
+
+
+@cache
 def all_assets_for_project(project):
     """
     Retrieve all assets stored in the database or for given project.

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -64,22 +64,6 @@ def get_asset(asset_id):
     return client.fetch_one('assets', asset_id)
 
 
-@cache
-def get_asset_type(asset_id):
-    """
-    Retrieve given asset type.
-    """
-    return client.fetch_one('asset-types', asset_id)
-
-
-@cache
-def get_asset_type_by_name(name):
-    """
-    Retrieve first asset matching given name.
-    """
-    return client.fetch_first("entity-types?name=%s" % name)
-
-
 def new_asset(project, asset_type, name, description="", extra_data={}):
     """
     Create a new asset in the database.
@@ -174,6 +158,14 @@ def get_asset_type(asset_id):
     Retrieve given asset type.
     """
     return client.fetch_one('asset-types', asset_id)
+
+
+@cache
+def get_asset_type_by_name(name):
+    """
+    Retrieve first asset matching given name.
+    """
+    return client.fetch_first("entity-types?name=%s" % name)
 
 
 @cache

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -48,9 +48,11 @@ def get_asset_by_name(project, name, asset_type=None):
     Retrieve first asset matching given name.
     """
     if asset_type is None:
-        path = "entities?project_id=%s&name=%s" % (project["id"], name)
+        path = "assets/all?project_id=%s&name=%s" % (project["id"], name)
     else:
-        path = "entities?project_id=%s&name=%s" % (project["id"], name)
+        path = "assets/all?project_id=%s&name=%s&entity_type_id=%s" % (
+            project["id"], name, asset_type["id"]
+        )
     return client.fetch_first(path)
 
 
@@ -88,11 +90,13 @@ def new_asset(project, asset_type, name, description="", extra_data={}):
         "data": extra_data
     }
 
-    get_asset_by_name(project, name, asset_type)
-    return client.post("data/projects/%s/asset-types/%s/assets/new" % (
-        project["id"],
-        asset_type["id"]
-    ), data)
+    asset = get_asset_by_name(project, name, asset_type)
+    if asset is None:
+        asset = client.post("data/projects/%s/asset-types/%s/assets/new" % (
+            project["id"],
+            asset_type["id"]
+        ), data)
+    return asset
 
 
 def update_asset(asset):

--- a/gazu/context.py
+++ b/gazu/context.py
@@ -16,6 +16,16 @@ def all_open_projects(user_context=False):
         return gazu_project.all_open_projects()
 
 
+def all_assets_for_project(project, user_context=False):
+    """
+    Return the list of assets for which the user has a task.
+    """
+    if user_context:
+        return gazu_user.all_assets_for_project(project)
+    else:
+        return gazu_asset.all_assets_for_project(project)
+
+
 def all_asset_types_for_project(project, user_context=False):
     """
     Return the list of asset types for which the user has a task.
@@ -23,7 +33,7 @@ def all_asset_types_for_project(project, user_context=False):
     if user_context:
         return gazu_user.all_asset_types_for_project(project)
     else:
-        return gazu_asset.all_types_for_project(project)
+        return gazu_asset.all_asset_types_for_project(project)
 
 
 def all_assets_for_asset_type_and_project(project, asset_type, user_context=False):

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -111,20 +111,31 @@ def get_output_file_by_path(path):
 
 
 @cache
-def all_output_files_for_entity(entity, output_type):
+def all_output_files_for_entity(
+    entity,
+    output_type,
+    representation=None
+):
     """
     Retrieves all the outputs of a given entity (asset or shot)
     and output type.
+    A representation can be given to filter output files on this parameter.
     """
     path = "data/entities/%s/output-types/%s/output-files" % (
         entity["id"],
         output_type["id"]
     )
+    if representation is not None:
+        path += "?representation=%s" % representation
     return client.get(path)
 
 
 @cache
-def all_output_files_for_asset_instance(asset_instance, output_type):
+def all_output_files_for_asset_instance(
+    asset_instance,
+    output_type,
+    representation=None
+):
     """
     Retrieves all the outputs of a given asset_instance (asset or shot)
     and output type.
@@ -133,6 +144,8 @@ def all_output_files_for_asset_instance(asset_instance, output_type):
         asset_instance["id"],
         output_type["id"]
     )
+    if representation is not None:
+        path += "?representation=%s" % representation
     return client.get(path)
 
 
@@ -248,6 +261,7 @@ def new_entity_output_file(
     name="main",
     person=None,
     revision=0,
+    nb_elements=1,
     mode="output",
     representation="",
     sep="/"
@@ -263,6 +277,7 @@ def new_entity_output_file(
         "comment": comment,
         "revision": revision,
         "representation": representation,
+        "nb_elements": nb_elements,
         "name": name,
         "sep": sep
     }
@@ -283,6 +298,7 @@ def new_asset_instance_output_file(
     person=None,
     name="master",
     revision=0,
+    nb_elements=1,
     mode="output",
     sep="/"
 ):
@@ -297,6 +313,7 @@ def new_asset_instance_output_file(
         "comment": comment,
         "name": name,
         "revision": revision,
+        "nb_elements": nb_elements,
         "representation": representation,
         "sep": sep
     }
@@ -437,6 +454,7 @@ def build_entity_output_file_path(
     mode="output",
     representation="",
     revision=0,
+    nb_elements=1,
     sep="/"
 ):
     """
@@ -468,7 +486,8 @@ def build_asset_instance_output_file_path(
     name="main",
     mode="output",
     representation="",
-    version=1,
+    revision=0,
+    nb_elements=1,
     sep="/"
 ):
     data = {
@@ -476,7 +495,8 @@ def build_asset_instance_output_file_path(
         "output_type_id": output_type["id"],
         "mode": mode,
         "name": name,
-        "version": version,
+        "revision": revision,
+        "nb_elements": nb_elements,
         "representation": representation,
         "sep": sep
     }

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -224,7 +224,7 @@ def get_next_entity_output_revision(
 
 
 def get_next_asset_instance_output_revision(
-    entity,
+    asset_instance,
     output_type,
     task_type,
     name="master"
@@ -232,7 +232,8 @@ def get_next_asset_instance_output_revision(
     """
     Generate next expected output revision for given entity.
     """
-    path = "data/asset-instances/%s/output-files/next-revision" % entity["id"]
+    path = "data/asset-instances/%s" % asset_instance["id"] + \
+           "/output-files/next-revision"
     data = {
         "name": name,
         "output_type_id": output_type["id"],

--- a/gazu/scene.py
+++ b/gazu/scene.py
@@ -64,7 +64,7 @@ def get_scene_by_name(sequence, scene_name):
     """
     Returns scene corresponding to given sequence and name.
     """
-    result = client.fetch_all("entities?parent_id=%s&name=%s" % (
+    result = client.fetch_all("scenes/all?parent_id=%s&name=%s" % (
         sequence["id"],
         scene_name
     ))

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -69,7 +69,7 @@ def get_episode_by_name(project, episode_name):
     """
     Returns episode corresponding to given name and project.
     """
-    return client.fetch_first("entities?project_id=%s&name=%s" % (
+    return client.fetch_first("episodes?project_id=%s&name=%s" % (
         project["id"],
         episode_name
     ))
@@ -89,9 +89,9 @@ def get_sequence_by_name(project, sequence_name, episode=None):
     Returns sequence corresponding to given name and project.
     """
     if episode is None:
-        path = "entities?project_id=%s&name=%s" % (project["id"], sequence_name)
+        path = "sequences?project_id=%s&name=%s" % (project["id"], sequence_name)
     else:
-        path = "entities?parent_id=%s&name=%s" % (episode["id"], sequence_name)
+        path = "sequences?parent_id=%s&name=%s" % (episode["id"], sequence_name)
 
     return client.fetch_first(path)
 
@@ -109,7 +109,7 @@ def get_shot_by_name(sequence, shot_name):
     """
     Returns shot corresponding to given sequence and name.
     """
-    return client.fetch_first("entities?parent_id=%s&name=%s" % (
+    return client.fetch_first("shots/all?parent_id=%s&name=%s" % (
         sequence["id"],
         shot_name
     ))

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -132,6 +132,14 @@ def get_task_by_name(entity, task_type, name):
 
 
 @cache
+def get_task_type(task_type_id):
+    """
+    Return task type object for given name.
+    """
+    return client.fetch_one("task-types", task_type_id)
+
+
+@cache
 def get_task_type_by_name(task_type_name):
     """
     Return task type object for given name.

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -114,7 +114,7 @@ class AssetTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?project_id=project-1&name=test"
+                    "data/assets/all?project_id=project-1&name=test"
                 ),
                 text=json.dumps([
                     {"name": "Asset 01", "project_id": "project-1"}
@@ -137,7 +137,7 @@ class AssetTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?project_id=project-id&name=Car"
+                    "data/assets/all?project_id=project-id&name=Car"
                 ),
                 text=json.dumps([])
             )

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -407,6 +407,22 @@ class FilesTestCase(unittest.TestCase):
                 {"id": "asset-1"},
                 {"id": "output-type-1"},
             )
+
+            path = "/data/entities/asset-1/output-types/utput-type-1/" \
+                   "output-files?representation=obj"
+            mock.get(
+                gazu.client.get_full_url(path),
+                text=json.dumps([{
+                    "id": "output-file-01",
+                    "name": "main",
+                    "representation": "obj"
+                }])
+            )
+            output_type = gazu.files.all_output_files_for_entity(
+                {"id": "asset-1"},
+                {"id": "output-type-1"},
+                representation="obj"
+            )
             self.assertEquals(output_type[0]["name"], "main")
 
     def test_get_output_files_for_asset_instance(self):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -21,7 +21,7 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?parent_id=sequence-1&name=Scene01"
+                    "data/scenes/all?parent_id=sequence-1&name=Scene01"
                 ),
                 text=json.dumps([
                     {"name": "Scene01", "project_id": "project-1"}

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -144,7 +144,7 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?parent_id=sequence-1&name=Shot01"
+                    "data/shots/all?parent_id=sequence-1&name=Shot01"
                 ),
                 text=json.dumps([
                     {"name": "Shot01", "project_id": "project-1"}
@@ -158,7 +158,7 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?project_id=project-1&name=Sequence01"
+                    "data/sequences?project_id=project-1&name=Sequence01"
                 ),
                 text=json.dumps([
                     {"name": "Sequence01", "project_id": "project-1"}
@@ -172,7 +172,7 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?project_id=project-1&name=Episode 01"
+                    "data/episodes?project_id=project-1&name=Episode 01"
                 ),
                 text=json.dumps([])
             )
@@ -190,7 +190,7 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?parent_id=episode-1&name=Sequence 01"
+                    "data/sequences?parent_id=episode-1&name=Sequence 01"
                 ),
                 text=json.dumps([])
             )
@@ -212,7 +212,7 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/entities?parent_id=sequence-1&name=Shot 01"
+                    "data/shots/all?parent_id=sequence-1&name=Shot 01"
                 ),
                 text=json.dumps([])
             )


### PR DESCRIPTION
**Problem**

* Retreving asset, shot, scene, sequence or episode by name can lead to unexpected result (having a shot as result of getting an asset (#26)
* There is no function to retrieve a task type from its id
* Output files cannot be filtered on representation

**Solution**

* Use specific routes instead of generic one to get entities by name
* Add a function to get a task type from its id
* `all_output_files` functions allow to filter them on representation
