### PR TITLE
Fix normalize_model_parameter to accept unicode arguments in python 2

### DIFF
--- a/gazu/helpers.py
+++ b/gazu/helpers.py
@@ -1,3 +1,8 @@
+import re
+
+_UUID_RE = re.compile("([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}")
+
+
 def normalize_model_parameter(model_parameter):
     """
     Args:
@@ -10,9 +15,15 @@ def normalize_model_parameter(model_parameter):
     """
     if model_parameter is None:
         return None
-    elif isinstance(model_parameter, str):
-        return {"id": model_parameter}
     elif isinstance(model_parameter, dict):
         return model_parameter
     else:
-        raise ValueError("Wrong format: expected ID string or Data dict")
+        try:
+            id_str = str(model_parameter)
+        except Exception:
+            raise ValueError("Failed to cast argument to str")
+
+        if _UUID_RE.match(id_str):
+            return {"id": id_str}
+        else:
+            raise ValueError("Wrong format: expected ID string or Data dict")

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -10,48 +10,48 @@ class AssetTestCase(unittest.TestCase):
     def test_all_assets_for_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/shots/shot-1/assets"),
+                gazu.client.get_full_url("data/shots/shot-01/assets"),
                 text=json.dumps(
-                    [{"name": "Asset 01", "project_id": "project-1"}]
+                    [{"name": "Asset 01", "project_id": "project-01"}]
                 ),
             )
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             assets = gazu.asset.all_assets_for_shot(shot)
             self.assertEqual(len(assets), 1)
             asset_instance = assets[0]
             self.assertEqual(asset_instance["name"], "Asset 01")
-            self.assertEqual(asset_instance["project_id"], "project-1")
+            self.assertEqual(asset_instance["project_id"], "project-01")
 
     def test_all_assets_for_project(self):
         with requests_mock.mock() as mock:
-            path = "data/projects/project-1/assets"
+            path = "data/projects/project-01/assets"
             mock.get(
                 gazu.client.get_full_url(path),
-                text='[{"name": "Asset 01", "project_id": "project-1"}]',
+                text='[{"name": "Asset 01", "project_id": "project-01"}]',
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             assets = gazu.asset.all_assets_for_project(project)
             self.assertEqual(len(assets), 1)
             asset = assets[0]
             self.assertEqual(asset["name"], "Asset 01")
-            self.assertEqual(asset["project_id"], "project-1")
+            self.assertEqual(asset["project_id"], "project-01")
 
     def test_all_assets_for_project_and_type(self):
         with requests_mock.mock() as mock:
-            path = "data/projects/project-1/asset-types/asset-type-1/assets"
+            path = "data/projects/project-01/asset-types/asset-type-01/assets"
             mock.get(
                 gazu.client.get_full_url(path),
-                text='[{"name": "Asset 01", "project_id": "project-1"}]',
+                text='[{"name": "Asset 01", "project_id": "project-01"}]',
             )
-            project = {"id": "project-1"}
-            asset_type = {"id": "asset-type-1"}
+            project = {"id": "project-01"}
+            asset_type = {"id": "asset-type-01"}
             assets = gazu.asset.all_assets_for_project_and_type(
                 project, asset_type
             )
             self.assertEqual(len(assets), 1)
             asset = assets[0]
             self.assertEqual(asset["name"], "Asset 01")
-            self.assertEqual(asset["project_id"], "project-1")
+            self.assertEqual(asset["project_id"], "project-01")
 
     def test_all_asset_types(self):
         with requests_mock.mock() as mock:
@@ -90,33 +90,33 @@ class AssetTestCase(unittest.TestCase):
     def test_get_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/assets/asset-1"),
-                text='{"name": "Asset 01", "project_id": "project-1"}',
+                gazu.client.get_full_url("data/assets/asset-01"),
+                text='{"name": "Asset 01", "project_id": "project-01"}',
             )
-            asset = gazu.asset.get_asset("asset-1")
+            asset = gazu.asset.get_asset("asset-01")
             self.assertEqual(asset["name"], "Asset 01")
 
     def test_get_asset_by_name(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/assets/all?project_id=project-1&name=test"
+                    "data/assets/all?project_id=project-01&name=test"
                 ),
                 text=json.dumps(
-                    [{"name": "Asset 01", "project_id": "project-1"}]
+                    [{"name": "Asset 01", "project_id": "project-01"}]
                 ),
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             asset = gazu.asset.get_asset_by_name(project, "test")
             self.assertEqual(asset["name"], "Asset 01")
 
     def test_get_asset_type(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/asset-types/asset-type-1"),
-                text='{"name": "Asset Type 01", "id": "asset-type-1"}',
+                gazu.client.get_full_url("data/asset-types/asset-type-01"),
+                text='{"name": "Asset Type 01", "id": "asset-type-01"}',
             )
-            asset = gazu.asset.get_asset_type("asset-type-1")
+            asset = gazu.asset.get_asset_type("asset-type-01")
             self.assertEqual(asset["name"], "Asset Type 01")
 
     def test_create_asset(self):
@@ -149,7 +149,7 @@ class AssetTestCase(unittest.TestCase):
             )
             mock.post(
                 gazu.client.get_full_url("data/entity-types/"),
-                text=json.dumps({"id": "asset-type-1", "name": "Characters"}),
+                text=json.dumps({"id": "asset-type-01", "name": "Characters"}),
             )
             name = "Characters"
             asset_type = gazu.asset.new_asset_type(name)
@@ -159,35 +159,35 @@ class AssetTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             name = "Modeling edited"
             mock.put(
-                gazu.client.get_full_url("data/asset-types/asset-type-1"),
-                text=json.dumps({"id": "asset-type-1", "name": name}),
+                gazu.client.get_full_url("data/asset-types/asset-type-01"),
+                text=json.dumps({"id": "asset-type-01", "name": name}),
             )
-            asset_type = {"id": "asset-type-1", "name": name}
+            asset_type = {"id": "asset-type-01", "name": name}
             response = gazu.asset.update_asset_type(asset_type)
             self.assertEqual(response["name"], name)
 
     def test_remove_asset_type(self):
         with requests_mock.mock() as mock:
             mock.delete(
-                gazu.client.get_full_url("data/asset-types/asset-type-1"),
+                gazu.client.get_full_url("data/asset-types/asset-type-01"),
                 text="",
             )
-            asset_type = {"id": "asset-type-1", "name": "Modeling edited"}
+            asset_type = {"id": "asset-type-01", "name": "Modeling edited"}
             response = gazu.asset.remove_asset_type(asset_type)
             self.assertEqual(response, "")
 
     def test_remove_asset(self):
         with requests_mock.mock() as mock:
             mock.delete(
-                gazu.client.get_full_url("data/assets/asset-1"), status_code=204
+                gazu.client.get_full_url("data/assets/asset-01"), status_code=204
             )
-            asset = {"id": "asset-1", "name": "Table"}
+            asset = {"id": "asset-01", "name": "Table"}
             gazu.asset.remove_asset(asset)
             mock.delete(
-                gazu.client.get_full_url("data/assets/asset-1?force=true"),
+                gazu.client.get_full_url("data/assets/asset-01?force=true"),
                 status_code=204,
             )
-            asset = {"id": "asset-1", "name": "Table"}
+            asset = {"id": "asset-01", "name": "Table"}
             gazu.asset.remove_asset(asset, True)
 
     def test_get_asset_instance(self):
@@ -195,102 +195,102 @@ class AssetTestCase(unittest.TestCase):
             mock.get(
                 gazu.client.get_full_url("data/asset-instances/instance-1"),
                 text=json.dumps(
-                    {"asset_id": "asset-1", "shot_id": "shot-1", "number": 1}
+                    {"asset_id": "asset-01", "shot_id": "shot-01", "number": 1}
                 ),
             )
             asset_instance = gazu.asset.get_asset_instance("instance-1")
-            self.assertEqual(asset_instance["asset_id"], "asset-1")
-            self.assertEqual(asset_instance["shot_id"], "shot-1")
+            self.assertEqual(asset_instance["asset_id"], "asset-01")
+            self.assertEqual(asset_instance["shot_id"], "shot-01")
             self.assertEqual(asset_instance["number"], 1)
 
     def test_all_shot_asset_instances_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/assets/asset-1/shot-asset-instances"
+                    "data/assets/asset-01/shot-asset-instances"
                 ),
                 text=json.dumps(
-                    [{"asset_id": "asset-1", "shot_id": "shot-1", "number": 1}]
+                    [{"asset_id": "asset-01", "shot_id": "shot-01", "number": 1}]
                 ),
             )
             asset_instance = gazu.asset.all_shot_asset_instances_for_asset(
-                {"id": "asset-1"}
+                {"id": "asset-01"}
             )[0]
-            self.assertEqual(asset_instance["asset_id"], "asset-1")
-            self.assertEqual(asset_instance["shot_id"], "shot-1")
+            self.assertEqual(asset_instance["asset_id"], "asset-01")
+            self.assertEqual(asset_instance["shot_id"], "shot-01")
             self.assertEqual(asset_instance["number"], 1)
 
     def test_get_scene_asset_instances_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/assets/asset-1/scene-asset-instances"
