### PR TITLE
Fix uncaught error on login

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -34,7 +34,7 @@ def log_in(email, password):
             "auth/login", {"email": email, "password": password}
         )
     except ParameterException:
-        pass
+        raise
 
     if "login" in tokens and tokens.get("login", False) == False:
         raise AuthFailedException

--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -34,9 +34,11 @@ def log_in(email, password):
             "auth/login", {"email": email, "password": password}
         )
     except ParameterException:
-        raise
+        pass
 
-    if "login" in tokens and tokens.get("login", False) == False:
+    if not tokens or (
+        "login" in tokens and tokens.get("login", False) == False
+    ):
         raise AuthFailedException
     else:
         client.set_tokens(tokens)


### PR DESCRIPTION
**Problem**
When the user enters wrong ids, an unexpected error is displayed

**Solution**
Fix the bug : instead of being propagated, the login error was not treated
