### PR TITLE
Better handling of server errors

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -158,7 +158,20 @@ def check_status(request, path):
     elif (status_code in [401, 422]):
         raise NotAuthenticatedException(path)
     elif (status_code in [500, 502]):
-        print(request.text)
+        try:
+            stacktrace = request.json().get(
+                "stacktrace",
+                "No stacktrace sent by the server"
+            )
+            message = request.json().get(
+                "message",
+                "No message sent by the server"
+            )
+            print("A server error occured!\n")
+            print("Server stacktrace:\n%s" % stacktrace)
+            print("Error message:\n%s\n" % message)
+        except:
+            print(request.text)
         raise ServerErrorException(path)
     return status_code
 


### PR DESCRIPTION

**Problem**

When an error occurs on server, the html error message is hard to read.

**Solution**

It prints a formated message when a request fails with a 500 status. It takes advantage of the new JSON formatting of server error implemented in the 0.9.1 version of Zou.

