### PR TITLE
remove cache from new_scene_asset_instance

### DIFF
--- a/gazu/scene.py
+++ b/gazu/scene.py
@@ -77,7 +77,6 @@ def update_scene(scene):
     return client.put("data/entities/%s" % scene["id"], scene)
 
 
-@cache
 def new_scene_asset_instance(scene, asset, description=""):
     """
     Creates a new asset instance on given scene. The instance number is


### PR DESCRIPTION
**Problem**
Could not create two instances of the same asset in a given scene without clearing the cache.
This lead to incomprehension.

**Solution**
Remove `cache` decorator from `new_scene_asset_instance` method.