+                    "data/assets/asset-01/scene-asset-instances"
                 ),
                 text=json.dumps(
-                    [{"asset_id": "asset-1", "shot_id": "shot-1", "number": 1}]
+                    [{"asset_id": "asset-01", "shot_id": "shot-01", "number": 1}]
                 ),
             )
             asset_instance = gazu.asset.all_scene_asset_instances_for_asset(
-                {"id": "asset-1"}
+                {"id": "asset-01"}
             )[0]
-            self.assertEqual(asset_instance["asset_id"], "asset-1")
-            self.assertEqual(asset_instance["shot_id"], "shot-1")
+            self.assertEqual(asset_instance["asset_id"], "asset-01")
+            self.assertEqual(asset_instance["shot_id"], "shot-01")
             self.assertEqual(asset_instance["number"], 1)
 
     def test_all_asset_instances_for_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/shots/shot-1/asset-instances"),
+                gazu.client.get_full_url("data/shots/shot-01/asset-instances"),
                 text=json.dumps(
-                    [{"asset_id": "asset-1", "shot_id": "shot-1", "number": 1}]
+                    [{"asset_id": "asset-01", "shot_id": "shot-01", "number": 1}]
                 ),
             )
             shot_instance = gazu.asset.all_asset_instances_for_shot(
-                {"id": "shot-1"}
+                {"id": "shot-01"}
             )[0]
-            self.assertEqual(shot_instance["asset_id"], "asset-1")
-            self.assertEqual(shot_instance["shot_id"], "shot-1")
+            self.assertEqual(shot_instance["asset_id"], "asset-01")
+            self.assertEqual(shot_instance["shot_id"], "shot-01")
             self.assertEqual(shot_instance["number"], 1)
 
     def test_all_asset_instances_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/assets/asset-1/asset-asset-instances"
+                    "data/assets/asset-01/asset-asset-instances"
                 ),
                 text=json.dumps(
                     [
                         {
-                            "asset_id": "asset-2",
-                            "target_asset_id": "asset-1",
+                            "asset_id": "asset-02",
+                            "target_asset_id": "asset-01",
                             "number": 1,
                         }
                     ]
                 ),
             )
             asset_instances = gazu.asset.all_asset_instances_for_asset(
-                "asset-1"
+                "asset-01"
             )
             asset_instance = asset_instances[0]
-            self.assertEqual(asset_instance["asset_id"], "asset-2")
-            self.assertEqual(asset_instance["target_asset_id"], "asset-1")
+            self.assertEqual(asset_instance["asset_id"], "asset-02")
+            self.assertEqual(asset_instance["target_asset_id"], "asset-01")
             self.assertEqual(asset_instance["number"], 1)
 
     def test_new_asset_asset_instance(self):
         with requests_mock.mock() as mock:
             result = {
                 "id": "asset-instance-01",
-                "asset_id": "asset-1",
-                "target_asset_id": "asset-2",
+                "asset_id": "asset-01",
+                "target_asset_id": "asset-02",
             }
             mock = mock.post(
                 gazu.client.get_full_url(
-                    "data/assets/asset-1/asset-asset-instances"
+                    "data/assets/asset-01/asset-asset-instances"
                 ),
                 text=json.dumps(result),
             )
-            asset = {"id": "asset-1"}
-            asset_to_instantiate = {"id": "asset-2"}
+            asset = {"id": "asset-01"}
+            asset_to_instantiate = {"id": "asset-02"}
             asset_instance = gazu.asset.new_asset_asset_instance(
                 asset, asset_to_instantiate
             )

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -5,6 +5,8 @@ import requests_mock
 import gazu.asset
 import gazu.client
 
+from utils import fakeid
+
 
 class AssetTestCase(unittest.TestCase):
     def test_all_assets_for_shot(self):
@@ -256,24 +258,25 @@ class AssetTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/assets/asset-01/asset-asset-instances"
+                    "data/assets/{}/asset-asset-instances"
+                    .format(fakeid("asset-01"))
                 ),
                 text=json.dumps(
                     [
                         {
-                            "asset_id": "asset-02",
-                            "target_asset_id": "asset-01",
+                            "asset_id": fakeid("asset-02"),
+                            "target_asset_id": fakeid("asset-01"),
                             "number": 1,
                         }
                     ]
                 ),
             )
             asset_instances = gazu.asset.all_asset_instances_for_asset(
-                "asset-01"
+                fakeid("asset-01")
             )
             asset_instance = asset_instances[0]
