### PR TITLE
Add fct to download attachment images of comments

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -1011,6 +1011,21 @@ def download_preview_file(preview_file, file_path):
     )
 
 
+def download_attachment_file(attachment_file, file_path):
+    """
+    Download given attachment file and save it at given location.
+
+    Args:
+        attachment_file (str / dict): The attachment file dict or ID.
+        file_path (str): Location on hard drive where to save the file.
+    """
+    attachment_file = normalize_model_parameter(attachment_file)
+    return client.download(
+        "data/attachment-files/%s/file" % (attachment_file["id"]),
+        file_path,
+    )
+
+
 def download_preview_file_thumbnail(preview_file, file_path):
     """
     Download given preview file thumbnail and save it at given location.

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -674,6 +674,22 @@ class FilesTestCase(unittest.TestCase):
                     os.path.getsize("./tests/fixtures/v1.png"),
                 )
 
+    def test_download_attachment_file(self):
+        with open("./tests/fixtures/v1.png", "rb") as attachment_file:
+            with requests_mock.mock() as mock:
+                path = "data/attachment-files/{}/file".format(
+                    fakeid("attachment-1")
+                )
+                mock.get(gazu.client.get_full_url(path), body=attachment_file)
+                gazu.files.download_attachment_file(
+                    fakeid("attachment-1"), "./test.png"
+                )
+                self.assertTrue(os.path.exists("./test.png"))
+                self.assertEqual(
+                    os.path.getsize("./test.png"),
+                    os.path.getsize("./tests/fixtures/v1.png"),
+                )
+
     def test_download_preview_file_thumbnail(self):
         with open("./tests/fixtures/v1.png", "rb") as thumbnail_file:
             with requests_mock.mock() as mock:


### PR DESCRIPTION
**Problem**
There is currently no function in the API to retrieve images attached to comments 

**Solution**
This PR adds this function, as well as the associated test.
Both of them are imitating the implementation of a similar function which downloads the thumbnail ([download_preview_file_thumbnail](https://github.com/LedruRollin/gazu/blob/dc3b1f2d35cd348e5f85e1ab944155a1007a9ba3/gazu/files.py#L1029) and [test_download_preview_file_thumbnail](https://github.com/LedruRollin/gazu/blob/dc3b1f2d35cd348e5f85e1ab944155a1007a9ba3/tests/test_files.py#L693))
