### PR TITLE
Fix gazu.person.get_person

### DIFF
--- a/gazu/person.py
+++ b/gazu/person.py
@@ -32,7 +32,7 @@ def get_person(id):
     Returns:
         dict: Person corresponding to given id.
     """
-    return client.fetch("persons/%s" % id)
+    return client.fetch_one("persons", id)
 
 
 @cache


### PR DESCRIPTION
**Problem**
The function `gazu.person.get_person` was broken since it relied on the removed function `gazu.client.fetch`.

**Solution**
Use `gazu.client.fetch_one` instead