-            self.assertEqual(asset_instance["asset_id"], "asset-02")
-            self.assertEqual(asset_instance["target_asset_id"], "asset-01")
+            self.assertEqual(asset_instance["asset_id"], fakeid("asset-02"))
+            self.assertEqual(asset_instance["target_asset_id"], fakeid("asset-01"))
             self.assertEqual(asset_instance["number"], 1)
 
     def test_new_asset_asset_instance(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,13 +11,13 @@ class CacheTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock_open = mock.get(
                 gazu.client.get_full_url("data/projects/open"),
-                text=json.dumps([{"name": "Agent 327", "id": "project_1"}]),
+                text=json.dumps([{"name": "Agent 327", "id": "project-01"}]),
             )
             mock_all = mock.get(
                 gazu.client.get_full_url("data/projects"),
                 text=json.dumps(
                     [
-                        {"name": "Agent 327", "id": "project_1"},
+                        {"name": "Agent 327", "id": "project-01"},
                         {"name": "Big Buck Bunny", "id": "project_2"},
                     ]
                 ),
@@ -51,11 +51,11 @@ class CacheTestCase(unittest.TestCase):
     def test_max_size(self):
         with requests_mock.mock() as mock:
             mock_1 = mock.get(
-                gazu.client.get_full_url("data/projects/project-1"),
-                text=json.dumps({"name": "Agent 327", "id": "project_1"}),
+                gazu.client.get_full_url("data/projects/project-01"),
+                text=json.dumps({"name": "Agent 327", "id": "project-01"}),
             )
             mock_2 = mock.get(
-                gazu.client.get_full_url("data/projects/project-2"),
+                gazu.client.get_full_url("data/projects/project-02"),
                 text=json.dumps({"name": "Agent 327 02", "id": "project_2"}),
             )
             mock_3 = mock.get(
@@ -65,19 +65,19 @@ class CacheTestCase(unittest.TestCase):
 
             gazu.cache.enable()
             gazu.project.get_project.set_cache_max_size(2)
-            gazu.project.get_project("project-1")
-            gazu.project.get_project("project-1")
-            gazu.project.get_project("project-1")
+            gazu.project.get_project("project-01")
+            gazu.project.get_project("project-01")
+            gazu.project.get_project("project-01")
             self.assertEqual(mock_1.call_count, 1)
-            gazu.project.get_project("project-2")
-            gazu.project.get_project("project-2")
-            gazu.project.get_project("project-1")
+            gazu.project.get_project("project-02")
+            gazu.project.get_project("project-02")
+            gazu.project.get_project("project-01")
             self.assertEqual(mock_2.call_count, 1)
             self.assertEqual(mock_1.call_count, 1)
 
             gazu.project.get_project("project-3")
             gazu.project.get_project("project-3")
-            gazu.project.get_project("project-1")
+            gazu.project.get_project("project-01")
             self.assertEqual(mock_3.call_count, 1)
             self.assertEqual(mock_1.call_count, 2)
             gazu.cache.disable()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,11 +67,11 @@ class BaseFuncTestCase(ClientTestCase):
         with requests_mock.mock() as mock:
             mock.post(
                 client.get_full_url("data/persons"),
-                text='{"id": "person-1", "first_name": "John"}',
+                text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.post("data/persons", "person-1"),
-                {"id": "person-1", "first_name": "John"},
+                client.post("data/persons", "person-01"),
+                {"id": "person-01", "first_name": "John"},
             )
 
     def test_post_with_a_date_field(self):
@@ -79,28 +79,28 @@ class BaseFuncTestCase(ClientTestCase):
         with requests_mock.mock() as mock:
             mock.post(
                 client.get_full_url("data/persons"),
-                text='{"id": "person-1", "first_name": "John"}',
+                text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
                 client.post("data/persons", {"birth_date": now}),
-                {"id": "person-1", "first_name": "John"},
+                {"id": "person-01", "first_name": "John"},
             )
 
     def test_put(self):
         with requests_mock.mock() as mock:
             mock.put(
                 client.get_full_url("data/persons"),
-                text='{"id": "person-1", "first_name": "John"}',
+                text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.put("data/persons", "person-1"),
-                {"id": "person-1", "first_name": "John"},
+                client.put("data/persons", "person-01"),
+                {"id": "person-01", "first_name": "John"},
             )
 
     def test_delete(self):
         with requests_mock.mock() as mock:
-            mock.delete(client.get_full_url("data/persons/person-1"), text="")
-            self.assertEqual(client.delete("data/persons/person-1"), "")
+            mock.delete(client.get_full_url("data/persons/person-01"), text="")
+            self.assertEqual(client.delete("data/persons/person-01"), "")
 
     def test_fetch_all(self):
         with requests_mock.mock() as mock:
@@ -144,23 +144,23 @@ class BaseFuncTestCase(ClientTestCase):
     def test_fetch_one(self):
         with requests_mock.mock() as mock:
             mock.get(
-                client.get_full_url("data/persons/person-1"),
-                text='{"id": "person-1", "first_name": "John"}',
+                client.get_full_url("data/persons/person-01"),
+                text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.fetch_one("persons", "person-1"),
-                {"id": "person-1", "first_name": "John"},
+                client.fetch_one("persons", "person-01"),
+                {"id": "person-01", "first_name": "John"},
             )
 
     def test_create(self):
         with requests_mock.mock() as mock:
             mock.post(
                 client.get_full_url("data/persons"),
-                text='{"id": "person-1", "first_name": "John"}',
+                text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
                 client.create("persons", {"first_name": "John"}),
-                {"id": "person-1", "first_name": "John"},
+                {"id": "person-01", "first_name": "John"},
             )
 
     def test_version(self):

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -11,14 +11,14 @@ class AssetTestCase(unittest.TestCase):
     def test_all_entities(self):
         entities = [
             {
-                "id": "asset-1",
+                "id": "asset-01",
                 "name": "Asset 01",
-                "project_id": "project-1",
+                "project_id": "project-01",
             },
             {
-                "id": "shot-1",
+                "id": "shot-01",
                 "name": "Shot 01",
-                "project_id": "project-1",
+                "project_id": "project-01",
             }
         ]
         with requests_mock.mock() as mock:
@@ -32,18 +32,18 @@ class AssetTestCase(unittest.TestCase):
     def test_get_entity(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/entities/asset-1"),
+                gazu.client.get_full_url("data/entities/asset-01"),
                 text=json.dumps(
                     {
-                        "id": "asset-1",
+                        "id": "asset-01",
                         "name": "Asset 01",
-                        "project_id": "project-1",
+                        "project_id": "project-01",
                     }
                 ),
             )
-            entity = gazu.entity.get_entity("asset-1")
+            entity = gazu.entity.get_entity("asset-01")
             self.assertEqual(entity["name"], "Asset 01")
-            self.assertEqual(entity["project_id"], "project-1")
+            self.assertEqual(entity["project_id"], "project-01")
 
     def test_get_entity_type(self):
         with requests_mock.mock() as mock:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -33,7 +33,7 @@ class FilesTestCase(unittest.TestCase):
             )
             task = {"id": "task-01"}
             working_file = gazu.files.new_working_file(
-                task, person={"id": "person-1"}, software={"id": "software-1"}
+                task, person={"id": "person-01"}, software={"id": "software-1"}
             )
             self.assertEqual(working_file["id"], 1)
 
@@ -297,12 +297,12 @@ class FilesTestCase(unittest.TestCase):
 
     def test_all_output_types_for_entity(self):
         with requests_mock.mock() as mock:
-            path = "/data/entities/asset-1/output-types/"
+            path = "/data/entities/asset-01/output-types/"
             mock.get(
                 gazu.client.get_full_url(path),
                 text=json.dumps([{"id": "output-type-01", "name": "geometry"}]),
             )
-            asset = {"id": "asset-1"}
+            asset = {"id": "asset-01"}
             output_type = gazu.files.all_output_types_for_entity(asset)
             self.assertEqual(output_type[0]["name"], "geometry")
 
@@ -355,7 +355,7 @@ class FilesTestCase(unittest.TestCase):
 
     def test_get_output_files_for_entity(self):
         with requests_mock.mock() as mock:
-            base_path = "entities/asset-1/output-files"
+            base_path = "entities/asset-01/output-files"
             path = gazu.client.url_path_join("data", base_path)
             params = {"output_type_id": u"output-type-1"}
 
@@ -366,7 +366,7 @@ class FilesTestCase(unittest.TestCase):
                 text=json.dumps([{"id": "output-file-01", "name": "main"}]),
             )
             output_files = gazu.files.all_output_files_for_entity(
-                {"id": "asset-1"}, output_type={"id": "output-type-1"}
+                {"id": "asset-01"}, output_type={"id": "output-type-1"}
             )
             self.assertEqual(output_files[0]["name"], "main")
 
@@ -390,7 +390,7 @@ class FilesTestCase(unittest.TestCase):
                 ),
             )
             output_files = gazu.files.all_output_files_for_entity(
-                {"id": "asset-1"}, {"id": "output-type-1"}, representation="obj"
+                {"id": "asset-01"}, {"id": "output-type-1"}, representation="obj"
             )
             self.assertEqual(output_files[0]["name"], "main")
 
@@ -457,7 +457,7 @@ class FilesTestCase(unittest.TestCase):
             result_path = "/path/to/entity/file_name.cache"
             mock.post(
                 gazu.client.get_full_url(
-                    "data/entities/asset-1/" "output-file-path"
+                    "data/entities/asset-01/" "output-file-path"
                 ),
                 text=json.dumps(
                     {
@@ -466,9 +466,9 @@ class FilesTestCase(unittest.TestCase):
                     }
                 ),
             )
-            asset = {"id": "asset-1"}
+            asset = {"id": "asset-01"}
             output_type = {"id": "output-type-1"}
-            task_type = {"id": "task-type-1"}
+            task_type = {"id": "task-type-01"}
             path = gazu.files.build_entity_output_file_path(
                 asset, output_type, task_type
             )
@@ -492,7 +492,7 @@ class FilesTestCase(unittest.TestCase):
             asset_instance = {"id": "asset-instance-1"}
             scene = {"id": "scene-1"}
             output_type = {"id": "output-type-1"}
-            task_type = {"id": "task-type-1"}
+            task_type = {"id": "task-type-01"}
             path = gazu.files.build_asset_instance_output_file_path(
                 asset_instance, scene, output_type, task_type
             )

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,11 +1,13 @@
-import os
-import unittest
+import datetime
 import json
+import os
 import requests_mock
+import unittest
 
 import gazu.client
 import gazu.files
-import datetime
+
+from utils import fakeid
 
 
 class FilesTestCase(unittest.TestCase):
@@ -532,27 +534,30 @@ class FilesTestCase(unittest.TestCase):
                 "name": "standard file tree",
                 "template": "<Project>/<AssetType>/<Asset>/<Task>",
             }
-            path = "data/projects/project-01"
+            path = "data/projects/{}".format(fakeid("project-01"))
             mock.put(
                 gazu.client.get_full_url(path),
-                text=json.dumps({"id": "project-id", "file_tree": file_tree}),
+                text=json.dumps({"id": fakeid("project-01"),
+                                 "file_tree": file_tree}),
             )
             file_tree = gazu.files.update_project_file_tree(
-                "project-01", file_tree
+                fakeid("project-01"), file_tree
             )["file_tree"]
             self.assertEqual(file_tree["name"], "standard file tree")
 
     def test_download_preview_file(self):
         with open("./tests/fixtures/v1.png", "rb") as thumbnail_file:
             with requests_mock.mock() as mock:
-                path = "data/preview-files/preview-1"
+                path = "data/preview-files/{}".format(fakeid("preview-1"))
                 mock.get(
                     gazu.client.get_full_url(path),
-                    text=json.dumps({"id": "preview-1", "extension": "png"}),
+                    text=json.dumps({"id": fakeid("preview-1"),
+                                     "extension": "png"}),
                 )
-                path = "pictures/originals/preview-files/preview-1.png"
+                path = ("pictures/originals/preview-files/{}.png"
+                        .format(fakeid("preview-1")))
                 mock.get(gazu.client.get_full_url(path), body=thumbnail_file)
