### PR TITLE
Add close_project method.

### DIFF
--- a/gazu/project.py
+++ b/gazu/project.py
@@ -121,3 +121,24 @@ def update_project_data(project, data={}):
         project["data"] = {}
     project["data"].update(data)
     update_project(project)
+
+
+def close_project(project):
+    """
+    Closes the provided project.
+
+    Args:
+        project (dict / ID): The project dict or id to save in database.
+
+    Returns:
+        dict: Updated project.
+    """
+    closed_status_id = None
+    for status in all_project_status():
+        if status["name"].lower() == "closed":
+            closed_status_id = status["id"]
+
+    project["project_status_id"] = closed_status_id
+    update_project(project)
+
+    return project


### PR DESCRIPTION
**Problem**
There was no easy way of closing a project.

**Solution**
Provide easy `close_project` method.

**Notes**
Not sure this is inline with gazu, but had to dig a bit to figure out how the project statuses worked, so I thought it might help someone else.
