### PR TITLE
Upgrade preview file handling methods

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -942,3 +942,18 @@ def download_preview_file_thumbnail(preview_file, file_path):
         "pictures/thumbnails/preview-files/%s.png" % (preview_file["id"]),
         file_path,
     )
+
+
+def update_preview(preview_file, data):
+    """
+    Update the data of given preview file.
+
+    Args:
+        preview_file (str / dict): The preview file dict or ID.
+
+    Returns:
+        dict: Modified preview file
+    """
+    preview_file = normalize_model_parameter(preview_file)
+    path = "/data/preview-files/%s" % preview_file["id"]
+    return client.put(path, data)

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -561,15 +561,13 @@ def remove_comment(comment):
     return client.delete("data/comments/%s" % comment["id"])
 
 
-def add_preview(task, comment, preview_file_path):
+def create_preview(task, comment):
     """
-    Add a preview to given comment. It it's a movie, it must be mentioned
-    in the option.
+    Create a preview into given comment.
 
     Args:
         task (str / dict): The task dict or the task ID.
         comment (str / dict): The comment or the comment ID.
-        preview_file_path (str): Path of the file to upload as preview.
 
     Returns:
         dict: Created preview file model.
@@ -580,9 +578,35 @@ def add_preview(task, comment, preview_file_path):
         task["id"],
         comment["id"],
     )
-    preview_file = client.post(path, {})
-    path = "pictures/preview-files/%s" % preview_file["id"]
-    client.upload(path, preview_file_path)
+    return client.post(path, {})
+
+
+def upload_preview_file(preview, file_path):
+    """
+    Create a preview into given comment.
+
+    Args:
+        task (str / dict): The task dict or the task ID.
+        file_path (str): Path of the file to upload as preview.
+    """
+    path = "pictures/preview-files/%s" % preview["id"]
+    client.upload(path, file_path)
+
+
+def add_preview(task, comment, preview_file_path):
+    """
+    Add a preview to given comment.
+
+    Args:
+        task (str / dict): The task dict or the task ID.
+        comment (str / dict): The comment or the comment ID.
+        preview_file_path (str): Path of the file to upload as preview.
+
+    Returns:
+        dict: Created preview file model.
+    """
+    preview_file = create_preview(task, comment)
+    upload_preview_file(preview_file, preview_file_path)
     return preview_file
 
 


### PR DESCRIPTION
**Problem**
There is no way to handle a preview file between its creation and the upload of a file.
There is no way to handle a preview file data.

**Solution**
- Separate add_preview method in create_preview and upload_preview_file
to let the user add logic inbetweeen.
- Add update_preview method to update a preview file datas