-                gazu.files.download_preview_file("preview-1", "./test.png")
+                gazu.files.download_preview_file(fakeid("preview-1"), "./test.png")
                 self.assertTrue(os.path.exists("./test.png"))
                 self.assertEqual(
                     os.path.getsize("./test.png"),
@@ -562,10 +567,11 @@ class FilesTestCase(unittest.TestCase):
     def test_download_preview_file_thumbnail(self):
         with open("./tests/fixtures/v1.png", "rb") as thumbnail_file:
             with requests_mock.mock() as mock:
-                path = "pictures/thumbnails/preview-files/preview-1.png"
+                path = ("pictures/thumbnails/preview-files/{}.png"
+                        .format(fakeid("preview-1")))
                 mock.get(gazu.client.get_full_url(path), body=thumbnail_file)
                 gazu.files.download_preview_file_thumbnail(
-                    "preview-1", "./test.png"
+                    fakeid("preview-1"), "./test.png"
                 )
                 self.assertTrue(os.path.exists("./test.png"))
                 self.assertEqual(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,14 +2,17 @@ import unittest
 
 from gazu import helpers
 
+from utils import fakeid
+
 
 class TestCase(unittest.TestCase):
     def test_normalize_model_parameter(self):
         self.assertDictEqual(
-            helpers.normalize_model_parameter("asset-01"), {"id": "asset-01"}
+            helpers.normalize_model_parameter(fakeid("asset-01")),
+            {"id": fakeid("asset-01")}
         )
         self.assertDictEqual(
-            helpers.normalize_model_parameter({"id": "asset-01"}),
-            {"id": "asset-01"},
+            helpers.normalize_model_parameter({"id": fakeid("asset-01")}),
+            {"id": fakeid("asset-01")},
         )
         self.assertIsNone(helpers.normalize_model_parameter(None))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,10 +6,10 @@ from gazu import helpers
 class TestCase(unittest.TestCase):
     def test_normalize_model_parameter(self):
         self.assertDictEqual(
-            helpers.normalize_model_parameter("asset-1"), {"id": "asset-1"}
+            helpers.normalize_model_parameter("asset-01"), {"id": "asset-01"}
         )
         self.assertDictEqual(
-            helpers.normalize_model_parameter({"id": "asset-1"}),
-            {"id": "asset-1"},
+            helpers.normalize_model_parameter({"id": "asset-01"}),
+            {"id": "asset-01"},
         )
         self.assertIsNone(helpers.normalize_model_parameter(None))

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -11,7 +11,7 @@ class PersonTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/persons"),
-                text=json.dumps([{"first_name": "John", "id": "person-1"}]),
+                text=json.dumps([{"first_name": "John", "id": "person-01"}]),
             )
             persons = gazu.person.all_persons()
             person_instance = persons[0]
@@ -26,7 +26,7 @@ class PersonTestCase(unittest.TestCase):
                         {
                             "first_name": "John",
                             "last_name": "Doe",
-                            "id": "person-1",
+                            "id": "person-01",
                         },
                         {
                             "first_name": "John",
@@ -54,13 +54,13 @@ class PersonTestCase(unittest.TestCase):
                             "first_name": "John",
                             "last_name": "Doe",
                             "desktop_login": "john.doe",
-                            "id": "person-1",
+                            "id": "person-01",
                         }
                     ]
                 ),
             )
             person = gazu.person.get_person_by_desktop_login("john.doe")
-            self.assertEqual(person["id"], "person-1")
+            self.assertEqual(person["id"], "person-01")
 
     def test_get_person_by_email(self):
         with requests_mock.mock() as mock:
@@ -72,13 +72,13 @@ class PersonTestCase(unittest.TestCase):
                             "first_name": "John",
                             "last_name": "Doe",
                             "desktop_login": "john.doe",
-                            "id": "person-1",
+                            "id": "person-01",
                         }
                     ]
                 ),
             )
             person = gazu.person.get_person_by_email("john@gmail.com")
-            self.assertEqual(person["id"], "person-1")
+            self.assertEqual(person["id"], "person-01")
 
     def test_new_person(self):
         with requests_mock.mock() as mock:
@@ -97,7 +97,7 @@ class PersonTestCase(unittest.TestCase):
                             "desktop_login": "john.doe",
                             "phone": "06 07 07 07 07",
                             "role": "user",
-                            "id": "person-1",
+                            "id": "person-01",
                         }
                     ]
                 ),

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -10,7 +10,7 @@ class ProjectTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/projects"),
-                text='[{"name": "Agent 327", "id": "project_1"}]',
+                text='[{"name": "Agent 327", "id": "project-01"}]',
             )
             projects = gazu.project.all_projects()
             project_instance = projects[0]
@@ -20,7 +20,7 @@ class ProjectTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/projects/open"),
-                text='[{"name": "Agent 327", "id": "project_1"}]',
+                text='[{"name": "Agent 327", "id": "project-01"}]',
             )
             projects = gazu.project.all_open_projects()
             project_instance = projects[0]
@@ -29,17 +29,17 @@ class ProjectTestCase(unittest.TestCase):
     def test_get_project(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/projects/project-1"),
-                text='{"name": "Agent 327", "id": "project_1"}',
+                gazu.client.get_full_url("data/projects/project-01"),
+                text='{"name": "Agent 327", "id": "project-01"}',
             )
-            project = gazu.project.get_project("project-1")
+            project = gazu.project.get_project("project-01")
             self.assertEqual(project["name"], "Agent 327")
 
     def test_get_project_by_name(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/projects?name=Test"),
-                text=json.dumps([{"name": "Test", "id": "project_1"}]),
+                text=json.dumps([{"name": "Test", "id": "project-01"}]),
             )
             project = gazu.project.get_project_by_name("Test")
             self.assertEqual(project["name"], "Test")
@@ -47,8 +47,8 @@ class ProjectTestCase(unittest.TestCase):
     def test_remove_project(self):
         with requests_mock.mock() as mock:
             mock = mock.delete(
-                gazu.client.get_full_url("data/projects/project-1"),
+                gazu.client.get_full_url("data/projects/project-01"),
                 status_code=204,
             )
-            project = {"id": "project-1", "name": "S02"}
+            project = {"id": "project-01", "name": "S02"}
             gazu.project.remove_project(project)

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -11,7 +11,7 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/scenes/scene-1"),
-                text='{"name": "Scene 01", "project_id": "project-1"}',
+                text='{"name": "Scene 01", "project_id": "project-01"}',
             )
             scene = gazu.scene.get_scene("scene-1")
             self.assertEqual(scene["name"], "Scene 01")
@@ -20,61 +20,61 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/scenes/all?parent_id=sequence-1&name=Scene01"
+                    "data/scenes/all?parent_id=sequence-01&name=Scene01"
                 ),
                 text=json.dumps(
-                    [{"name": "Scene01", "project_id": "project-1"}]
+                    [{"name": "Scene01", "project_id": "project-01"}]
                 ),
             )
-            sequence = {"id": "sequence-1"}
+            sequence = {"id": "sequence-01"}
             scene = gazu.scene.get_scene_by_name(sequence, "Scene01")
             self.assertEqual(scene["name"], "Scene01")
 
     def test_all_scenes_for_project(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/projects/project-1/scenes"),
+                gazu.client.get_full_url("data/projects/project-01/scenes"),
                 text=json.dumps(
-                    [{"name": "Scene 01", "project_id": "project-1"}]
+                    [{"name": "Scene 01", "project_id": "project-01"}]
                 ),
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             scenes = gazu.scene.all_scenes_for_project(project)
             self.assertEqual(len(scenes), 1)
             scene_instance = scenes[0]
             self.assertEqual(scene_instance["name"], "Scene 01")
-            self.assertEqual(scene_instance["project_id"], "project-1")
+            self.assertEqual(scene_instance["project_id"], "project-01")
 
     def test_all_scenes_for_sequence(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/sequences/sequence-1/scenes"),
+                gazu.client.get_full_url("data/sequences/sequence-01/scenes"),
                 text=json.dumps(
                     [
                         {
                             "name": "Scene 01",
-                            "project_id": "project-1",
-                            "parent_id": "sequence-1",
+                            "project_id": "project-01",
+                            "parent_id": "sequence-01",
                         }
                     ]
                 ),
             )
-            sequence = {"id": "sequence-1"}
+            sequence = {"id": "sequence-01"}
             scenes = gazu.scene.all_scenes_for_sequence(sequence)
             self.assertEqual(len(scenes), 1)
             scene_instance = scenes[0]
             self.assertEqual(scene_instance["name"], "Scene 01")
-            self.assertEqual(scene_instance["project_id"], "project-1")
-            self.assertEqual(scene_instance["parent_id"], "sequence-1")
+            self.assertEqual(scene_instance["project_id"], "project-01")
+            self.assertEqual(scene_instance["parent_id"], "sequence-01")
 
     def test_new_scene(self):
         with requests_mock.mock() as mock:
             mock.post(
-                gazu.client.get_full_url("data/projects/project-1/scenes"),
-                text=json.dumps({"id": "scene-01", "project_id": "project-1"}),
+                gazu.client.get_full_url("data/projects/project-01/scenes"),
+                text=json.dumps({"id": "scene-01", "project_id": "project-01"}),
             )
-            project = {"id": "project-1"}
-            sequence = {"id": "sequence-1"}
+            project = {"id": "project-01"}
+            sequence = {"id": "sequence-01"}
             scene = gazu.scene.new_scene(project, sequence, "Scene 01")
             self.assertEqual(scene["id"], "scene-01")
 
@@ -83,7 +83,7 @@ class SceneTestCase(unittest.TestCase):
             mock = mock.put(
                 gazu.client.get_full_url("data/entities/scene-id"),
                 text=json.dumps(
-                    {"id": "scene-id", "name": "S02", "project_id": "project-1"}
+                    {"id": "scene-id", "name": "S02", "project_id": "project-01"}
                 ),
             )
             scene = {"id": "scene-id", "name": "S02"}
@@ -116,32 +116,32 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/scenes/scene-1/shots"),
-                text=json.dumps([{"id": "shot-1"}, {"id": "shot-2"}]),
+                text=json.dumps([{"id": "shot-01"}, {"id": "shot-2"}]),
             )
             scene = {"id": "scene-1"}
             shots = gazu.scene.all_shots_for_scene(scene)
             self.assertEqual(len(shots), 2)
