### PR TITLE
[NEW] Modify host_is_up function

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -38,9 +38,12 @@ tokens = {"access_token": "", "refresh_token": ""}
 def host_is_up():
     """
     Returns:
-        True if the host is up
+        True if the host is up.
     """
-    response = requests_session.head(HOST)
+    try:
+        response = requests_session.head(HOST)
+    except:
+        return False
     return response.status_code == 200
 
 


### PR DESCRIPTION
**Problem**
When a user enters a host manually, we need to check if this host is really up, but the function host_is_up throws errors. When its HEAD request fails, it returns the associated error message instead of a boolean. 

**Solution**
A try statement has been added to ensure the function always returns a boolean. The handling of the error is made higher in the code.
