### PR TITLE
Fix `episode` parameter in `new_asset`

### DIFF
--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -129,7 +129,7 @@ def get_asset(asset_id):
 
 
 def new_asset(
-    project, asset_type, name, description="", extra_data={}, episode_id=None
+    project, asset_type, name, description="", extra_data={}, episode=None
 ):
     """
     Create a new asset in the database for given project and asset type.
@@ -140,17 +140,19 @@ def new_asset(
         name (str): Asset name.
         description (str): Additional information.
         extra_data (dict): Free field to add any kind of metadata.
+        episode (str / dict): The episode this asset is linked to.
 
     Returns:
         dict: Created asset.
     """
     project = normalize_model_parameter(project)
     asset_type = normalize_model_parameter(asset_type)
+    episode = normalize_model_parameter(episode)
 
     data = {"name": name, "description": description, "data": extra_data}
 
-    if episode_id is not None:
-        data["episode_id"] = episode_id
+    if episode is not None:
+        data["source_id"] = episode["id"]
 
     asset = get_asset_by_name(project, name, asset_type)
     if asset is None:


### PR DESCRIPTION
This PR replaces #92 

**Problem**

The `new_asset` function takes an `episode_id` parameter.

* Passing an `id` as a parameter is an old practice and violates homogeneity.
* The data field `episode_id` this value gets assigned to seems deprecated (no effect in kitsu)

**Solution**

* We normalize the `episode_id` parameter into a generic `episode` parameter (`dict` or `str`)
* We fix the data field this id is assigned to (used to be `episode_id`, now is `source_id`)