-            self.assertEqual(shots[0]["id"], "shot-1")
+            self.assertEqual(shots[0]["id"], "shot-01")
 
     def test_add_shot_to_scene(self):
         with requests_mock.mock() as mock:
             mock.post(
                 gazu.client.get_full_url("data/scenes/scene-1/shots"),
-                text=json.dumps({"id": "shot-1"}),
+                text=json.dumps({"id": "shot-01"}),
             )
             scene = {"id": "scene-1"}
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             shot = gazu.scene.add_shot_to_scene(scene, shot)
-            self.assertEqual(shot["id"], "shot-1")
+            self.assertEqual(shot["id"], "shot-01")
 
     def test_remove_shot_from_scene(self):
         with requests_mock.mock() as mock:
             mock.delete(
-                gazu.client.get_full_url("data/scenes/scene-1/shots/shot-1"),
+                gazu.client.get_full_url("data/scenes/scene-1/shots/shot-01"),
                 text="",
             )
             scene = {"id": "scene-1"}
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             gazu.scene.remove_shot_from_scene(scene, shot)
 
     def test_add_asset_instance(self):
@@ -152,7 +152,7 @@ class SceneTestCase(unittest.TestCase):
                 text=json.dumps(result),
             )
             scene = {"id": "scene-1"}
-            asset = {"id": "asset-1"}
+            asset = {"id": "asset-01"}
             asset_instance = gazu.scene.new_scene_asset_instance(scene, asset)
             self.assertEqual(asset_instance, result)
 

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -10,50 +10,50 @@ class ShotTestCase(unittest.TestCase):
     def test_all_shots_for_project(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/projects/project-1/shots"),
-                text='[{"name": "Shot 01", "project_id": "project-1"}]',
+                gazu.client.get_full_url("data/projects/project-01/shots"),
+                text='[{"name": "Shot 01", "project_id": "project-01"}]',
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             shots = gazu.shot.all_shots_for_project(project)
             self.assertEqual(len(shots), 1)
             shot_instance = shots[0]
             self.assertEqual(shot_instance["name"], "Shot 01")
-            self.assertEqual(shot_instance["project_id"], "project-1")
+            self.assertEqual(shot_instance["project_id"], "project-01")
 
     def test_all_shots_for_sequence(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/sequences/sequence-1/shots"),
+                gazu.client.get_full_url("data/sequences/sequence-01/shots"),
                 text=json.dumps(
                     [
                         {
                             "name": "Shot 01",
-                            "project_id": "project-1",
-                            "parent_id": "sequence-1",
+                            "project_id": "project-01",
+                            "parent_id": "sequence-01",
                         }
                     ]
                 ),
             )
-            sequence = {"id": "sequence-1"}
+            sequence = {"id": "sequence-01"}
             shots = gazu.shot.all_shots_for_sequence(sequence)
             self.assertEqual(len(shots), 1)
             shot_instance = shots[0]
             self.assertEqual(shot_instance["name"], "Shot 01")
-            self.assertEqual(shot_instance["project_id"], "project-1")
-            self.assertEqual(shot_instance["parent_id"], "sequence-1")
+            self.assertEqual(shot_instance["project_id"], "project-01")
+            self.assertEqual(shot_instance["parent_id"], "sequence-01")
 
     def test_all_sequences_for_project(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/projects/project-1/sequences"),
-                text='[{"name": "Sequence 01", "project_id": "project-1"}]',
+                gazu.client.get_full_url("data/projects/project-01/sequences"),
+                text='[{"name": "Sequence 01", "project_id": "project-01"}]',
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             sequences = gazu.shot.all_sequences_for_project(project)
             self.assertEqual(len(sequences), 1)
             sequence_instance = sequences[0]
             self.assertEqual(sequence_instance["name"], "Sequence 01")
-            self.assertEqual(sequence_instance["project_id"], "project-1")
+            self.assertEqual(sequence_instance["project_id"], "project-01")
 
     def test_all_sequences_for_episode(self):
         with requests_mock.mock() as mock:
@@ -63,7 +63,7 @@ class ShotTestCase(unittest.TestCase):
                     [
                         {
                             "name": "Sequence 01",
-                            "project_id": "project-1",
+                            "project_id": "project-01",
                             "parent_id": "episode-1",
                         }
                     ]
@@ -74,27 +74,27 @@ class ShotTestCase(unittest.TestCase):
             self.assertEqual(len(sequences), 1)
             sequence_instance = sequences[0]
             self.assertEqual(sequence_instance["name"], "Sequence 01")
-            self.assertEqual(sequence_instance["project_id"], "project-1")
+            self.assertEqual(sequence_instance["project_id"], "project-01")
             self.assertEqual(sequence_instance["parent_id"], "episode-1")
 
     def test_all_episodes_for_project(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/projects/project-1/episodes"),
-                text='[{"name": "Episode 01", "project_id": "project-1"}]',
+                gazu.client.get_full_url("data/projects/project-01/episodes"),
+                text='[{"name": "Episode 01", "project_id": "project-01"}]',
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             episodes = gazu.shot.all_episodes_for_project(project)
             self.assertEqual(len(episodes), 1)
             episode_instance = episodes[0]
             self.assertEqual(episode_instance["name"], "Episode 01")
-            self.assertEqual(episode_instance["project_id"], "project-1")
+            self.assertEqual(episode_instance["project_id"], "project-01")
 
     def test_get_episode(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/episodes/episode-1"),
-                text='{"name": "Episode 01", "project_id": "project-1"}',
+                text='{"name": "Episode 01", "project_id": "project-01"}',
             )
             episode = gazu.shot.get_episode("episode-1")
             self.assertEqual(episode["name"], "Episode 01")
@@ -104,58 +104,58 @@ class ShotTestCase(unittest.TestCase):
             mock.get(
                 gazu.client.get_full_url("data/episodes/episode-1"),
                 text=json.dumps(
-                    {"name": "Episode 01", "project_id": "project-1"}
+                    {"name": "Episode 01", "project_id": "project-01"}
                 ),
             )
             episode = gazu.shot.get_episode_from_sequence(
-                {"id": "shot-1", "parent_id": "episode-1"}
+                {"id": "shot-01", "parent_id": "episode-1"}
             )
             self.assertEqual(episode["name"], "Episode 01")
 
     def test_get_sequence(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/sequences/sequence-1"),
+                gazu.client.get_full_url("data/sequences/sequence-01"),
                 text=json.dumps(
-                    {"name": "Sequence 01", "project_id": "project-1"}
+                    {"name": "Sequence 01", "project_id": "project-01"}
                 ),
             )
-            sequence = gazu.shot.get_sequence("sequence-1")
+            sequence = gazu.shot.get_sequence("sequence-01")
             self.assertEqual(sequence["name"], "Sequence 01")
 
     def test_get_sequence_from_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/sequences/sequence-1"),
+                gazu.client.get_full_url("data/sequences/sequence-01"),
                 text=json.dumps(
-                    {"name": "Sequence 01", "project_id": "project-1"}
+                    {"name": "Sequence 01", "project_id": "project-01"}
                 ),
             )
             sequence = gazu.shot.get_sequence_from_shot(
-                {"id": "shot-1", "parent_id": "sequence-1"}
+                {"id": "shot-01", "parent_id": "sequence-01"}
             )
             self.assertEqual(sequence["name"], "Sequence 01")
 
     def test_get_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/shots/shot-1"),
-                text='{"name": "Shot 01", "project_id": "project-1"}',
+                gazu.client.get_full_url("data/shots/shot-01"),
+                text='{"name": "Shot 01", "project_id": "project-01"}',
             )
-            shot = gazu.shot.get_shot("shot-1")
+            shot = gazu.shot.get_shot("shot-01")
             self.assertEqual(shot["name"], "Shot 01")
 
     def test_get_shot_by_name(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/shots/all?sequence_id=sequence-1&name=Shot01"
+                    "data/shots/all?sequence_id=sequence-01&name=Shot01"
                 ),
                 text=json.dumps(
-                    [{"name": "Shot01", "project_id": "project-1"}]
+                    [{"name": "Shot01", "project_id": "project-01"}]
                 ),
             )
-            sequence = {"id": "sequence-1"}
+            sequence = {"id": "sequence-01"}
             shot = gazu.shot.get_shot_by_name(sequence, "Shot01")
             self.assertEqual(shot["name"], "Shot01")
 
@@ -163,13 +163,13 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/sequences?project_id=project-1&name=Sequence01"
+                    "data/sequences?project_id=project-01&name=Sequence01"
                 ),
                 text=json.dumps(
-                    [{"name": "Sequence01", "project_id": "project-1"}]
+                    [{"name": "Sequence01", "project_id": "project-01"}]
                 ),
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             sequence = gazu.shot.get_sequence_by_name(project, "Sequence01")
             self.assertEqual(sequence["name"], "Sequence01")
 
