### PR TITLE
Fix obscure error message on error 413

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -325,9 +325,11 @@ def upload(path, file_path):
     """
     url = get_full_url(path)
     files = {"file": open(file_path, "rb")}
-    result = requests_session.post(
+    response = requests_session.post(
         url, headers=make_auth_header(), files=files
-    ).json()
+    )
+    check_status(response, path)
+    result = response.json()
     if "message" in result:
         raise UploadFailedException(result["message"])
     return result


### PR DESCRIPTION
**Problem**
I have scratched my head around this traceback a long time : 
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\aboellinger\venv-gazu\lib\site-packages\gazu\task.py", line 610, in add_preview
    upload_preview_file(preview_file, preview_file_path)
  File "C:\Users\aboellinger\venv-gazu\lib\site-packages\gazu\task.py", line 594, in upload_preview_file
    client.upload(path, file_path)
  File "C:\Users\aboellinger\venv-gazu\lib\site-packages\gazu\client.py", line 316, in upload
    url, headers=make_auth_header(), files=files
  File "C:\Users\aboellinger\venv-gazu\lib\site-packages\requests\models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "C:\Users\aboellinger\AppData\Local\Programs\Python\Python37\lib\json\__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "C:\Users\aboellinger\AppData\Local\Programs\Python\Python37\lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "C:\Users\aboellinger\AppData\Local\Programs\Python\Python37\lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

By going step by step in with pdb, it turns out this obfuscates a pretty clear feedback from the server : 
```
<html>
<head><title>413 Request Entity Too Large</title></head>
<body bgcolor="white">
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx/1.10.3 (Ubuntu)</center>
</body>
</html>
```


**Solution**
In the upload method, check the request response status code before we try to get a json out of it.

