### PR TITLE
Set project file tree and allow to download files

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -208,6 +208,21 @@ def upload(path, file_path):
     return requests_session.post(url, files=files).json()
 
 
+def download(path, file_path):
+    """
+    Upload file located at *file_path* to given url *path*.
+    """
+    url = get_full_url(path)
+    response = requests_session.get(
+        url,
+        headers=make_auth_header(),
+        stream=True
+    )
+    print(url)
+    with open(file_path, 'wb') as target_file:
+        target_file.write(response.content)
+
+
 def get_api_version():
     """
     Get current version of the API.

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -1,6 +1,7 @@
 from . import client
 
 from .cache import cache
+from .helpers import normalize_model_parameter
 
 
 @cache
@@ -521,3 +522,13 @@ def set_project_file_tree(project, file_tree_name):
     data = {"tree_name": file_tree_name}
     path = "actions/projects/%s/set-file-tree" % project["id"]
     return client.post(path, data)
+
+
+def update_project_file_tree(project, file_tree):
+    """
+    Set given dict as file tree to generate files for given project.
+    """
+    project = normalize_model_parameter(project)
+    data = {"file_tree": file_tree}
+    path = "data/projects/%s" % project["id"]
+    return client.put(path, data)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -567,3 +567,23 @@ class FilesTestCase(unittest.TestCase):
                 ".max"
             )
             self.assertEquals(output_type["id"], "software-01")
+
+    def test_update_project_file_tree(self):
+        with requests_mock.mock() as mock:
+            file_tree = {
+                "name": "standard file tree",
+                "template": "<Project>/<AssetType>/<Asset>/<Task>"
+            }
+            path = "data/projects/project-01"
+            mock.put(
+                gazu.client.get_full_url(path),
+                text=json.dumps({
+                    "id": "project-id",
+                    "file_tree": file_tree
+                })
+            )
+            file_tree = gazu.files.update_project_file_tree(
+                "project-01",
+                file_tree
+            )["file_tree"]
+            self.assertEquals(file_tree["name"], "standard file tree")


### PR DESCRIPTION
**Problem**

* There is no simple way to update the project file tree.
* There is no method to download files from the api.

**Solution**

* Add missing method to the project module
* Add missing method to the raw client