@@ -177,17 +177,17 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/episodes?project_id=project-1&name=Episode 01"
+                    "data/episodes?project_id=project-01&name=Episode 01"
                 ),
                 text=json.dumps([]),
             )
             mock.post(
-                gazu.client.get_full_url("data/projects/project-1/episodes"),
+                gazu.client.get_full_url("data/projects/project-01/episodes"),
                 text=json.dumps(
-                    {"id": "episode-01", "project_id": "project-1"}
+                    {"id": "episode-01", "project_id": "project-01"}
                 ),
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             shot = gazu.shot.new_episode(project, "Episode 01")
             self.assertEqual(shot["id"], "episode-01")
 
@@ -200,12 +200,12 @@ class ShotTestCase(unittest.TestCase):
                 text=json.dumps([]),
             )
             mock.post(
-                gazu.client.get_full_url("data/projects/project-1/sequences"),
+                gazu.client.get_full_url("data/projects/project-01/sequences"),
                 text=json.dumps(
-                    {"id": "sequence-01", "project_id": "project-1"}
+                    {"id": "sequence-01", "project_id": "project-01"}
                 ),
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             episode = {"id": "episode-1"}
             shot = gazu.shot.new_sequence(project, episode, "Sequence 01")
             self.assertEqual(shot["id"], "sequence-01")
@@ -214,16 +214,16 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/shots/all?sequence_id=sequence-1&name=Shot 01"
+                    "data/shots/all?sequence_id=sequence-01&name=Shot 01"
                 ),
                 text=json.dumps([]),
             )
             mock = mock.post(
-                gazu.client.get_full_url("data/projects/project-1/shots"),
-                text=json.dumps({"id": "shot-01", "project_id": "project-1"}),
+                gazu.client.get_full_url("data/projects/project-01/shots"),
+                text=json.dumps({"id": "shot-01", "project_id": "project-01"}),
             )
-            project = {"id": "project-1"}
-            sequence = {"id": "sequence-1"}
+            project = {"id": "project-01"}
+            sequence = {"id": "sequence-01"}
             shot = gazu.shot.new_shot(
                 project, sequence, "Shot 01", frame_in=10, frame_out=20
             )
@@ -234,34 +234,34 @@ class ShotTestCase(unittest.TestCase):
     def test_update_shot(self):
         with requests_mock.mock() as mock:
             mock = mock.put(
-                gazu.client.get_full_url("data/entities/shot-1"),
-                text=json.dumps({"id": "shot-01", "project_id": "project-1"}),
+                gazu.client.get_full_url("data/entities/shot-01"),
+                text=json.dumps({"id": "shot-01", "project_id": "project-01"}),
             )
-            shot = {"id": "shot-1", "name": "S02"}
+            shot = {"id": "shot-01", "name": "S02"}
             shot = gazu.shot.update_shot(shot)
             self.assertEqual(shot["id"], "shot-01")
 
     def test_remove_shot(self):
         with requests_mock.mock() as mock:
             mock.delete(
-                gazu.client.get_full_url("data/shots/shot-1"), status_code=204
+                gazu.client.get_full_url("data/shots/shot-01"), status_code=204
             )
-            shot = {"id": "shot-1", "name": "S02"}
+            shot = {"id": "shot-01", "name": "S02"}
             gazu.shot.remove_shot(shot)
             mock.delete(
-                gazu.client.get_full_url("data/shots/shot-1?force=true"),
+                gazu.client.get_full_url("data/shots/shot-01?force=true"),
                 status_code=204,
             )
-            shot = {"id": "shot-1", "name": "S02"}
+            shot = {"id": "shot-01", "name": "S02"}
             gazu.shot.remove_shot(shot, True)
 
     def test_remove_sequence(self):
         with requests_mock.mock() as mock:
             mock = mock.delete(
-                gazu.client.get_full_url("data/entities/sequence-1"),
+                gazu.client.get_full_url("data/entities/sequence-01"),
                 status_code=204,
             )
-            sequence = {"id": "sequence-1", "name": "S02"}
+            sequence = {"id": "sequence-01", "name": "S02"}
             gazu.shot.remove_sequence(sequence)
 
     def test_remove_episode(self):
@@ -277,10 +277,10 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             result = [{"id": "asset-instance-01"}]
             mock = mock.get(
-                gazu.client.get_full_url("data/shots/shot-1/asset-instances"),
+                gazu.client.get_full_url("data/shots/shot-01/asset-instances"),
                 text=json.dumps(result),
             )
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             asset_instances = gazu.shot.all_asset_instances_for_shot(shot)
             self.assertEqual(asset_instances[0]["id"], "asset-instance-01")
 
@@ -288,10 +288,10 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             result = {"id": "asset-instance-01"}
             mock = mock.post(
-                gazu.client.get_full_url("data/shots/shot-1/asset-instances"),
+                gazu.client.get_full_url("data/shots/shot-01/asset-instances"),
                 text=json.dumps(result),
             )
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             asset_instance = {"id": "asset-instance-1"}
             asset_instance = gazu.shot.add_asset_instance_to_shot(
                 shot, asset_instance
@@ -302,10 +302,10 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock = mock.delete(
                 gazu.client.get_full_url(
-                    "data/shots/shot-1/asset-instances/asset-instance-1"
+                    "data/shots/shot-01/asset-instances/asset-instance-1"
                 )
             )
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             asset_instance = {"id": "asset-instance-1"}
             asset_instance = gazu.shot.remove_asset_instance_from_shot(
                 shot, asset_instance
@@ -314,12 +314,12 @@ class ShotTestCase(unittest.TestCase):
     def test_get_shot_casting(self):
         with requests_mock.mock() as mock:
             mock = mock.put(
-                gazu.client.get_full_url("data/shots/shot-1/casting"),
+                gazu.client.get_full_url("data/shots/shot-01/casting"),
                 text=json.dumps({"success": True}),
             )
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             casting = [
-                {"asset_id": "asset-1", "nb_occurences": 2},
-                {"asset_id": "asset-2", "nb_occurences": 1},
+                {"asset_id": "asset-01", "nb_occurences": 2},
+                {"asset_id": "asset-02", "nb_occurences": 1},
             ]
             gazu.shot.update_casting(shot, casting)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -29,8 +29,8 @@ class TaskTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/sequences/sequence-01/tasks"),
                 text=json.dumps(
                     [
-                        {"id": 1, "name": "Master Compositing"},
-                        {"id": 2, "name": "Master Animation"},
+                        {"id": "task-01", "name": "Master Compositing"},
+                        {"id": "task-02", "name": "Master Animation"},
                     ]
                 ),
             )
@@ -46,8 +46,8 @@ class TaskTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/assets/asset-01/tasks"),
                 text=json.dumps(
                     [
-                        {"id": 1, "name": "Master Modeling"},
-                        {"id": 2, "name": "Master Texture"},
+                        {"id": "task-01", "name": "Master Modeling"},
+                        {"id": "task-02", "name": "Master Texture"},
                     ]
                 ),
             )
@@ -61,7 +61,7 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/episodes/episode-01/tasks"),
-                text=json.dumps([{"id": 1, "name": "Toto Task"}]),
+                text=json.dumps([{"id": "task-01", "name": "Toto Task"}]),
             )
 
             episode = {"id": "episode-01"}
@@ -73,7 +73,7 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/task-types"),
-                text=json.dumps([{"id": 1, "name": "Modeling"}]),
+                text=json.dumps([{"id": "task-type-01", "name": "Modeling"}]),
             )
             task_types = gazu.task.all_task_types()
             task_type = task_types[0]
@@ -82,11 +82,11 @@ class TaskTestCase(unittest.TestCase):
     def test_all_task_types_for_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/shots/shot-1/task-types"),
-                text=json.dumps([{"id": 1, "name": "Modeling"}]),
+                gazu.client.get_full_url("data/shots/shot-01/task-types"),
+                text=json.dumps([{"id": "task-type-01", "name": "Modeling"}]),
             )
 
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             task_types = gazu.task.all_task_types_for_shot(shot)
             task_type = task_types[0]
             self.assertEqual(task_type["name"], "Modeling")
@@ -95,12 +95,12 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/sequences/sequence-1/task-types"
+                    "data/sequences/sequence-01/task-types"
                 ),
-                text=json.dumps([{"id": 1, "name": "Modeling"}]),
+                text=json.dumps([{"id": "task-type-01", "name": "Modeling"}]),
             )
 
-            sequence = {"id": "sequence-1"}
+            sequence = {"id": "sequence-01"}
             task_types = gazu.task.all_task_types_for_sequence(sequence)
             task_type = task_types[0]
             self.assertEqual(task_type["name"], "Modeling")
@@ -109,7 +109,7 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/episodes/episode-1/task-types"),
-                text=json.dumps([{"id": 1, "name": "TotoType"}]),
+                text=json.dumps([{"id": "task-type-01", "name": "TotoType"}]),
             )
 
             episode = {"id": "episode-1"}
