### PR TITLE
Simplify gazu.task.set_main_preview function

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -15,7 +15,7 @@ from . import task
 from . import user
 from . import playlist
 
-from .exception import AuthFailedException
+from .exception import AuthFailedException, ParameterException
 from .__version__ import __version__
 
 
@@ -28,8 +28,15 @@ def set_host(url):
 
 
 def log_in(email, password):
-    tokens = client.post("auth/login", {"email": email, "password": password})
-    if "login" in tokens and tokens["login"] == False:
+    tokens = {}
+    try:
+        tokens = client.post(
+            "auth/login", {"email": email, "password": password}
+        )
+    except ParameterException:
+        pass
+
+    if "login" in tokens and tokens.get("login", False) == False:
         raise AuthFailedException
     else:
         client.set_tokens(tokens)

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -586,23 +586,18 @@ def add_preview(task, comment, preview_file_path):
     return preview_file
 
 
-def set_main_preview(entity, preview_file):
+def set_main_preview(preview_file):
     """
     Set given preview as thumbnail of given entity.
 
     Args:
-        task (str / dict): The task dict or the task ID.
         preview_file (str / dict): The preview file dict or ID.
 
     Returns:
         dict: Created preview file model.
     """
-    entity = normalize_model_parameter(entity)
     preview_file = normalize_model_parameter(preview_file)
-    path = "actions/entities/%s/set-main-preview/%s" % (
-        entity["id"],
-        preview_file["id"],
-    )
+    path = "actions/preview-files/%s/set-main-preview" % preview_file["id"]
     return client.put(path, {})
 
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -419,3 +419,21 @@ class TaskTestCase(unittest.TestCase):
             self.assertEqual(
                 gazu.task.new_task_status(name, short_name, color), status
             )
+
+
+    def test_set_main_preview(self):
+        with requests_mock.mock() as mock:
+            result = {
+                "id": "preview-1"
+            }
+            path = "actions/preview-files/preview-1/set-main-preview"
+            mock.put(
+                gazu.client.get_full_url(path),
+                text=json.dumps(result),
+            )
+            preview_file = {
+                "id": "preview-1"
+            }
+            self.assertEqual(
+                gazu.task.set_main_preview(preview_file), result
+            )


### PR DESCRIPTION
**Problem**

See #107 

**Solution**

Use the new route available in Zou requiring only the preview as a parameter.
