### PR TITLE
Fix path error

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -117,7 +117,7 @@ def get_all_working_files_for_entity(
     """
     entity = normalize_model_parameter(entity)
     task = normalize_model_parameter(task)
-    path = "data/entities/{entity_id}/working-files?".format(
+    path = "entities/{entity_id}/working-files?".format(
         entity_id=entity["id"],
     )
 


### PR DESCRIPTION
**Problem**
`get_all_working_files_for_entity` is broken, since the path it relies on get prepended with `"data/"` in the `client.fetch_all` function

**Solution**
Remove `"data/"` from the path string, and let `client.fetch_all` add it.