@@ -121,15 +121,15 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/tasks?name=Task%2001&entity_id=entity-1&"
-                    + "task_type_id=modeling-1"
+                    "data/tasks?name=Task%2001&entity_id=entity-01&"
+                    "task_type_id=modeling-1"
                 ),
                 text=json.dumps(
-                    [{"name": "Task 01", "project_id": "project-1"}]
+                    [{"name": "Task 01", "project_id": "project-01"}]
                 ),
             )
             test_task = gazu.task.get_task_by_name(
-                {"id": "entity-1"}, {"id": "modeling-1"}, "Task 01"
+                {"id": "entity-01"}, {"id": "modeling-1"}, "Task 01"
             )
             self.assertEqual(test_task["name"], "Task 01")
 
@@ -190,24 +190,24 @@ class TaskTestCase(unittest.TestCase):
     def test_start_task(self):
         with requests_mock.mock() as mock:
             mock.put(
-                gazu.client.get_full_url("actions/tasks/task-1/start"),
+                gazu.client.get_full_url("actions/tasks/task-01/start"),
                 text='{"name": "Task 01", "task_status_id": "wip-1"}',
             )
-            test_task = gazu.task.start_task({"id": "task-1"})
+            test_task = gazu.task.start_task({"id": "task-01"})
             self.assertEqual(test_task["task_status_id"], "wip-1")
 
     def test_to_review(self):
         with requests_mock.mock() as mock:
             mock.put(
-                gazu.client.get_full_url("actions/tasks/task-1/to-review"),
+                gazu.client.get_full_url("actions/tasks/task-01/to-review"),
                 text=json.dumps({"name": "Task 01", "task_status_id": "wfa-1"}),
             )
             test_task = gazu.task.task_to_review(
-                {"id": "task-1"}, {"id": "person-1"}, "my comment"
+                {"id": "task-01"}, {"id": "person-01"}, "my comment"
             )
             self.assertEqual(test_task["task_status_id"], "wfa-1")
             test_task = gazu.task.task_to_review(
-                {"id": "task-1"}, {"id": "person-1"}, "my comment"
+                {"id": "task-01"}, {"id": "person-01"}, "my comment"
             )
             self.assertEqual(test_task["task_status_id"], "wfa-1")
 
@@ -215,12 +215,12 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "actions/tasks/task-1/time-spents/2017-09-23"
+                    "actions/tasks/task-01/time-spents/2017-09-23"
                 ),
                 text=json.dumps({"person1": {"duration": 3600}, "total": 3600}),
             )
             time_spents = gazu.task.get_time_spent(
-                {"id": "task-1"}, "2017-09-23"
+                {"id": "task-01"}, "2017-09-23"
             )
             self.assertEqual(time_spents["total"], 3600)
 
@@ -228,13 +228,13 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.post(
                 gazu.client.get_full_url(
-                    "actions/tasks/task-1/time-spents/2017-09-23/"
-                    "persons/person-1"
+                    "actions/tasks/task-01/time-spents/2017-09-23/"
+                    "persons/person-01"
                 ),
-                text=json.dumps({"id": "time-spent-1", "duration": 3600}),
+                text=json.dumps({"id": "time-spent-01", "duration": 3600}),
             )
             time_spents = gazu.task.set_time_spent(
-                {"id": "task-1"}, {"id": "person-1"}, "2017-09-23", 3600
+                {"id": "task-01"}, {"id": "person-01"}, "2017-09-23", 3600
             )
             self.assertEqual(time_spents["duration"], 3600)
 
@@ -242,13 +242,13 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.post(
                 gazu.client.get_full_url(
-                    "actions/tasks/task-1/time-spents/2017-09-23/"
-                    "persons/person-1/add"
+                    "actions/tasks/task-01/time-spents/2017-09-23/"
+                    "persons/person-01/add"
                 ),
-                text=json.dumps({"id": "time-spent-1", "duration": 7200}),
+                text=json.dumps({"id": "time-spent-01", "duration": 7200}),
             )
             time_spent = gazu.task.add_time_spent(
-                {"id": "task-1"}, {"id": "person-1"}, "2017-09-23", 7200
+                {"id": "task-01"}, {"id": "person-01"}, "2017-09-23", 7200
             )
             self.assertEqual(time_spent["duration"], 7200)
 
@@ -265,18 +265,18 @@ class TaskTestCase(unittest.TestCase):
 
     def test_all_tasks_for_task_status(self):
         with requests_mock.mock() as mock:
-            result = [{"id": "task-1"}, {"id": "task-1"}]
+            result = [{"id": "task-01"}, {"id": "task-01"}]
             mock.get(
                 gazu.client.get_full_url(
-                    "data/tasks?project_id=project-1&"
-                    "task_type_id=task-type-1&"
-                    "task_status_id=task-status-1"
+                    "data/tasks?project_id=project-01&"
+                    "task_type_id=task-type-01&"
+                    "task_status_id=task-status-01"
                 ),
                 text=json.dumps(result),
             )
-            project = {"id": "project-1"}
-            task_type = {"id": "task-type-1"}
-            task_status = {"id": "task-status-1"}
+            project = {"id": "project-01"}
+            task_type = {"id": "task-type-01"}
+            task_status = {"id": "task-status-01"}
             tasks = gazu.task.all_tasks_for_task_status(
                 project, task_type, task_status
             )
@@ -284,17 +284,17 @@ class TaskTestCase(unittest.TestCase):
 
     def test_all_tasks_for_person(self):
         with requests_mock.mock() as mock:
-            result = [{"id": "task-status-1"}, {"id": "task-status-2"}]
+            result = [{"id": "task-status-01"}, {"id": "task-status-2"}]
             mock.get(
-                gazu.client.get_full_url("data/persons/person-1/tasks"),
+                gazu.client.get_full_url("data/persons/person-01/tasks"),
                 text=json.dumps(result),
             )
-            tasks = gazu.task.all_tasks_for_person("person-1")
+            tasks = gazu.task.all_tasks_for_person("person-01")
             self.assertEqual(tasks, result)
 
     def test_get_task_status_by_name(self):
         with requests_mock.mock() as mock:
