### PR TITLE
Fix README quickstart examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ needs to know where is located the API server and to log in:
 
     import gazu
 
-    gazu.set_host("https://zou-server-url")
+    gazu.set_host("https://zou-server-url/api")
     gazu.log_in("user@yourdomain.com", "password")
 
 Let's finish with an example. Fetch all the open projects:

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Let's finish with an example. Fetch all the open projects:
 
 ::
 
-    projects = gazu.projects.open_projects()
+    projects = gazu.project.all_open_projects()
 
 Then jump to the `documentation <https://gazu.cg-wire.com>`__ to see
 what features are available!


### PR DESCRIPTION
**Problem**
The Quickstart examples in the README did not work as expected.

**Solution**
Fix them. :)

- Add `/api` suffix to the host url.
- Update the list all open projects example code.
