### PR TITLE
add cache infos

### DIFF
--- a/gazu/cache.py
+++ b/gazu/cache.py
@@ -169,7 +169,7 @@ def cache(function, maxsize=300, expire=120):
         return infos
 
     def set_expire(new_expire):
-        state["expire"] = expire
+        state["expire"] = new_expire
 
     def set_max_size(maxsize):
         state["maxsize"] = maxsize

--- a/gazu/cache.py
+++ b/gazu/cache.py
@@ -151,8 +151,22 @@ def cache(function, maxsize=300, expire=120):
     cache_store = {}
     state = {"enabled": True, "expire": expire, "maxsize": maxsize}
 
+    statistics = {
+        "hits": 0,
+        "misses": 0,
+        "expired_hits": 0
+    }
+
     def clear_cache():
         cache_store.clear()
+
+    def get_cache_infos():
+        size = {'current_size': len(cache_store)}
+        infos = {}
+        for d in [state, statistics, size]:
+            infos.update(d)
+
+        return infos
 
     def set_expire(new_expire):
         state["expire"] = expire
@@ -174,11 +188,14 @@ def cache(function, maxsize=300, expire=120):
 
             if key in cache_store:
                 if is_cache_expired(cache_store, state, key):
+                    statistics["expired_hits"] += 1
                     return insert_value(function, cache_store, args, kwargs)
                 else:
+                    statistics["hits"] += 1
                     return get_value(cache_store, key)
 
             else:
+                statistics["misses"] += 1
                 returned_value = insert_value(
                     function, cache_store, args, kwargs
                 )
@@ -193,6 +210,7 @@ def cache(function, maxsize=300, expire=120):
     wrapper.clear_cache = clear_cache
     wrapper.enable_cache = enable_cache
     wrapper.disable_cache = disable_cache
+    wrapper.get_cache_infos = get_cache_infos
 
     cached_functions.append(wrapper)
     return wrapper


### PR DESCRIPTION
**Problem**
There was no way to see the effectiveness of a cache

**Solution**
Add a method to display cache infos in a lru_cache way

```pyhon
gazu.person.all_persons.get_cache_infos()
>>> {'maxsize': 300, 'expire': 120, 'expired_hits': 0, 'misses': 0, 'current_size': 0, 'enabled': True, 'hits': 0}
all_1 = gazu.person.all_persons()
gazu.person.all_persons.get_cache_infos()
>>> {'maxsize': 300, 'expire': 120, 'expired_hits': 0, 'misses': 1, 'current_size': 0, 'enabled': True, 'hits': 0}
all_2 = gazu.person.all_persons()
gazu.person.all_persons.get_cache_infos()
>>> {'maxsize': 300, 'expire': 120, 'expired_hits': 0, 'misses': 1, 'current_size': 0, 'enabled': True, 'hits': 1}
```