-            result = [{"id": "task-status-1"}]
+            result = [{"id": "task-status-01"}]
             mock.get(
                 gazu.client.get_full_url("data/task-status?name=wip"),
                 text=json.dumps(result),
@@ -304,23 +304,23 @@ class TaskTestCase(unittest.TestCase):
 
     def test_new_task(self):
         with requests_mock.mock() as mock:
-            result = {"id": "task-1"}
+            result = {"id": "task-01"}
             mock.get(
                 gazu.client.get_full_url(
-                    "data/tasks?name=main&entity_id=asset-1"
-                    + "&task_type_id=task-type-1"
+                    "data/tasks?name=main&entity_id=asset-01"
+                    + "&task_type_id=task-type-01"
                 ),
                 text=json.dumps([]),
             )
             mock.get(
                 gazu.client.get_full_url("data/task-status?name=Todo"),
-                text=json.dumps([{"id": "task-status-1"}]),
+                text=json.dumps([{"id": "task-status-01"}]),
             )
             mock.post(
                 gazu.client.get_full_url("data/tasks"), text=json.dumps(result)
             )
-            asset = {"id": "asset-1", "project_id": "project-1"}
-            task_type = {"id": "task-type-1"}
+            asset = {"id": "asset-01", "project_id": "project-01"}
+            task_type = {"id": "task-type-01"}
             task = gazu.task.new_task(asset, task_type)
             self.assertEqual(task, result)
 
@@ -328,11 +328,11 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             result = {"id": "comment-1"}
             mock.post(
-                gazu.client.get_full_url("actions/tasks/task-1/comment"),
+                gazu.client.get_full_url("actions/tasks/task-01/comment"),
                 text=json.dumps(result),
             )
-            task = {"id": "task-1"}
-            task_status = {"id": "task-status-1"}
+            task = {"id": "task-01"}
+            task_status = {"id": "task-status-01"}
             comment = "New comment"
             task = gazu.task.add_comment(task, task_status, comment)
 
@@ -340,10 +340,10 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             result = [{"id": "comment-1"}]
             mock.get(
-                gazu.client.get_full_url("data/tasks/task-1/comments"),
+                gazu.client.get_full_url("data/tasks/task-01/comments"),
                 text=json.dumps(result),
             )
-            task = {"id": "task-1"}
+            task = {"id": "task-01"}
             comments = gazu.task.all_comments_for_task(task)
             self.assertEquals(comments[0]["id"], result[0]["id"])
 
@@ -353,19 +353,19 @@ class TaskTestCase(unittest.TestCase):
     def test_assign_task(self):
         with requests_mock.mock() as mock:
             mock.put(
-                gazu.client.get_full_url("actions/persons/person-1/assign"),
-                text=json.dumps([{"id": "task-1", "assignees": ["person-1"]}]),
+                gazu.client.get_full_url("actions/persons/person-01/assign"),
+                text=json.dumps([{"id": "task-01", "assignees": ["person-01"]}]),
             )
-            task = gazu.task.assign_task({"id": "task-1"}, {"id": "person-1"})[
+            task = gazu.task.assign_task({"id": "task-01"}, {"id": "person-01"})[
                 0
             ]
-            self.assertIn("person-1", task["assignees"])
+            self.assertIn("person-01", task["assignees"])
 
     def test_new_task_type(self):
         task_type_name = "task-type-name"
         with requests_mock.mock() as mock:
             task_type = {
-                "id": "task-type-1",
+                "id": "task-type-01",
                 "name": task_type_name
             }
             mock.post(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -4,6 +4,8 @@ import requests_mock
 import gazu.client
 import gazu.task
 
+from utils import fakeid
+
 
 class TaskTestCase(unittest.TestCase):
     def test_all_for_shot(self):
@@ -179,13 +181,13 @@ class TaskTestCase(unittest.TestCase):
 
     def test_get_task(self):
         with requests_mock.mock() as mock:
-            path = "data/tasks/task-01/full"
+            path = "data/tasks/{}/full".format(fakeid("task-01"))
             mock.get(
                 gazu.client.get_full_url(path),
-                text=json.dumps({"id": "task-01"}),
+                text=json.dumps({"id": fakeid("task-01")}),
             )
-            task = gazu.task.get_task("task-01")
-            self.assertEqual(task["id"], "task-01")
+            task = gazu.task.get_task(fakeid("task-01"))
+            self.assertEqual(task["id"], fakeid("task-01"))
 
     def test_start_task(self):
         with requests_mock.mock() as mock:
@@ -284,12 +286,14 @@ class TaskTestCase(unittest.TestCase):
 
     def test_all_tasks_for_person(self):
         with requests_mock.mock() as mock:
-            result = [{"id": "task-status-01"}, {"id": "task-status-2"}]
+            result = [{"id": fakeid("task-status-01")},
+                      {"id": fakeid("task-status-02")}]
             mock.get(
-                gazu.client.get_full_url("data/persons/person-01/tasks"),
+                gazu.client.get_full_url(
+                    "data/persons/{}/tasks".format(fakeid("person-01"))),
                 text=json.dumps(result),
             )
-            tasks = gazu.task.all_tasks_for_person("person-01")
+            tasks = gazu.task.all_tasks_for_person(fakeid("person-01"))
             self.assertEqual(tasks, result)
 
     def test_get_task_status_by_name(self):
@@ -304,23 +308,27 @@ class TaskTestCase(unittest.TestCase):
 
     def test_new_task(self):
         with requests_mock.mock() as mock:
-            result = {"id": "task-01"}
+            result = {"id": fakeid("task-01")}
             mock.get(
                 gazu.client.get_full_url(
-                    "data/tasks?name=main&entity_id=asset-01"
-                    + "&task_type_id=task-type-01"
+                    "data/tasks?name=main&entity_id={asset}"
+                    "&task_type_id={task_type}".format(
+                        asset=fakeid("asset-01"),
+                        task_type=fakeid("task-type-01"))
                 ),
                 text=json.dumps([]),
             )
             mock.get(
                 gazu.client.get_full_url("data/task-status?name=Todo"),
-                text=json.dumps([{"id": "task-status-01"}]),
+                text=json.dumps([{"id": fakeid("task-status-01")}]),
             )
             mock.post(
-                gazu.client.get_full_url("data/tasks"), text=json.dumps(result)
+                gazu.client.get_full_url("data/tasks"),
+                text=json.dumps(result)
             )
-            asset = {"id": "asset-01", "project_id": "project-01"}
-            task_type = {"id": "task-type-01"}
+            asset = {"id": fakeid("asset-01"),
+                     "project_id": fakeid("project-01")}
+            task_type = {"id": fakeid("task-type-01")}
             task = gazu.task.new_task(asset, task_type)
             self.assertEqual(task, result)
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -9,7 +9,7 @@ class ProjectTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/user/projects/open"),
-                text='[{"name": "Big Buck Bunny", "id": "project_1"}]',
+                text='[{"name": "Big Buck Bunny", "id": "project-01"}]',
             )
             projects = gazu.user.all_open_projects()
             project_instance = projects[0]
@@ -19,12 +19,12 @@ class ProjectTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/user/projects/project-1/asset-types"
+                    "data/user/projects/project-01/asset-types"
                 ),
                 text='[{"name": "Props", "id": "asset-type-01"}]',
             )
 
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             asset_types = gazu.user.all_asset_types_for_project(project)
             asset_type = asset_types[0]
             self.assertEqual(asset_type["name"], "Props")
@@ -33,14 +33,14 @@ class ProjectTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/user/projects/project-1/asset-types/asset-type-1"
+                    "data/user/projects/project-01/asset-types/asset-type-01"
                     "/assets"
                 ),
                 text='[{"name": "Chair", "id": "asset-01"}]',
             )
 
-            project = {"id": "project-1"}
-            asset_type = {"id": "asset-type-1"}
+            project = {"id": "project-01"}
+            asset_type = {"id": "asset-type-01"}
             assets = gazu.user.all_assets_for_asset_type_and_project(
                 project, asset_type
             )
@@ -50,10 +50,10 @@ class ProjectTestCase(unittest.TestCase):
     def test_tasks_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/user/assets/asset-1/tasks"),
+                gazu.client.get_full_url("data/user/assets/asset-01/tasks"),
                 text='[{"name": "main", "id": "task-01"}]',
             )
-            asset = {"id": "asset-1"}
+            asset = {"id": "asset-01"}
             tasks = gazu.user.all_tasks_for_asset(asset)
             task = tasks[0]
             self.assertEqual(task["name"], "main")
@@ -61,10 +61,10 @@ class ProjectTestCase(unittest.TestCase):
     def test_tasks_for_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/user/shots/shot-1/tasks"),
+                gazu.client.get_full_url("data/user/shots/shot-01/tasks"),
                 text='[{"name": "main", "id": "task-01"}]',
             )
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             tasks = gazu.user.all_tasks_for_shot(shot)
             task = tasks[0]
             self.assertEqual(task["name"], "main")
@@ -72,10 +72,10 @@ class ProjectTestCase(unittest.TestCase):
     def test_task_types_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/user/assets/asset-1/task-types"),
+                gazu.client.get_full_url("data/user/assets/asset-01/task-types"),
                 text='[{"name": "modeling", "id": "task-type-01"}]',
             )
-            asset = {"id": "asset-1"}
+            asset = {"id": "asset-01"}
             task_types = gazu.user.all_task_types_for_asset(asset)
             task_type = task_types[0]
             self.assertEqual(task_type["name"], "modeling")
@@ -83,11 +83,11 @@ class ProjectTestCase(unittest.TestCase):
     def test_task_types_for_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/user/shots/shot-1/task-types"),
+                gazu.client.get_full_url("data/user/shots/shot-01/task-types"),
                 text='[{"name": "animation", "id": "task-type-01"}]',
             )
 
-            shot = {"id": "shot-1"}
+            shot = {"id": "shot-01"}
             tasks = gazu.user.all_task_types_for_shot(shot)
             task = tasks[0]
             self.assertEqual(task["name"], "animation")
@@ -96,11 +96,11 @@ class ProjectTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/user/projects/project-1/sequences"
+                    "data/user/projects/project-01/sequences"
                 ),
                 text='[{"name": "SEQ01", "id": "sequence-01"}]',
             )
-            project = {"id": "project-1"}
+            project = {"id": "project-01"}
             sequences = gazu.user.all_sequences_for_project(project)
             sequence = sequences[0]
             self.assertEqual(sequence["name"], "SEQ01")
@@ -109,11 +109,11 @@ class ProjectTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/user/sequences/sequence-1/shots"
+                    "data/user/sequences/sequence-01/shots"
                 ),
                 text='[{"name": "SEQ01", "id": "shot-01"}]',
             )
-            sequence = {"id": "sequence-1"}
+            sequence = {"id": "sequence-01"}
             shots = gazu.user.all_shots_for_sequence(sequence)
             shot = shots[0]
             self.assertEqual(shot["name"], "SEQ01")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,19 @@
+"""
+Contains utility routines to be used in gazu tests
+"""
+
+import binascii
+
+
+def fakeid(string):
+    """
+    Returns a mock uuid from text.
+
+    Result is consistent (same text will yield the same uuid).
+    """
+    hex_string = binascii.hexlify(string.encode()).decode()
+    return "{:0<8}-{:0<4}-{:0<4}-{:0<4}-{:0<12}".format(hex_string[0:8],
+                                                        hex_string[8:12],
+                                                        hex_string[12:16],
+                                                        hex_string[16:20],
+                                                        hex_string[20:32])


### PR DESCRIPTION
**Problem**
In python 2, `normalize_model_parameter` raises an `ValueError` when the `id` it receives as an argument is a `unicode`

**Solution**
Test `id` type against `basestring` instead of `str`, which is the base type for `str` and `unicode` in python2 (using the `future` library for python3 compatibility).
