### PR TITLE
Fix gazu.user.all_tasks_to_do() 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ doing software and focus more on the artistic work.
 
 Visit `cg-wire.com <https://cg-wire.com>`__ for more information.
 
-[![CGWire Logo](https://zou.cg-wire.com/cgwire.png)](https://cg-wire.com)
+|CGWire Logo|
 
 .. |Build status| image:: https://api.travis-ci.org/cgwire/gazu.svg?branch=master
    :target: https://travis-ci.org/cgwire/gazu

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ doing software and focus more on the artistic work.
 
 Visit `cg-wire.com <https://cg-wire.com>`__ for more information.
 
-|CGWire Logo|
+[![CGWire Logo](https://zou.cg-wire.com/cgwire.png)](https://cg-wire.com)
 
 .. |Build status| image:: https://api.travis-ci.org/cgwire/gazu.svg?branch=master
    :target: https://travis-ci.org/cgwire/gazu

--- a/gazu/user.py
+++ b/gazu/user.py
@@ -210,7 +210,7 @@ def all_tasks_to_do():
     Returns:
         list: Tasks assigned to current user which are not complete.
     """
-    return client.fetch_all("/data/users/tasks")
+    return client.fetch_all("user/tasks")
 
 
 def log_desktop_session_log_in():


### PR DESCRIPTION
**Problem**
The example [`tasks = gazu.user.all_tasks_to_do()`](https://gazu.cg-wire.com/examples.html#get-user-todo-list) does not work.

The error is:
```python
>>> gazu.user.all_tasks_to_do()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python27\lib\site-packages\gazu\cache.py", line 196, in wrapper
    return function(*args, **kwargs)
  File "C:\Python27\lib\site-packages\gazu\user.py", line 213, in all_tasks_to_do
    return client.fetch_all("/data/users/tasks")
  File "C:\Python27\lib\site-packages\gazu\client.py", line 239, in fetch_all
    return get(url_path_join('data', path))
  File "C:\Python27\lib\site-packages\gazu\client.py", line 119, in get
    check_status(response, path)
  File "C:\Python27\lib\site-packages\gazu\client.py", line 196, in check_status
    raise RouteNotFoundException(path)
gazu.exception.RouteNotFoundException: data/data/users/tasks
```


**Solution**

I fixed it to match the other functions.

~Still need to test this!~ - Works!

---

Sorry for the messy commits on the logo. ;)