### PR TITLE
Fix missing parameter normalization

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -302,6 +302,7 @@ def get_task_status(task):
     Returns:
         A task status object corresponding to status set on given task.
     """
+    task = normalize_model_parameter(task)
     return client.fetch_first("task-status", {"id": task["task_status_id"]})
 
 


### PR DESCRIPTION
**Problem**
`gazu.task.get_task_status(...)` does not accept a `task_id` as argument
 
**Solution**
Use the argument `normalize_model_parameter` function on the `task` parameter.
(improving global code consistency)