### PR TITLE
Allow to have several instances of the gazu cilent

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -1,4 +1,4 @@
-from . import client
+from . import client as raw
 from . import cache
 from . import helpers
 from . import events
@@ -20,19 +20,19 @@ from .exception import AuthFailedException, ParameterException
 from .__version__ import __version__
 
 
-def get_host():
-    return client.get_host()
+def get_host(client=raw.default_client):
+    return raw.get_host(client=client)
 
 
-def set_host(url):
-    client.set_host(url)
+def set_host(url, client=raw.default_client):
+    raw.set_host(url, client=client)
 
 
-def log_in(email, password):
+def log_in(email, password, client=raw.default_client):
     tokens = {}
     try:
-        tokens = client.post(
-            "auth/login", {"email": email, "password": password}
+        tokens = raw.post(
+            "auth/login", {"email": email, "password": password}, client=client
         )
     except ParameterException:
         pass
@@ -42,13 +42,13 @@ def log_in(email, password):
     ):
         raise AuthFailedException
     else:
-        client.set_tokens(tokens)
+        raw.set_tokens(tokens, client=client)
     return tokens
 
 
-def get_event_host():
-    return client.get_event_host()
+def get_event_host(client=raw.default_client):
+    return raw.get_event_host(client, client=client)
 
 
-def set_event_host(url):
-    client.set_event_host(url)
+def set_event_host(url, client=raw.default_client):
+    raw.set_event_host(url, client=client)

--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -97,7 +97,7 @@ def get_shot_casting(shot, client=default):
     Return casting for given shot.
     `[{"asset_id": "asset-1", "nb_occurences": 3}]}`
     Args:
-        shot (dict, client=default): The shot dict
+        shot (dict): The shot dict
 
     Returns:
         dict: Casting of the given shot.
@@ -114,7 +114,7 @@ def get_asset_casting(asset, client=default):
     Return casting for given asset.
     `[{"asset_id": "asset-1", "nb_occurences": 3}]}`
     Args:
-        asset (dict, client=default): The asset dict
+        asset (dict): The asset dict
 
     Returns:
         dict: Casting for given asset.
@@ -130,10 +130,24 @@ def get_asset_cast_in(asset, client=default):
     """
     Return shot list where given asset is casted.
     Args:
-        asset (dict, client=default): The asset dict
+        asset (dict): The asset dict
 
     Returns:
         dict: Shot list where given asset is casted.
     """
+    asset = normalize_model_parameter(asset)
     path = "/data/assets/%s/cast-in" % asset["id"]
+    return raw.get(path, client=client)
+
+
+def all_entity_links_for_project(project, client=default):
+    """
+    Args:
+        project (dict): The project
+
+    Returns:
+        dict: Entity links for given project.
+    """
+    project = normalize_model_parameter(project)
+    path = "/data/projects/%s/entity-links" % project["id"]
     return raw.get(path, client=client)

--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -1,9 +1,11 @@
-from . import client
+from . import client as raw
 
 from .helpers import normalize_model_parameter
 
+default = raw.default_client
 
-def update_shot_casting(project, shot, casting):
+
+def update_shot_casting(project, shot, casting, client=default):
     """
     Change casting of given shot with given casting (list of asset ids displayed
     into the shot).
@@ -19,10 +21,10 @@ def update_shot_casting(project, shot, casting):
     shot = normalize_model_parameter(shot)
     project = normalize_model_parameter(project)
     path = "data/projects/%s/entities/%s/casting" % (project["id"], shot["id"])
-    return client.put(path, casting)
+    return raw.put(path, casting, client=client)
 
 
-def update_asset_casting(project, asset, casting):
+def update_asset_casting(project, asset, casting, client=default):
     """
     Change casting of given asset with given casting (list of asset ids
     displayed into the asset).
@@ -41,10 +43,10 @@ def update_asset_casting(project, asset, casting):
         project["id"],
         asset["id"],
     )
-    return client.put(path, casting)
+    return raw.put(path, casting, client=client)
 
 
-def get_asset_type_casting(project, asset_type):
+def get_asset_type_casting(project, asset_type, client=default):
     """
     Return casting for given asset_type.
     `casting = {
@@ -66,10 +68,10 @@ def get_asset_type_casting(project, asset_type):
         project["id"],
         asset_type["id"],
     )
-    return client.get(path)
+    return raw.get(path, client=client)
 
 
-def get_sequence_casting(sequence):
+def get_sequence_casting(sequence, client=default):
     """
     Return casting for given sequence.
     `casting = {
@@ -87,15 +89,15 @@ def get_sequence_casting(sequence):
         sequence["project_id"],
         sequence["id"],
     )
-    return client.get(path)
+    return raw.get(path, client=client)
 
 
-def get_shot_casting(shot):
+def get_shot_casting(shot, client=default):
     """
     Return casting for given shot.
     `[{"asset_id": "asset-1", "nb_occurences": 3}]}`
     Args:
-        shot (dict): The shot dict
+        shot (dict, client=default): The shot dict
 
     Returns:
         dict: Casting of the given shot.
@@ -104,15 +106,15 @@ def get_shot_casting(shot):
         shot["project_id"],
         shot["id"],
     )
-    return client.get(path)
+    return raw.get(path, client=client)
 
 
-def get_asset_casting(asset):
+def get_asset_casting(asset, client=default):
     """
     Return casting for given asset.
     `[{"asset_id": "asset-1", "nb_occurences": 3}]}`
     Args:
-        asset (dict): The asset dict
+        asset (dict, client=default): The asset dict
 
     Returns:
         dict: Casting for given asset.
@@ -121,17 +123,17 @@ def get_asset_casting(asset):
         asset["project_id"],
         asset["id"],
     )
-    return client.get(path)
+    return raw.get(path, client=client)
 
 
-def get_asset_cast_in(asset):
+def get_asset_cast_in(asset, client=default):
     """
     Return shot list where given asset is casted.
     Args:
-        asset (dict): The asset dict
+        asset (dict, client=default): The asset dict
 
     Returns:
         dict: Shot list where given asset is casted.
     """
     path = "/data/assets/%s/cast-in" % asset["id"]
-    return client.get(path)
+    return raw.get(path, client=client)

--- a/gazu/entity.py
+++ b/gazu/entity.py
@@ -1,86 +1,90 @@
-from . import client
+from . import client as raw
 
 from .cache import cache
 from .sorting import sort_by_name
 
+default = raw.default_client
+
 
 @cache
-def all_entities():
+def all_entities(client=default):
     """
     Returns:
         list: Retrieve all entities
     """
-    return client.fetch_all("entities")
+    return raw.fetch_all("entities", client=client)
 
 
 @cache
-def all_entity_types():
+def all_entity_types(client=default):
     """
     Returns:
         list: Entity types listed in database.
     """
-    return sort_by_name(client.fetch_all("entity-types"))
+    return sort_by_name(raw.fetch_all("entity-types", client=client))
 
 
 @cache
-def get_entity(entity_id):
+def get_entity(entity_id, client=default):
     """
     Args:
-        id (str): ID of claimed entity.
+        id (str, client=default): ID of claimed entity.
 
     Returns:
         dict: Retrieve entity matching given ID (It can be an entity of any
         kind: asset, shot, sequence or episode).
     """
-    return client.fetch_one("entities", entity_id)
+    return raw.fetch_one("entities", entity_id, client=client)
 
 
 @cache
-def get_entity_by_name(entity_name):
+def get_entity_by_name(entity_name, client=default):
     """
     Args:
-        name (str): The name of the claimed entity.
+        name (str, client=default): The name of the claimed entity.
 
     Returns:
         Retrieve entity matching given name.
     """
-    return client.fetch_first("entities", {"name": entity_name})
+    return raw.fetch_first("entities", {"name": entity_name}, client=client)
 
 
 @cache
-def get_entity_type(entity_type_id):
+def get_entity_type(entity_type_id, client=default):
     """
     Args:
-        id (str): ID of claimed entity type.
-
+        id (str, client=default): ID of claimed entity type.
+, client=client
     Returns:
         Retrieve entity type matching given ID (It can be an entity type of any
         kind).
     """
-    return client.fetch_one("entity-types", entity_type_id)
+    return raw.fetch_one("entity-types", entity_type_id, client=client)
 
 
 @cache
-def get_entity_type_by_name(entity_type_name):
+def get_entity_type_by_name(entity_type_name, client=default):
     """
     Args:
-        name (str): The name of the claimed entity type
+        name (str, client=default): The name of the claimed entity type
 
     Returns:
         Retrieve entity type matching given name.
     """
-    return client.fetch_first("entity-types", {"name": entity_type_name})
+    return raw.fetch_first(
+        "entity-types", {"name": entity_type_name}, client=client
+    )
 
 
-def new_entity_type(name):
+def new_entity_type(name, client=default):
     """
     Creates an entity type with the given name.
 
     Args:
-        name (str): The name of the entity type
+        name (str, client=default): The name of the entity type
 
     Returns:
         dict: The created entity type
     """
     data = {"name": name}
-    return client.create("entity-types", data)
+    return raw.create("entity-types", data, client=client)

--- a/gazu/events.py
+++ b/gazu/events.py
@@ -1,7 +1,8 @@
 from .exception import AuthFailedException
+from .client import default_client
 
 
-def init():
+def init(client=default_client):
     """
     Init configuration for SocketIO client.
 
@@ -12,12 +13,12 @@ def init():
     from . import get_event_host
     from gazu.client import make_auth_header
 
-    path = get_event_host()
-    socketIO = SocketIO(path, None, headers=make_auth_header())
-    main_namespace = socketIO.define(BaseNamespace, "/events")
-    socketIO.main_namespace = main_namespace
-    socketIO.on('error', connect_error)
-    return socketIO
+    path = get_event_host(client)
+    event_client = SocketIO(path, None, headers=make_auth_header())
+    main_namespace = event_client.define(BaseNamespace, "/events")
+    event_client.main_namespace = main_namespace
+    event_client.on('error', connect_error)
+    return event_client
 
 
 def connect_error(data):

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -1,20 +1,22 @@
-from . import client
+from . import client as raw
 
 from .cache import cache
 from .helpers import normalize_model_parameter
 
+default = raw.default_client
+
 
 @cache
-def all_output_types():
+def all_output_types(client=default):
     """
     Returns:
         list: Output types listed in database.
     """
-    return client.fetch_all("output-types")
+    return raw.fetch_all("output-types", client=client)
 
 
 @cache
-def all_output_types_for_entity(entity):
+def all_output_types_for_entity(entity, client=default):
     """
     Args:
         entity (str / dict): The entity dict or the entity ID.
@@ -23,23 +25,28 @@ def all_output_types_for_entity(entity):
         list: All output types linked to output files for given entity.
     """
     entity = normalize_model_parameter(entity)
-    return client.fetch_all("entities/%s/output-types" % entity["id"])
-
-
-@cache
-def all_output_types_for_asset_instance(asset_instance, temporal_entity):
-    """
-    Returns:
-        list: Output types for given asset instance and entity (shot or scene).
-    """
-    return client.fetch_all(
-        "asset-instances/%s/entities/%s/output-types"
-        % (asset_instance["id"], temporal_entity["id"])
+    return raw.fetch_all(
+        "entities/%s/output-types" % entity["id"], client=client
     )
 
 
 @cache
-def get_output_type(output_type_id):
+def all_output_types_for_asset_instance(
+    asset_instance, temporal_entity, client=default
+):
+    """
+    Returns:
+        list: Output types for given asset instance and entity (shot or scene).
+    """
+    return raw.fetch_all(
+        "asset-instances/%s/entities/%s/output-types"
+        % (asset_instance["id"], temporal_entity["id"]),
+        client=client
+    )
+
+
+@cache
+def get_output_type(output_type_id, client=default):
     """
     Args:
         output_type_id (str): ID of claimed output type.
@@ -47,11 +54,11 @@ def get_output_type(output_type_id):
     Returns:
         dict: Output type matching given ID.
     """
-    return client.fetch_one("output-types", output_type_id)
+    return raw.fetch_one("output-types", output_type_id, client=client)
 
 
 @cache
-def get_output_type_by_name(output_type_name):
+def get_output_type_by_name(output_type_name, client=default):
     """
     Args:
         output_type_name (str): name of claimed output type.
@@ -59,10 +66,12 @@ def get_output_type_by_name(output_type_name):
     Returns:
         dict: Output type matching given name.
     """
-    return client.fetch_first("output-types", {"name": output_type_name})
+    return raw.fetch_first(
+        "output-types", {"name": output_type_name}, client=client
+    )
 
 
-def new_output_type(name, short_name):
+def new_output_type(name, short_name, client=default):
     """
     Create a new output type in database.
 
@@ -74,15 +83,15 @@ def new_output_type(name, short_name):
         dict: Created output type.
     """
     data = {"name": name, "short_name": short_name}
-    output_type = get_output_type_by_name(name)
+    output_type = get_output_type_by_name(name, client=client)
     if output_type is None:
-        return client.create("output-types", data)
+        return raw.create("output-types", data, client=client)
     else:
         return output_type
 
 
 @cache
-def get_output_file(output_file_id):
+def get_output_file(output_file_id, client=default):
     """
     Args:
         output_file_id (str): ID of claimed output file.
@@ -91,23 +100,25 @@ def get_output_file(output_file_id):
         dict: Output file matching given ID.
     """
     path = "data/output-files/%s" % (output_file_id)
-    return client.get(path)
+    return raw.get(path)
 
 
 @cache
-def get_output_file_by_path(path):
+def get_output_file_by_path(path, client=default):
     """
     Args:
-        output_file_id (str): Path of claimed output file.
+        output_file_id (str, client=default): Path of claimed output file.
 
     Returns:
         dict: Output file matching given path.
     """
-    return client.fetch_first("output-files", {"path": path})
+    return raw.fetch_first("output-files", {"path": path}, client=client)
 
 
 @cache
-def get_all_working_files_for_entity(entity, task=None, name=None):
+def get_all_working_files_for_entity(
+    entity, task=None, name=None, client=default
+):
     """
     Retrieves all the working files of a given entity and specied parameters
     """
@@ -121,11 +132,11 @@ def get_all_working_files_for_entity(entity, task=None, name=None):
     if name is not None:
         params["name"] = name
 
-    return client.fetch_all(path, params)
+    return raw.fetch_all(path, params, client=client)
 
 
 @cache
-def get_preview_file(preview_file_id):
+def get_preview_file(preview_file_id, client=default):
     """
     Args:
         preview_file_id (str): ID of claimed preview file.
@@ -133,17 +144,21 @@ def get_preview_file(preview_file_id):
     Returns:
         dict: Preview file corresponding to given ID.
     """
-    return client.fetch_one("preview-files", preview_file_id)
-
+    return raw.fetch_one("preview-files", preview_file_id, client=client)
 
 
 @cache
-def get_all_preview_files_for_task(task):
+def get_all_preview_files_for_task(task, client=default):
     """
     Retrieves all the preview files for a given task.
+
+    Args:
+        task (str, id): Target task
     """
     task = normalize_model_parameter(task)
-    return client.fetch_all("preview-files", {"task_id":task["id"]})
+    return raw.fetch_all(
+        "preview-files", {"task_id": task["id"]}, client=client
+    )
 
 
 def all_output_files_for_entity(
@@ -153,6 +168,7 @@ def all_output_files_for_entity(
     name=None,
     representation=None,
     file_status=None,
+    client=default
 ):
     """
     Args:
@@ -186,7 +202,7 @@ def all_output_files_for_entity(
     if file_status:
         params["file_status_id"] = file_status["id"]
 
-    return client.fetch_all(path, params)
+    return raw.fetch_all(path, params, client=client)
 
 
 @cache
@@ -198,6 +214,7 @@ def all_output_files_for_asset_instance(
     name=None,
     representation=None,
     file_status=None,
+    client=default
 ):
     """
     Args:
@@ -236,20 +253,20 @@ def all_output_files_for_asset_instance(
     if file_status:
         params["file_status_id"] = file_status["id"]
 
-    return client.fetch_all(path, params)
+    return raw.fetch_all(path, params, client=client)
 
 
 @cache
-def all_softwares():
+def all_softwares(client=default):
     """
     Returns:
         dict: Software versions listed in database.
     """
-    return client.fetch_all("softwares")
+    return raw.fetch_all("softwares", client=client)
 
 
 @cache
-def get_software(software_id):
+def get_software(software_id, client=default):
     """
     Args:
         software_id (str): ID of claimed output type.
@@ -257,11 +274,11 @@ def get_software(software_id):
     Returns:
         dict: Software object corresponding to given ID.
     """
-    return client.fetch_one("softwares", software_id)
+    return raw.fetch_one("softwares", software_id, client=client)
 
 
 @cache
-def get_software_by_name(software_name):
+def get_software_by_name(software_name, client=default):
     """
     Args:
         software_name (str): Name of claimed output type.
@@ -269,10 +286,10 @@ def get_software_by_name(software_name):
     Returns:
         dict: Software object corresponding to given name.
     """
-    return client.fetch_first("softwares", {"name": software_name})
+    return raw.fetch_first("softwares", {"name": software_name}, client=client)
 
 
-def new_software(name, short_name, file_extension):
+def new_software(name, short_name, file_extension, client=default):
     """
     Create a new software in datatabase.
 
@@ -289,20 +306,26 @@ def new_software(name, short_name, file_extension):
         "short_name": short_name,
         "file_extension": file_extension,
     }
-    software = get_software_by_name(name)
+    software = get_software_by_name(name, client=client)
     if software is None:
-        return client.create("softwares", data)
+        return raw.create("softwares", data, client=client)
     else:
         return software
 
 
 @cache
 def build_working_file_path(
-    task, name="main", mode="working", software=None, revision=1, sep="/"
+    task,
+    name="main",
+    mode="working",
+    software=None,
+    revision=1,
+    sep="/",
+    client=default
 ):
     """
-    From the file path template configured at the project level and arguments, it
-    builds a file path location where to store related DCC file.
+    From the file path template configured at the project level and arguments,
+    it builds a file path location where to store related DCC file.
 
     Args:
         task (str / id): Task related to working file.
@@ -320,7 +343,9 @@ def build_working_file_path(
     software = normalize_model_parameter(software)
     if software is not None:
         data["software_id"] = software["id"]
-    result = client.post("data/tasks/%s/working-file-path" % task["id"], data)
+    result = raw.post(
+        "data/tasks/%s/working-file-path" % task["id"], data, client=client
+    )
     return "%s%s%s" % (
         result["path"].replace(" ", "_"),
         sep,
@@ -339,10 +364,11 @@ def build_entity_output_file_path(
     revision=0,
     nb_elements=1,
     sep="/",
+    client=default
 ):
     """
-    From the file path template configured at the project level and arguments, it
-    builds a file path location where to store related DCC output file.
+    From the file path template configured at the project level and arguments,
+    it builds a file path location where to store related DCC output file.
 
     Args:
         entity (str / id): Entity for which an output file is needed.
@@ -375,7 +401,7 @@ def build_entity_output_file_path(
         "separator": sep,
     }
     path = "data/entities/%s/output-file-path" % entity["id"]
-    result = client.post(path, data)
+    result = raw.post(path, data, client=client)
     return "%s%s%s" % (
         result["folder_path"].replace(" ", "_"),
         sep,
@@ -395,10 +421,11 @@ def build_asset_instance_output_file_path(
     revision=0,
     nb_elements=1,
     sep="/",
+    client=default
 ):
     """
-    From the file path template configured at the project level and arguments, it
-    builds a file path location where to store related DCC output file.
+    From the file path template configured at the project level and arguments,
+    it builds a file path location where to store related DCC output file.
 
     Args:
         asset_instance_id entity (str / id): Asset instance for which a file
@@ -437,7 +464,7 @@ def build_asset_instance_output_file_path(
         asset_instance["id"],
         temporal_entity["id"],
     )
-    result = client.post(path, data)
+    result = raw.post(path, data, client=client)
     return "%s%s%s" % (
         result["folder_path"].replace(" ", "_"),
         sep,
@@ -454,6 +481,7 @@ def new_working_file(
     person=None,
     revision=0,
     sep="/",
+    client=default
 ):
     """
     Create a new working_file for given task. It generates and store the
@@ -488,7 +516,7 @@ def new_working_file(
     if software is not None:
         data["software_id"] = software["id"]
 
-    return client.post("data/tasks/%s/working-files/new" % task["id"], data)
+    return raw.post("data/tasks/%s/working-files/new" % task["id"], data)
 
 
 def new_entity_output_file(
@@ -505,6 +533,7 @@ def new_entity_output_file(
     representation="",
     sep="/",
     file_status_id=None,
+    client=default
 ):
     """
     Create a new output file for given entity, task type and output type.
@@ -558,7 +587,7 @@ def new_entity_output_file(
     if file_status_id is not None:
         data["file_status_id"] = file_status_id
 
-    return client.post(path, data)
+    return raw.post(path, data, client=client)
 
 
 def new_asset_instance_output_file(
@@ -576,6 +605,7 @@ def new_asset_instance_output_file(
     representation="",
     sep="/",
     file_status_id=None,
+    client=default
 ):
     """
     Create a new output file for given asset instance, temporal entity, task
@@ -633,11 +663,11 @@ def new_asset_instance_output_file(
     if file_status_id is not None:
         data["file_status_id"] = file_status_id
 
-    return client.post(path, data)
+    return raw.post(path, data, client=client)
 
 
 def get_next_entity_output_revision(
-    entity, output_type, task_type, name="main"
+    entity, output_type, task_type, name="main", client=default
 ):
     """
     Args:
@@ -657,11 +687,16 @@ def get_next_entity_output_revision(
         "task_type_id": task_type["id"],
         "name": name,
     }
-    return client.post(path, data)["next_revision"]
+    return raw.post(path, data, client=client)["next_revision"]
 
 
 def get_next_asset_instance_output_revision(
-    asset_instance, temporal_entity, output_type, task_type, name="master"
+    asset_instance,
+    temporal_entity,
+    output_type,
+    task_type,
+    name="master",
+    client=default
 ):
     """
     Args:
@@ -679,8 +714,7 @@ def get_next_asset_instance_output_revision(
     output_type = normalize_model_parameter(output_type)
     task_type = normalize_model_parameter(task_type)
     path = (
-        "data/asset-instances/"
-        + "%s/entities/%s/output-files/next-revision"
+        "data/asset-instances/%s/entities/%s/output-files/next-revision"
         % (asset_instance["id"], temporal_entity["id"])
     )
     data = {
@@ -688,18 +722,18 @@ def get_next_asset_instance_output_revision(
         "output_type_id": output_type["id"],
         "task_type_id": task_type["id"],
     }
-    return client.post(path, data)["next_revision"]
+    return raw.post(path, data, client=client)["next_revision"]
 
 
 def get_last_entity_output_revision(
-    entity, output_type, task_type, name="master"
+    entity, output_type, task_type, name="master", client=default
 ):
     """
     Args:
-        entity (str / dict): The entity dict or ID.
-        output_type (str / dict): The entity dict or ID.
-        task_type (str / dict): The entity dict or ID.
-        name (str): The output name
+        entity (str / dict, client=default): The entity dict or ID.
+        output_type (str / dict, client=default): The entity dict or ID.
+        task_type (str / dict, client=default): The entity dict or ID.
+        name (str, client=default): The output name
 
     Returns:
         int: Last revision of ouput files for given entity, output type and task
@@ -709,7 +743,7 @@ def get_last_entity_output_revision(
     output_type = normalize_model_parameter(output_type)
     task_type = normalize_model_parameter(task_type)
     revision = get_next_entity_output_revision(
-        entity, output_type, task_type, name
+        entity, output_type, task_type, name, client=client
     )
     if revision != 1:
         revision -= 1
@@ -717,7 +751,12 @@ def get_last_entity_output_revision(
 
 
 def get_last_asset_instance_output_revision(
-    asset_instance, temporal_entity, output_type, task_type, name="master"
+    asset_instance,
+    temporal_entity,
+    output_type,
+    task_type,
+    name="master",
+    client=default
 ):
     """
     Generate last output revision for given asset instance.
@@ -727,7 +766,8 @@ def get_last_asset_instance_output_revision(
     output_type = normalize_model_parameter(output_type)
     task_type = normalize_model_parameter(task_type)
     revision = get_next_asset_instance_output_revision(
-        asset_instance, temporal_entity, output_type, task_type, name=name
+        asset_instance, temporal_entity, output_type, task_type, name=name,
+        client=client
     )
     if revision != 1:
         revision -= 1
@@ -742,6 +782,7 @@ def get_last_output_files_for_entity(
     name=None,
     representation=None,
     file_status=None,
+    client=default
 ):
     """
     Args:
@@ -777,7 +818,7 @@ def get_last_output_files_for_entity(
     if file_status:
         params["file_status_id"] = file_status["id"]
 
-    return client.fetch_all(path, params)
+    return raw.fetch_all(path, params, client=client)
 
 
 @cache
@@ -789,6 +830,7 @@ def get_last_output_files_for_asset_instance(
     name=None,
     representation=None,
     file_status=None,
+    client=default
 ):
     """
     Args:
@@ -829,11 +871,11 @@ def get_last_output_files_for_asset_instance(
     if file_status:
         params["file_status_id"] = file_status["id"]
 
-    return client.fetch_all(path, params)
+    return raw.fetch_all(path, params, client=client)
 
 
 @cache
-def get_working_files_for_task(task):
+def get_working_files_for_task(task, client=default):
     """
     Args:
         task (str / dict): The task dict or the task ID.
@@ -843,11 +885,11 @@ def get_working_files_for_task(task):
     """
     task = normalize_model_parameter(task)
     path = "data/tasks/%s/working-files" % task["id"]
-    return client.get(path)
+    return raw.get(path, client=client)
 
 
 @cache
-def get_last_working_files(task):
+def get_last_working_files(task, client=default):
     """
     Args:
         task (str / dict): The task dict or the task ID.
@@ -858,11 +900,11 @@ def get_last_working_files(task):
     """
     task = normalize_model_parameter(task)
     path = "data/tasks/%s/working-files/last-revisions" % task["id"]
-    return client.get(path)
+    return raw.get(path, client=client)
 
 
 @cache
-def get_last_working_file_revision(task, name="main"):
+def get_last_working_file_revision(task, name="main", client=default):
     """
     Args:
         task (str / dict): The task dict or the task ID.
@@ -874,12 +916,12 @@ def get_last_working_file_revision(task, name="main"):
     """
     task = normalize_model_parameter(task)
     path = "data/tasks/%s/working-files/last-revisions" % task["id"]
-    working_files_dict = client.get(path)
+    working_files_dict = raw.get(path, client=client)
     return working_files_dict.get(name)
 
 
 @cache
-def get_working_file(working_file_id):
+def get_working_file(working_file_id, client=default):
     """
     Args:
         working_file_id (str): ID of claimed working file.
@@ -887,10 +929,10 @@ def get_working_file(working_file_id):
     Returns:
         dict: Working file corresponding to given ID.
     """
-    return client.fetch_one("working-files", working_file_id)
+    return raw.fetch_one("working-files", working_file_id, client=client)
 
 
-def update_comment(working_file, comment):
+def update_comment(working_file, comment, client=default):
     """
     Update the file comment in database for given working file.
 
@@ -901,13 +943,14 @@ def update_comment(working_file, comment):
         dict: Modified working file
     """
     working_file = normalize_model_parameter(working_file)
-    return client.put(
+    return raw.put(
         "/actions/working-files/%s/comment" % working_file["id"],
         {"comment": comment},
+        client=client
     )
 
 
-def update_modification_date(working_file):
+def update_modification_date(working_file, client=default):
     """
     Update modification date of given working file with current time (now).
 
@@ -917,12 +960,13 @@ def update_modification_date(working_file):
     Returns:
         dict: Modified working file
     """
-    return client.put(
-        "/actions/working-files/%s/modified" % working_file["id"], {}
+    return raw.put(
+        "/actions/working-files/%s/modified" % working_file["id"], {},
+        client=client
     )
 
 
-def update_output_file(output_file, data):
+def update_output_file(output_file, data, client=default):
     """
     Update the data of given output file.
 
@@ -934,10 +978,10 @@ def update_output_file(output_file, data):
     """
     output_file = normalize_model_parameter(output_file)
     path = "/data/output-files/%s" % output_file["id"]
-    return client.put(path, data)
+    return raw.put(path, data, client)
 
 
-def set_project_file_tree(project, file_tree_name):
+def set_project_file_tree(project, file_tree_name, client=default):
     """
     (Deprecated) Set given file tree template on given project. This template
     will be used to generate file paths. The template is selected from sources.
@@ -953,10 +997,10 @@ def set_project_file_tree(project, file_tree_name):
     project = normalize_model_parameter(project)
     data = {"tree_name": file_tree_name}
     path = "actions/projects/%s/set-file-tree" % project["id"]
-    return client.post(path, data)
+    return raw.post(path, data, client=client)
 
 
-def update_project_file_tree(project, file_tree):
+def update_project_file_tree(project, file_tree, client=default):
     """
     Set given dict as file tree template on given project. This template
     will be used to generate file paths.
@@ -971,10 +1015,10 @@ def update_project_file_tree(project, file_tree):
     project = normalize_model_parameter(project)
     data = {"file_tree": file_tree}
     path = "data/projects/%s" % project["id"]
-    return client.put(path, data)
+    return raw.put(path, data, client=client)
 
 
-def upload_working_file(working_file, file_path):
+def upload_working_file(working_file, file_path, client=default):
     """
     Save given file in working file storage.
 
@@ -984,11 +1028,11 @@ def upload_working_file(working_file, file_path):
     """
     working_file = normalize_model_parameter(working_file)
     url_path = "/data/working-files/%s/file" % working_file["id"]
-    client.upload(url_path, file_path)
+    raw.upload(url_path, file_path, client=client)
     return working_file
 
 
-def download_working_file(working_file, file_path=None):
+def download_working_file(working_file, file_path=None, client=default):
     """
     Download given working file and save it at given location.
 
@@ -998,15 +1042,17 @@ def download_working_file(working_file, file_path=None):
     """
     working_file = normalize_model_parameter(working_file)
     if file_path is None:
-        working_file = client.fetch_one("working-files", working_file["id"])
+        working_file = \
+            raw.fetch_one("working-files", working_file["id"], client=client)
         file_path = working_file["path"]
-    return client.download(
+    return raw.download(
         "data/working-files/%s/file" % (working_file["id"]),
         file_path,
+        client=client
     )
 
 
-def download_preview_file(preview_file, file_path):
+def download_preview_file(preview_file, file_path, client=default):
     """
     Download given preview file and save it at given location.
 
@@ -1015,16 +1061,19 @@ def download_preview_file(preview_file, file_path):
         file_path (str): Location on hard drive where to save the file.
     """
     preview_file = normalize_model_parameter(preview_file)
-    preview_file = client.fetch_one("preview-files", preview_file["id"])
+    preview_file = raw.fetch_one(
+        "preview-files", preview_file["id"], client=client
+    )
     file_type = 'movies' if preview_file['extension'] == 'mp4' else 'pictures'
-    return client.download(
+    return raw.download(
         "%s/originals/preview-files/%s.%s"
         % (file_type, preview_file["id"], preview_file["extension"]),
         file_path,
+        client=client
     )
 
 
-def download_attachment_file(attachment_file, file_path):
+def download_attachment_file(attachment_file, file_path, client=default):
     """
     Download given attachment file and save it at given location.
 
@@ -1033,13 +1082,14 @@ def download_attachment_file(attachment_file, file_path):
         file_path (str): Location on hard drive where to save the file.
     """
     attachment_file = normalize_model_parameter(attachment_file)
-    return client.download(
+    return raw.download(
         "data/attachment-files/%s/file" % (attachment_file["id"]),
         file_path,
+        client=client
     )
 
 
-def download_preview_file_thumbnail(preview_file, file_path):
+def download_preview_file_thumbnail(preview_file, file_path, client=default):
     """
     Download given preview file thumbnail and save it at given location.
 
@@ -1049,13 +1099,14 @@ def download_preview_file_thumbnail(preview_file, file_path):
 
     """
     preview_file = normalize_model_parameter(preview_file)
-    return client.download(
+    return raw.download(
         "pictures/thumbnails/preview-files/%s.png" % (preview_file["id"]),
         file_path,
+        client=client
     )
 
 
-def update_preview(preview_file, data):
+def update_preview(preview_file, data, client=default):
     """
     Update the data of given preview file.
 
@@ -1067,32 +1118,32 @@ def update_preview(preview_file, data):
     """
     preview_file = normalize_model_parameter(preview_file)
     path = "/data/preview-files/%s" % preview_file["id"]
-    return client.put(path, data)
+    return raw.put(path, data, client=client)
 
 
-def new_file_status(name, color):
+def new_file_status(name, color, client=default):
     """
     Create a new file status if not existing yet.
     """
     data = {"name": name, "color": color}
-    status = get_file_status_by_name(name)
+    status = get_file_status_by_name(name, client=client)
     if status is None:
-        return client.create("file-status", data)
+        return raw.create("file-status", data, client=client)
     else:
         return status
 
 
 @cache
-def get_file_status(status_id):
+def get_file_status(status_id, client=default):
     """
     Return file status object corresponding to given ID.
     """
-    return client.fetch_one("file-status", status_id)
+    return raw.fetch_one("file-status", status_id, client=client)
 
 
 @cache
-def get_file_status_by_name(name):
+def get_file_status_by_name(name, client=default):
     """
     Return file status object corresponding to given name
     """
-    return client.fetch_first("file-status?name=%s" % name)
+    return raw.fetch_first("file-status?name=%s" % name, client=client)

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -125,6 +125,19 @@ def get_all_working_files_for_entity(entity, task=None, name=None):
 
 
 @cache
+def get_preview_file(preview_file_id):
+    """
+    Args:
+        preview_file_id (str): ID of claimed preview file.
+
+    Returns:
+        dict: Preview file corresponding to given ID.
+    """
+    return client.fetch_one("preview-files", preview_file_id)
+
+
+
+@cache
 def get_all_preview_files_for_task(task):
     """
     Retrieves all the preview files for a given task.

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -1,21 +1,23 @@
-from . import client
+from . import client as raw
 
 from .sorting import sort_by_name
 from .cache import cache
 from .helpers import normalize_model_parameter
 
+default = raw.default_client
+
 
 @cache
-def all_project_status():
+def all_project_status(client=default):
     """
     Returns:
         list: Project status listed in database.
     """
-    return sort_by_name(client.fetch_all("project-status"))
+    return sort_by_name(raw.fetch_all("project-status", client=client))
 
 
 @cache
-def get_project_status_by_name(project_status_name):
+def get_project_status_by_name(project_status_name, client=default):
     """
     Args:
         project_status_name (str): Name of claimed project status.
@@ -23,29 +25,31 @@ def get_project_status_by_name(project_status_name):
     Returns:
         dict: Project status corresponding to given name.
     """
-    return client.fetch_first("project-status", {"name": project_name})
+    return raw.fetch_first(
+        "project-status", {"name": project_name}, client=client
+    )
 
 
 @cache
-def all_projects():
+def all_projects(client=default):
     """
     Returns:
         list: Projects stored in the database.
     """
-    return sort_by_name(client.fetch_all("projects"))
+    return sort_by_name(raw.fetch_all("projects", client=client))
 
 
 @cache
-def all_open_projects():
+def all_open_projects(client=default):
     """
     Returns:
         Open projects stored in the database.
     """
-    return sort_by_name(client.fetch_all("projects/open"))
+    return sort_by_name(raw.fetch_all("projects/open", client=client))
 
 
 @cache
-def get_project(project_id):
+def get_project(project_id, client=default):
     """
     Args:
         project_id (str): ID of claimed project.
@@ -53,10 +57,11 @@ def get_project(project_id):
     Returns:
         dict: Project corresponding to given id.
     """
-    return client.fetch_one("projects", project_id)
+    return raw.fetch_one("projects", project_id, client=client)
+
 
 @cache
-def get_project_url(project, section="assets"):
+def get_project_url(project, section="assets", client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -68,13 +73,14 @@ def get_project_url(project, section="assets"):
     project = normalize_model_parameter(project)
     path = "{host}/productions/{project_id}/{section}/"
     return path.format(
-        host=client.get_zou_url_from_host(),
+        host=raw.get_api_url_from_host(),
         project_id=project["id"],
-        section=section,
+        section=section
     )
 
+
 @cache
-def get_project_by_name(project_name):
+def get_project_by_name(project_name, client=default):
     """
     Args:
         project_name (str): Name of claimed project.
@@ -82,10 +88,10 @@ def get_project_by_name(project_name):
     Returns:
         dict: Project corresponding to given name.
     """
-    return client.fetch_first("projects", {"name": project_name})
+    return raw.fetch_first("projects", {"name": project_name}, client=client)
 
 
-def new_project(name, production_type="short"):
+def new_project(name, production_type="short", client=default):
     """
     Creates a new project.
 
@@ -97,13 +103,13 @@ def new_project(name, production_type="short"):
         dict: Created project.
     """
     data = {"name": name, "production_type": production_type}
-    project = get_project_by_name(name)
+    project = get_project_by_name(name, client=client)
     if project is None:
-        project = client.create("projects", data)
+        project = raw.create("projects", data, client=client)
     return project
 
 
-def remove_project(project, force=False):
+def remove_project(project, force=False, client=default):
     """
     Remove given project from database. (Prior to do that, make sure, there
     is no asset or shot left).
@@ -115,10 +121,10 @@ def remove_project(project, force=False):
     path = "data/projects/%s" % project["id"]
     if force:
         path += "?force=true"
-    return client.delete(path)
+    return raw.delete(path, client=client)
 
 
-def update_project(project):
+def update_project(project, client=default):
     """
     Save given project data into the API. Metadata are fully replaced by the
     ones set on given project.
@@ -129,10 +135,12 @@ def update_project(project):
     Returns:
         dict: Updated project.
     """
-    return client.put("data/projects/%s" % project["id"], project)
+    return raw.put(
+        "data/projects/%s" % project["id"], project, client=client
+    )
 
 
-def update_project_data(project, data={}):
+def update_project_data(project, data={}, client=default):
     """
     Update the metadata for the provided project. Keys that are not provided
     are not changed.
@@ -145,14 +153,14 @@ def update_project_data(project, data={}):
         dict: Updated project.
     """
     project = normalize_model_parameter(project)
-    project = get_project(project["id"])
+    project = get_project(project["id"], client=client)
     if "data" not in project or project["data"] is None:
         project["data"] = {}
     project["data"].update(data)
-    update_project(project)
+    update_project(project, client=client)
 
 
-def close_project(project):
+def close_project(project, client=default):
     """
     Closes the provided project.
 
@@ -163,11 +171,11 @@ def close_project(project):
         dict: Updated project.
     """
     closed_status_id = None
-    for status in all_project_status():
+    for status in all_project_status(client=client):
         if status["name"].lower() == "closed":
             closed_status_id = status["id"]
 
     project["project_status_id"] = closed_status_id
-    update_project(project)
+    update_project(project, client=client)
 
     return project

--- a/gazu/scene.py
+++ b/gazu/scene.py
@@ -1,83 +1,97 @@
-from . import client
+from . import client as raw
 
 from .sorting import sort_by_name
 from .cache import cache
 from .helpers import normalize_model_parameter
 from .shot import get_sequence
 
+default = raw.default_client
 
-def new_scene(project, sequence, name):
+
+def new_scene(project, sequence, name, client=default):
     """
     Create a scene for given sequence.
     """
     project = normalize_model_parameter(project)
     sequence = normalize_model_parameter(sequence)
     shot = {"name": name, "sequence_id": sequence["id"]}
-    return client.post("data/projects/%s/scenes" % project["id"], shot)
+    return raw.post(
+        "data/projects/%s/scenes" % project["id"],
+        shot,
+        client=client
+    )
 
 
 @cache
-def all_scenes(project=None):
+def all_scenes(project=None, client=default):
     """
     Retrieve all scenes.
     """
     project = normalize_model_parameter(project)
     if project is not None:
-        scenes = client.fetch_all("projects/%s/scenes" % project["id"])
+        scenes = raw.fetch_all(
+            "projects/%s/scenes" % project["id"],
+            client=client
+        )
     else:
-        scenes = client.fetch_all("scenes")
+        scenes = raw.fetch_all("scenes")
     return sort_by_name(scenes)
 
 
 @cache
-def all_scenes_for_project(project):
+def all_scenes_for_project(project, client=default):
     """
     Retrieve all scenes for given project.
     """
     project = normalize_model_parameter(project)
-    scenes = client.fetch_all("projects/%s/scenes" % project["id"])
+    scenes = raw.fetch_all(
+        "projects/%s/scenes" % project["id"],
+        client=client
+    )
     return sort_by_name(scenes)
 
 
 @cache
-def all_scenes_for_sequence(sequence):
+def all_scenes_for_sequence(sequence, client=default):
     """
     Retrieve all scenes which are children from given sequence.
     """
     sequence = normalize_model_parameter(sequence)
     return sort_by_name(
-        client.fetch_all("sequences/%s/scenes" % sequence["id"])
+        raw.fetch_all("sequences/%s/scenes" % sequence["id"], client=client),
     )
 
 
 @cache
-def get_scene(scene_id):
+def get_scene(scene_id, client=default):
     """
     Return scene corresponding to given scene ID.
     """
-    return client.fetch_one("scenes", scene_id)
+    return raw.fetch_one("scenes", scene_id, client=client)
 
 
 @cache
-def get_scene_by_name(sequence, scene_name):
+def get_scene_by_name(sequence, scene_name, client=default):
     """
     Returns scene corresponding to given sequence and name.
     """
     sequence = normalize_model_parameter(sequence)
-    result = client.fetch_all(
-        "scenes/all", {"parent_id": sequence["id"], "name": scene_name}
+    result = raw.fetch_all(
+        "scenes/all",
+        {"parent_id": sequence["id"], "name": scene_name},
+        client=client
     )
     return next(iter(result or []), None)
 
 
-def update_scene(scene):
+def update_scene(scene, client=default):
     """
     Save given scene data into the API.
     """
-    return client.put("data/entities/%s" % scene["id"], scene)
+    return raw.put("data/entities/%s" % scene["id"], scene, client=client)
 
 
-def new_scene_asset_instance(scene, asset, description=""):
+def new_scene_asset_instance(scene, asset, description="", client=default):
     """
     Creates a new asset instance on given scene. The instance number is
     automatically generated (increment highest number).
@@ -85,47 +99,62 @@ def new_scene_asset_instance(scene, asset, description=""):
     scene = normalize_model_parameter(scene)
     asset = normalize_model_parameter(asset)
     data = {"asset_id": asset["id"], "description": description}
-    return client.post("data/scenes/%s/asset-instances" % scene["id"], data)
-
-
-@cache
-def all_asset_instances_for_scene(scene):
-    """
-    Return the list of asset instances listed in a scene.
-    """
-    scene = normalize_model_parameter(scene)
-    return client.get("data/scenes/%s/asset-instances" % scene["id"])
-
-
-@cache
-def get_asset_instance_by_name(scene, name):
-    """
-    Returns the asset instance of the scene that has the given name.
-    """
-    return client.fetch_first(
-        "asset-instances", {"name": name, "scene_id": scene["id"]}
+    return raw.post(
+        "data/scenes/%s/asset-instances" % scene["id"],
+        data,
+        client=client
     )
 
 
 @cache
-def all_camera_instances_for_scene(scene):
+def all_asset_instances_for_scene(scene, client=default):
+    """
+    Return the list of asset instances listed in a scene.
+    """
+    scene = normalize_model_parameter(scene)
+    return raw.get(
+        "data/scenes/%s/asset-instances" % scene["id"],
+        client=client
+    )
+
+
+@cache
+def get_asset_instance_by_name(scene, name, client=default):
+    """
+    Returns the asset instance of the scene that has the given name.
+    """
+    return raw.fetch_first(
+        "asset-instances",
+        {"name": name, "scene_id": scene["id"]},
+        client=client
+    )
+
+
+@cache
+def all_camera_instances_for_scene(scene, client=default):
     """
     Return the list of camera instances listed in a scene.
     """
     scene = normalize_model_parameter(scene)
-    return client.get("data/scenes/%s/camera-instances" % scene["id"])
+    return raw.get(
+        "data/scenes/%s/camera-instances" % scene["id"],
+        client=client
+    )
 
 
 @cache
-def all_shots_for_scene(scene):
+def all_shots_for_scene(scene, client=default):
     """
     Return the list of shots issued from given scene.
     """
     scene = normalize_model_parameter(scene)
-    return client.get("data/scenes/%s/shots" % scene["id"])
+    return raw.get(
+        "data/scenes/%s/shots" % scene["id"],
+        client=client
+    )
 
 
-def add_shot_to_scene(scene, shot):
+def add_shot_to_scene(scene, shot, client=default):
     """
     Link a shot to a scene to mark the fact it was generated out from that
     scene.
@@ -133,39 +162,46 @@ def add_shot_to_scene(scene, shot):
     scene = normalize_model_parameter(scene)
     shot = normalize_model_parameter(shot)
     data = {"shot_id": shot["id"]}
-    return client.post("data/scenes/%s/shots" % scene["id"], data)
+    return raw.post(
+        "data/scenes/%s/shots" % scene["id"],
+        data,
+        client=client
+    )
 
 
-def remove_shot_from_scene(scene, shot):
+def remove_shot_from_scene(scene, shot, client=default):
     """
     Remove link between a shot and a scene.
     """
     scene = normalize_model_parameter(scene)
     shot = normalize_model_parameter(shot)
-    return client.delete("data/scenes/%s/shots/%s" % (scene["id"], shot["id"]))
+    return raw.delete(
+        "data/scenes/%s/shots/%s" % (scene["id"], shot["id"]),
+        client=client
+    )
 
 
-def update_asset_instance_name(asset_instance, name):
+def update_asset_instance_name(asset_instance, name, client=default):
     """
     Update the name of given asset instance.
     """
     path = "/data/asset-instances/%s" % asset_instance["id"]
-    return client.put(path, {"name": name})
+    return raw.put(path, {"name": name}, client=client)
 
 
-def update_asset_instance_data(asset_instance, data):
+def update_asset_instance_data(asset_instance, data, client=default):
     """
     Update the extra data of given asset instance.
     """
     asset_instance = normalize_model_parameter(asset_instance)
     path = "/data/asset-instances/%s" % asset_instance["id"]
-    return client.put(path, {"data": data})
+    return raw.put(path, {"data": data}, client=client)
 
 
 @cache
-def get_sequence_from_scene(scene):
+def get_sequence_from_scene(scene, client=default):
     """
     Return sequence which is parent of given shot.
     """
     scene = normalize_model_parameter(scene)
-    return get_sequence(scene["parent_id"])
+    return get_sequence(scene["parent_id"], client=client)

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -1,12 +1,14 @@
-from . import client
+from . import client as raw
 
 from .sorting import sort_by_name
 from .cache import cache
 from .helpers import normalize_model_parameter
 
+default = raw.default_client
+
 
 @cache
-def all_previews_for_shot(shot):
+def all_previews_for_shot(shot, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
@@ -15,11 +17,11 @@ def all_previews_for_shot(shot):
         list: Previews from database for given shot.
     """
     shot = normalize_model_parameter(shot)
-    return client.fetch_all("shots/%s/preview-files" % shot["id"])
+    return raw.fetch_all("shots/%s/preview-files" % shot["id"], client=client)
 
 
 @cache
-def all_shots_for_project(project):
+def all_shots_for_project(project, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -28,13 +30,13 @@ def all_shots_for_project(project):
         list: Shots from database or for given project.
     """
     project = normalize_model_parameter(project)
-    shots = client.fetch_all("projects/%s/shots" % project["id"])
+    shots = raw.fetch_all("projects/%s/shots" % project["id"], client=client)
 
     return sort_by_name(shots)
 
 
 @cache
-def all_shots_for_sequence(sequence):
+def all_shots_for_sequence(sequence, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -44,12 +46,12 @@ def all_shots_for_sequence(sequence):
     """
     sequence = normalize_model_parameter(sequence)
     return sort_by_name(
-        client.fetch_all("sequences/%s/shots" % sequence["id"])
+        raw.fetch_all("sequences/%s/shots" % sequence["id"], client=client)
     )
 
 
 @cache
-def all_sequences_for_project(project):
+def all_sequences_for_project(project, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -58,12 +60,13 @@ def all_sequences_for_project(project):
         list: Sequences from database for given project.
     """
     project = normalize_model_parameter(project)
-    sequences = client.fetch_all("projects/%s/sequences" % project["id"])
+    path = "projects/%s/sequences" % project["id"]
+    sequences = raw.fetch_all(path, client=client)
     return sort_by_name(sequences)
 
 
 @cache
-def all_sequences_for_episode(episode):
+def all_sequences_for_episode(episode, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -72,12 +75,13 @@ def all_sequences_for_episode(episode):
         list: Sequences which are children of given episode.
     """
     episode = normalize_model_parameter(episode)
-    sequences = client.fetch_all("episodes/%s/sequences" % episode["id"])
+    path = "episodes/%s/sequences" % episode["id"]
+    sequences = raw.fetch_all(path, client=client)
     return sort_by_name(sequences)
 
 
 @cache
-def all_episodes_for_project(project):
+def all_episodes_for_project(project, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -86,12 +90,13 @@ def all_episodes_for_project(project):
         list: Episodes from database for given project.
     """
     project = normalize_model_parameter(project)
-    episodes = client.fetch_all("projects/%s/episodes" % project["id"])
+    path = "projects/%s/episodes" % project["id"]
+    episodes = raw.fetch_all(path, client=client)
     return sort_by_name(episodes)
 
 
 @cache
-def get_episode(episode_id):
+def get_episode(episode_id, client=default):
     """
     Args:
         episode_id (str): Id of claimed episode.
@@ -99,11 +104,11 @@ def get_episode(episode_id):
     Returns:
         dict: Episode corresponding to given episode ID.
     """
-    return client.fetch_one("episodes", episode_id)
+    return raw.fetch_one("episodes", episode_id)
 
 
 @cache
-def get_episode_by_name(project, episode_name):
+def get_episode_by_name(project, episode_name, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -113,13 +118,15 @@ def get_episode_by_name(project, episode_name):
         dict: Episode corresponding to given name and project.
     """
     project = normalize_model_parameter(project)
-    return client.fetch_first(
-        "episodes", {"project_id": project["id"], "name": episode_name}
+    return raw.fetch_first(
+        "episodes",
+        {"project_id": project["id"], "name": episode_name},
+        client=client
     )
 
 
 @cache
-def get_episode_from_sequence(sequence):
+def get_episode_from_sequence(sequence, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -128,11 +135,11 @@ def get_episode_from_sequence(sequence):
         dict: Episode which is parent of given sequence.
     """
     sequence = normalize_model_parameter(sequence)
-    return get_episode(sequence["parent_id"])
+    return get_episode(sequence["parent_id"], client=client)
 
 
 @cache
-def get_sequence(sequence_id):
+def get_sequence(sequence_id, client=default):
     """
     Args:
         sequence_id (str): ID of claimed sequence.
@@ -140,11 +147,11 @@ def get_sequence(sequence_id):
     Returns:
         dict: Sequence corresponding to given sequence ID.
     """
-    return client.fetch_one("sequences", sequence_id)
+    return raw.fetch_one("sequences", sequence_id, client=client)
 
 
 @cache
-def get_sequence_by_name(project, sequence_name, episode=None):
+def get_sequence_by_name(project, sequence_name, episode=None, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -161,11 +168,11 @@ def get_sequence_by_name(project, sequence_name, episode=None):
     else:
         episode = normalize_model_parameter(episode)
         params = {"episode_id": episode["id"], "name": sequence_name}
-    return client.fetch_first("sequences", params)
+    return raw.fetch_first("sequences", params, client=client)
 
 
 @cache
-def get_sequence_from_shot(shot):
+def get_sequence_from_shot(shot, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
@@ -174,11 +181,11 @@ def get_sequence_from_shot(shot):
         dict: Sequence which is parent of given shot.
     """
     shot = normalize_model_parameter(shot)
-    return get_sequence(shot["parent_id"])
+    return get_sequence(shot["parent_id"], client=client)
 
 
 @cache
-def get_shot(shot_id):
+def get_shot(shot_id, client=default):
     """
     Args:
         episode_id (str): Id of claimed episode.
@@ -186,11 +193,11 @@ def get_shot(shot_id):
     Returns:
         dict: Shot corresponding to given shot ID.
     """
-    return client.fetch_one("shots", shot_id)
+    return raw.fetch_one("shots", shot_id, client=client)
 
 
 @cache
-def get_shot_by_name(sequence, shot_name):
+def get_shot_by_name(sequence, shot_name, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -200,28 +207,32 @@ def get_shot_by_name(sequence, shot_name):
         dict: Shot corresponding to given name and sequence.
     """
     sequence = normalize_model_parameter(sequence)
-    return client.fetch_first(
-        "shots/all", {"sequence_id": sequence["id"], "name": shot_name}
+    return raw.fetch_first(
+        "shots/all",
+        {"sequence_id": sequence["id"], "name": shot_name},
+        client=client
     )
 
+
 @cache
-def get_shot_url(shot):
+def get_shot_url(shot, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
 
     Returns:
-        url (str): Web url associated to the given shot
+        url (str, client=default): Web url associated to the given shot
     """
     shot = normalize_model_parameter(shot)
     path = "{host}/productions/{project_id}/shots/{shot_id}/"
     return path.format(
-        host=client.get_zou_url_from_host(),
+        host=raw.get_api_url_from_host(client=client),
         project_id=shot["project_id"],
         shot_id=shot["id"],
     )
 
-def new_sequence(project, name, episode=None):
+
+def new_sequence(project, name, episode=None, client=default):
     """
     Create a sequence for given project and episode.
 
@@ -240,9 +251,11 @@ def new_sequence(project, name, episode=None):
         episode = normalize_model_parameter(episode)
         data["episode_id"] = episode["id"]
 
-    sequence = get_sequence_by_name(project, name, episode=episode)
+    sequence = \
+        get_sequence_by_name(project, name, episode=episode, client=client)
     if sequence is None:
-        return client.post("data/projects/%s/sequences" % project["id"], data)
+        path = "data/projects/%s/sequences" % project["id"]
+        return raw.post(path, data, client=client)
     else:
         return sequence
 
@@ -254,7 +267,8 @@ def new_shot(
     nb_frames=None,
     frame_in=None,
     frame_out=None,
-    data={}
+    data={},
+    client=default
 ):
     """
     Create a shot for given sequence and project. Add frame in and frame out
@@ -283,14 +297,15 @@ def new_shot(
     if nb_frames is not None:
         data["nb_frames"] = nb_frames
 
-    shot = get_shot_by_name(sequence, name)
+    shot = get_shot_by_name(sequence, name, client=client)
     if shot is None:
-        return client.post("data/projects/%s/shots" % project["id"], data)
+        path = "data/projects/%s/shots" % project["id"]
+        return raw.post(path, data, client=client)
     else:
         return shot
 
 
-def update_shot(shot):
+def update_shot(shot, client=default):
     """
     Save given shot data into the API. Metadata are fully replaced by the ones
     set on given shot.
@@ -301,10 +316,10 @@ def update_shot(shot):
     Returns:
         dict: Updated shot.
     """
-    return client.put("data/entities/%s" % shot["id"], shot)
+    return raw.put("data/entities/%s" % shot["id"], shot, client=client)
 
 
-def update_sequence(sequence):
+def update_sequence(sequence, client=default):
     """
     Save given sequence data into the API. Metadata are fully replaced by the
     ones set on given sequence.
@@ -315,18 +330,18 @@ def update_sequence(sequence):
     Returns:
         dict: Updated sequence.
     """
-    return client.put("data/entities/%s" % sequence["id"], sequence)
+    return raw.put("data/entities/%s" % sequence["id"], sequence, client=client)
 
 
 @cache
-def get_asset_instances_for_shot(shot):
+def get_asset_instances_for_shot(shot, client=default):
     """
     Return the list of asset instances linked to given shot.
     """
-    return client.get("data/shots/%s/asset-instances" % shot["id"])
+    return raw.get("data/shots/%s/asset-instances" % shot["id"], client=client)
 
 
-def update_shot_data(shot, data={}):
+def update_shot_data(shot, data={}, client=default):
     """
     Update the metadata for the provided shot. Keys that are not provided are
     not changed.
@@ -342,10 +357,10 @@ def update_shot_data(shot, data={}):
     current_shot = get_shot(shot["id"])
     updated_shot = {"id": current_shot["id"], "data": current_shot["data"]}
     updated_shot["data"].update(data)
-    update_shot(updated_shot)
+    update_shot(updated_shot, client=client)
 
 
-def update_sequence_data(sequence, data={}):
+def update_sequence_data(sequence, data={}, client=default):
     """
     Update the metadata for the provided sequence. Keys that are not provided are
     not changed.
@@ -358,9 +373,9 @@ def update_sequence_data(sequence, data={}):
         dict: Updated sequence.
     """
     sequence = normalize_model_parameter(sequence)
-    current_sequence = get_sequence(sequence["id"])
+    current_sequence = get_sequence(sequence["id"], client=client)
 
-    if not current_sequence.get('data'):
+    if not current_sequence.get('data', client=default):
         current_sequence["data"] = {}
 
     updated_sequence = {
@@ -368,10 +383,10 @@ def update_sequence_data(sequence, data={}):
         "data": current_sequence["data"]
     }
     updated_sequence["data"].update(data)
-    update_sequence(updated_sequence)
+    return update_sequence(updated_sequence, client)
 
 
-def remove_shot(shot, force=False):
+def remove_shot(shot, force=False, client=default):
     """
     Remove given shot from database.
 
@@ -383,10 +398,10 @@ def remove_shot(shot, force=False):
     params = {}
     if force:
         params = {"force": "true"}
-    return client.delete(path, params)
+    return raw.delete(path, params, client=client)
 
 
-def new_episode(project, name):
+def new_episode(project, name, client=default):
     """
     Create an episode for given project.
 
@@ -399,14 +414,18 @@ def new_episode(project, name):
     """
     project = normalize_model_parameter(project)
     data = {"name": name}
-    episode = get_episode_by_name(project, name)
+    episode = get_episode_by_name(project, name, client=client)
     if episode is None:
-        return client.post("data/projects/%s/episodes" % project["id"], data)
+        return raw.post(
+            "data/projects/%s/episodes" % project["id"],
+            data,
+            client=client
+        )
     else:
         return episode
 
 
-def update_episode(episode):
+def update_episode(episode, client=default):
     """
     Save given episode data into the API. Metadata are fully replaced by the
     ones set on given episode.
@@ -417,10 +436,10 @@ def update_episode(episode):
     Returns:
         dict: Updated episode.
     """
-    return client.put("data/entities/%s" % episode["id"], episode)
+    return raw.put("data/entities/%s" % episode["id"], episode, client=client)
 
 
-def update_episode_data(episode, data={}):
+def update_episode_data(episode, data={}, client=default):
     """
     Update the metadata for the provided episode. Keys that are not provided
     are not changed.
@@ -433,16 +452,16 @@ def update_episode_data(episode, data={}):
         dict: Updated episode.
     """
     episode = normalize_model_parameter(episode)
-    current_episode = get_sequence(episode["id"])
+    current_episode = get_sequence(episode["id"], client=client)
     updated_episode = {
         "id": current_episode["id"],
         "data": current_episode["data"]
     }
     updated_episode["data"].update(data)
-    update_episode(updated_episode)
+    return update_episode(updated_episode, client=client)
 
 
-def remove_episode(episode):
+def remove_episode(episode, client=default):
     """
     Remove given episode and related from database.
 
@@ -451,10 +470,10 @@ def remove_episode(episode):
     """
     episode = normalize_model_parameter(episode)
     path = "data/entities/%s" % episode["id"]
-    return client.delete(path)
+    return raw.delete(path, client=client)
 
 
-def remove_sequence(sequence):
+def remove_sequence(sequence, client=default):
     """
     Remove given sequence and related from database.
 
@@ -463,11 +482,11 @@ def remove_sequence(sequence):
     """
     sequence = normalize_model_parameter(sequence)
     path = "data/entities/%s" % sequence["id"]
-    return client.delete(path)
+    return raw.delete(path, client=client)
 
 
 @cache
-def all_asset_instances_for_shot(shot):
+def all_asset_instances_for_shot(shot, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
@@ -476,10 +495,10 @@ def all_asset_instances_for_shot(shot):
         list: Asset instances linked to given shot.
     """
     shot = normalize_model_parameter(shot)
-    return client.get("data/shots/%s/asset-instances" % shot["id"])
+    return raw.get("data/shots/%s/asset-instances" % shot["id"], client=client)
 
 
-def add_asset_instance_to_shot(shot, asset_instance):
+def add_asset_instance_to_shot(shot, asset_instance, client=default):
     """
     Link a new asset instance to given shot.
 
@@ -493,10 +512,11 @@ def add_asset_instance_to_shot(shot, asset_instance):
     shot = normalize_model_parameter(shot)
     asset_instance = normalize_model_parameter(asset_instance)
     data = {"asset_instance_id": asset_instance["id"]}
-    return client.post("data/shots/%s/asset-instances" % shot["id"], data)
+    path = "data/shots/%s/asset-instances" % shot["id"]
+    return raw.post(path, data, client=client)
 
 
-def remove_asset_instance_from_shot(shot, asset_instance):
+def remove_asset_instance_from_shot(shot, asset_instance, client=default):
     """
     Remove link between an asset instance and given shot.
 
@@ -510,4 +530,4 @@ def remove_asset_instance_from_shot(shot, asset_instance):
         shot["id"],
         asset_instance["id"],
     )
-    return client.delete(path)
+    return raw.delete(path, client=client)

--- a/gazu/sync.py
+++ b/gazu/sync.py
@@ -1,0 +1,112 @@
+from . import client as raw
+
+default = raw.default_client
+
+
+def import_entities(entities, client=default):
+    """
+    Import entities from another instance to target instance (keep id and audit
+    dates).
+    Args:
+        entities (list): Entities to import.
+
+    Returns:
+        dict: Entities created.
+    """
+    return raw.post("import/kitsu/entities", entities, client=client)
+
+
+def import_tasks(tasks, client=default):
+    """
+    Import tasks from another instance to target instance (keep id and audit
+    dates).
+    Args:
+        tasks (list): Tasks to import.
+
+    Returns:
+        dict: Tasks created.
+    """
+    return raw.post("import/kitsu/tasks", tasks, client=client)
+
+
+def import_entity_links(links, client=default):
+    """
+    Import enitity links from another instance to target instance (keep id and
+    audit dates).
+    Args:
+        links (list): Entity links to import.
+
+    Returns:
+        dict: Entity links created.
+    """
+    return raw.post("import/kitsu/entity-links", links, client=client)
+
+
+def get_model_list_diff(source_list, target_list):
+    """
+    Args:
+        source_list (list): List of models to compare.
+        target_list (list): List of models for which we want a diff.
+
+    Returns:
+        tuple: Two lists, one containing the missing models in the target list
+        and one containing the models that should not be in the target list.
+    """
+    missing = []
+    unexpected = []
+    source_ids = {m["id"]: True for m in source_list}
+    target_ids = {m["id"]: True for m in target_list}
+    for model in source_list:
+        if model["id"] not in target_ids:
+            missing.append(model)
+    for model in target_list:
+        if model["id"] not in source_ids:
+            unexpected.append(model)
+    return (missing, unexpected)
+
+
+def get_link_list_diff(source_list, target_list):
+    """
+    Args:
+        source_list (list): List of links to compare.
+        target_list (list): List of links for which we want a diff.
+
+    Returns:
+        tuple: Two lists, one containing the missing links in the target list
+        and one containing the links that should not be in the target list.
+        Links are identified by their in ID and their out ID.
+    """
+    def get_link_key(l): return l["entity_in_id"] + "-" + l["entity_out_id"]
+    missing = []
+    unexpected = []
+    source_ids = {get_link_key(m): True for m in source_list}
+    target_ids = {get_link_key(m): True for m in target_list}
+    for link in source_list:
+        if get_link_key(link) not in target_ids:
+            missing.append(link)
+    for link in target_list:
+        if get_link_key(link) not in source_ids:
+            unexpected.append(link)
+    return (missing, unexpected)
+
+
+def get_id_map_by_name(source_list, target_list):
+    """
+    Args:
+        source_list (list): List of links to compare.
+        target_list (list): List of links for which we want a diff.
+
+    Returns:
+        dict: A dict where keys are the source model names and the values are
+        the IDs of the target models with same name.
+        It's useful to match a model from the source list to its relative in
+        the target list based on its name.
+    """
+    link_map = {}
+    name_map = {}
+    for model in target_list:
+        name_map[model["name"].lower()] = model["id"]
+    for model in source_list:
+        if model["name"].lower() in name_map:
+            link_map[model["id"]] = name_map[model["name"].lower()]
+    return link_map

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -1,34 +1,36 @@
 import string
 
-from . import client
+from . import client as raw
 from .sorting import sort_by_name
 from .helpers import normalize_model_parameter
 
 from .cache import cache
 
+default = raw.default_client
+
 
 @cache
-def all_task_statuses():
+def all_task_statuses(client=default):
     """
     Returns:
         list: Task statuses stored in database.
     """
-    task_statuses = client.fetch_all("task-status")
+    task_statuses = raw.fetch_all("task-status", client=client)
     return sort_by_name(task_statuses)
 
 
 @cache
-def all_task_types():
+def all_task_types(client=default):
     """
     Returns:
         list: Task types stored in database.
     """
-    task_types = client.fetch_all("task-types")
+    task_types = raw.fetch_all("task-types", client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_tasks_for_shot(shot, relations=False):
+def all_tasks_for_shot(shot, relations=False, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
@@ -40,12 +42,12 @@ def all_tasks_for_shot(shot, relations=False):
     params = {}
     if relations:
         params = {"relations": "true"}
-    tasks = client.fetch_all("shots/%s/tasks" % shot["id"], params)
+    tasks = raw.fetch_all("shots/%s/tasks" % shot["id"], params, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_sequence(sequence, relations=False):
+def all_tasks_for_sequence(sequence, relations=False, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -57,12 +59,13 @@ def all_tasks_for_sequence(sequence, relations=False):
     params = {}
     if relations:
         params = {"relations": "true"}
-    tasks = client.fetch_all("sequences/%s/tasks" % sequence["id"], params)
+    path = "sequences/%s/tasks" % sequence["id"]
+    tasks = raw.fetch_all(path, params, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_scene(scene, relations=False):
+def all_tasks_for_scene(scene, relations=False, client=default):
     """
     Args:
         sequence (str / dict): The scene dict or the scene ID.
@@ -74,12 +77,13 @@ def all_tasks_for_scene(scene, relations=False):
     params = {}
     if relations:
         params = {"relations": "true"}
-    tasks = client.fetch_all("scenes/%s/tasks" % scene["id"], params)
+    path = "scenes/%s/tasks" % scene["id"]
+    tasks = raw.fetch_all(path, params, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_asset(asset, relations=False):
+def all_tasks_for_asset(asset, relations=False, client=default):
     """
     Args:
         asset (str / dict): The asset dict or the asset ID.
@@ -91,12 +95,13 @@ def all_tasks_for_asset(asset, relations=False):
     params = {}
     if relations:
         params = {"relations": "true"}
-    tasks = client.fetch_all("assets/%s/tasks" % asset["id"], params)
+    path = "assets/%s/tasks" % asset["id"]
+    tasks = raw.fetch_all(path, params, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_episode(episode, relations=False):
+def all_tasks_for_episode(episode, relations=False, client=default):
     """
     Retrieve all tasks directly linked to given episode.
     """
@@ -104,12 +109,13 @@ def all_tasks_for_episode(episode, relations=False):
     params = {}
     if relations:
         params = {"relations": "true"}
-    tasks = client.fetch_all("episodes/%s/tasks" % episode["id"], params)
+    path = "episodes/%s/tasks" % episode["id"]
+    tasks = raw.fetch_all(path, params, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_shot_tasks_for_sequence(sequence, relations=False):
+def all_shot_tasks_for_sequence(sequence, relations=False, client=default):
     """
     Retrieve all tasks directly linked to all shots of given sequence.
     """
@@ -117,12 +123,13 @@ def all_shot_tasks_for_sequence(sequence, relations=False):
     params = {}
     if relations:
         params = {"relations": "true"}
-    tasks = client.fetch_all("sequences/%s/shot-tasks" % sequence["id"], params)
+    path = "sequences/%s/shot-tasks" % sequence["id"]
+    tasks = raw.fetch_all(path, params, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_shot_tasks_for_episode(episode, relations=False):
+def all_shot_tasks_for_episode(episode, relations=False, client=default):
     """
     Retrieve all tasks directly linked to all shots of given episode.
     """
@@ -130,12 +137,13 @@ def all_shot_tasks_for_episode(episode, relations=False):
     params = {}
     if relations:
         params = {"relations": "true"}
-    tasks = client.fetch_all("episodes/%s/shot-tasks" % episode["id"], params)
+    path = "episodes/%s/shot-tasks" % episode["id"]
+    tasks = raw.fetch_all(path, params, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_task_status(project, task_type, task_status):
+def all_tasks_for_task_status(project, task_type, task_status, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -148,18 +156,19 @@ def all_tasks_for_task_status(project, task_type, task_status):
     project = normalize_model_parameter(project)
     task_type = normalize_model_parameter(task_type)
     task_status = normalize_model_parameter(task_status)
-    return client.fetch_all(
+    return raw.fetch_all(
         "tasks",
         {
             "project_id": project["id"],
             "task_type_id": task_type["id"],
             "task_status_id": task_status["id"],
         },
+        client=client
     )
 
 
 @cache
-def all_tasks_for_task_type(project, task_type):
+def all_tasks_for_task_type(project, task_type, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -170,17 +179,18 @@ def all_tasks_for_task_type(project, task_type):
     """
     project = normalize_model_parameter(project)
     task_type = normalize_model_parameter(task_type)
-    return client.fetch_all(
+    return raw.fetch_all(
         "tasks",
         {
             "project_id": project["id"],
             "task_type_id": task_type["id"],
         },
+        client=client
     )
 
 
 @cache
-def all_task_types_for_shot(shot):
+def all_task_types_for_shot(shot, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
@@ -189,12 +199,13 @@ def all_task_types_for_shot(shot):
         list: Task types of task linked to given shot.
     """
     shot = normalize_model_parameter(shot)
-    task_types = client.fetch_all("shots/%s/task-types" % shot["id"])
+    path = "shots/%s/task-types" % shot["id"]
+    task_types = raw.fetch_all(path, client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_task_types_for_asset(asset):
+def all_task_types_for_asset(asset, client=default):
     """
     Args:
         asset (str / dict): The asset dict or the asset ID.
@@ -203,12 +214,14 @@ def all_task_types_for_asset(asset):
         list: Task types of tasks related to given asset.
     """
     asset = normalize_model_parameter(asset)
-    task_types = client.fetch_all("assets/%s/task-types" % asset["id"])
+    task_types = raw.fetch_all(
+        "assets/%s/task-types" % asset["id"], client=client
+    )
     return sort_by_name(task_types)
 
 
 @cache
-def all_task_types_for_scene(scene):
+def all_task_types_for_scene(scene, client=default):
     """
     Args:
         scene (str / dict): The scene dict or the scene ID.
@@ -217,12 +230,13 @@ def all_task_types_for_scene(scene):
         list: Task types of tasks linked to given scene.
     """
     scene = normalize_model_parameter(scene)
-    task_types = client.fetch_all("scenes/%s/task-types" % scene["id"])
+    path = "scenes/%s/task-types" % scene["id"]
+    task_types = raw.fetch_all(path, client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_task_types_for_sequence(sequence):
+def all_task_types_for_sequence(sequence, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -231,23 +245,25 @@ def all_task_types_for_sequence(sequence):
         list: Task types of tasks linked directly to given sequence.
     """
     sequence = normalize_model_parameter(sequence)
-    task_types = client.fetch_all("sequences/%s/task-types" % sequence["id"])
+    path = "sequences/%s/task-types" % sequence["id"]
+    task_types = raw.fetch_all(path, client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_task_types_for_episode(episode):
+def all_task_types_for_episode(episode, client=default):
     """
     Returns:
         list: Task types of tasks linked directly to given episode.
     """
     episode = normalize_model_parameter(episode)
-    task_types = client.fetch_all("episodes/%s/task-types" % episode["id"])
+    path = "episodes/%s/task-types" % episode["id"]
+    task_types = raw.fetch_all(path, client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_tasks_for_entity_and_task_type(entity, task_type):
+def all_tasks_for_entity_and_task_type(entity, task_type, client=default):
     """
     Args:
         entity (str / dict): The entity dict or the entity ID.
@@ -260,36 +276,38 @@ def all_tasks_for_entity_and_task_type(entity, task_type):
     task_type = normalize_model_parameter(task_type)
     task_type_id = task_type["id"]
     entity_id = entity["id"]
-    return client.fetch_all(
-        "entities/%s/task-types/%s/tasks" % (entity_id, task_type_id)
-    )
+    path = "entities/%s/task-types/%s/tasks" % (entity_id, task_type_id)
+    return raw.fetch_all(path, client=client)
 
 
 @cache
-def all_tasks_for_person(person):
+def all_tasks_for_person(person, client=default):
     """
     Returns:
         list: Tasks that are not done for given person (only for open projects).
     """
     person = normalize_model_parameter(person)
-    return client.fetch_all("persons/%s/tasks" % person["id"])
+    return raw.fetch_all("persons/%s/tasks" % person["id"])
 
 
 @cache
-def all_done_tasks_for_person(person):
+def all_done_tasks_for_person(person, client=default):
     """
     Returns:
         list: Tasks that are done for given person (only for open projects).
     """
     person = normalize_model_parameter(person)
-    return client.fetch_all("persons/%s/done-tasks" % person["id"])
+    return raw.fetch_all("persons/%s/done-tasks" % person["id"], client=client)
 
 
 @cache
-def get_task_by_name(entity, task_type, name="main"):
-    """
-    Deprecated.
+def get_task_by_entity(entity, task_type, client=default):
+    return get_task_by_name(entity, task_type, client=client)
 
+
+@cache
+def get_task_by_name(entity, task_type, name="main", client=default):
+    """
     Args:
         entity (str / dict): The entity dict or the entity ID.
         task_type (str / dict): The task type dict or ID.
@@ -300,18 +318,19 @@ def get_task_by_name(entity, task_type, name="main"):
     """
     entity = normalize_model_parameter(entity)
     task_type = normalize_model_parameter(task_type)
-    return client.fetch_first(
+    return raw.fetch_first(
         "tasks",
         {
             "name": name,
             "task_type_id": task_type["id"],
             "entity_id": entity["id"],
         },
+        client=client
     )
 
 
 @cache
-def get_task_type(task_type_id):
+def get_task_type(task_type_id, client=default):
     """
     Args:
         task_type_id (str): Id of claimed task type.
@@ -319,11 +338,11 @@ def get_task_type(task_type_id):
     Returns:
         dict: Task type matching given ID.
     """
-    return client.fetch_one("task-types", task_type_id)
+    return raw.fetch_one("task-types", task_type_id, client=client)
 
 
 @cache
-def get_task_type_by_name(task_type_name):
+def get_task_type_by_name(task_type_name, client=default):
     """
     Args:
         task_type_name (str): Name of claimed task type.
@@ -331,11 +350,13 @@ def get_task_type_by_name(task_type_name):
     Returns:
         dict: Task type object for given name.
     """
-    return client.fetch_first("task-types", {"name": task_type_name})
+    return raw.fetch_first(
+        "task-types", {"name": task_type_name}, client=client
+    )
 
 
 @cache
-def get_task_by_path(project, file_path, entity_type="shot"):
+def get_task_by_path(project, file_path, entity_type="shot", client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -352,11 +373,11 @@ def get_task_by_path(project, file_path, entity_type="shot"):
         "project_id": project["id"],
         "type": entity_type,
     }
-    return client.post("data/tasks/from-path/", data)
+    return raw.post("data/tasks/from-path/", data, client=client)
 
 
 @cache
-def get_task_status(task):
+def get_task_status(task, client=default):
     """
     Args:
         task (str / dict): The task dict or the task ID.
@@ -365,11 +386,15 @@ def get_task_status(task):
         A task status object corresponding to status set on given task.
     """
     task = normalize_model_parameter(task)
-    return client.fetch_first("task-status", {"id": task["task_status_id"]})
+    return raw.fetch_first(
+        "task-status",
+        {"id": task["task_status_id"]},
+        client=client
+    )
 
 
 @cache
-def get_task_status_by_name(name):
+def get_task_status_by_name(name, client=default):
     """
     Args:
         name (str / dict): The name of claimed task status.
@@ -377,11 +402,11 @@ def get_task_status_by_name(name):
     Returns:
         dict: Task status matching given name.
     """
-    return client.fetch_first("task-status", {"name": name})
+    return raw.fetch_first("task-status", {"name": name}, client=client)
 
 
 @cache
-def get_task_status_by_short_name(task_status_short_name):
+def get_task_status_by_short_name(task_status_short_name, client=default):
     """
     Args:
         short_name (str / dict): The short name of claimed task status.
@@ -389,12 +414,12 @@ def get_task_status_by_short_name(task_status_short_name):
     Returns:
         dict: Task status matching given short name.
     """
-    return client.fetch_first(
-        "task-status", {"short_name": task_status_short_name}
+    return raw.fetch_first(
+        "task-status", {"short_name": task_status_short_name}, client=client
     )
 
 
-def remove_task_status(task_status):
+def remove_task_status(task_status, client=default):
     """
     Remove given task status from database.
 
@@ -402,13 +427,15 @@ def remove_task_status(task_status):
         task_status (str / dict): The task status dict or ID.
     """
     task_status = normalize_model_parameter(task_status)
-    return client.delete(
-        "data/task-status/%s" % task_status["id"], {"force": "true"}
+    return raw.delete(
+        "data/task-status/%s" % task_status["id"],
+        {"force": "true"},
+        client=client
     )
 
 
 @cache
-def get_task(task_id):
+def get_task(task_id, client=default):
     """
     Args:
         task_id (str): Id of claimed task.
@@ -417,7 +444,7 @@ def get_task(task_id):
         dict: Task matching given ID.
     """
     task_id = normalize_model_parameter(task_id)
-    return client.get("data/tasks/%s/full" % task_id["id"])
+    return raw.get("data/tasks/%s/full" % task_id["id"], client=client)
 
 
 def new_task(
@@ -427,6 +454,7 @@ def new_task(
     task_status=None,
     assigner=None,
     assignees=None,
+    client=default
 ):
     """
     Create a new task for given entity and task type.
@@ -445,7 +473,7 @@ def new_task(
     entity = normalize_model_parameter(entity)
     task_type = normalize_model_parameter(task_type)
     if task_status is None:
-        task_status = get_task_status_by_name("Todo")
+        task_status = get_task_status_by_name("Todo", client=client)
 
     data = {
         "project_id": entity["project_id"],
@@ -463,13 +491,13 @@ def new_task(
     else:
         data["assignees"] = []
 
-    task = get_task_by_name(entity, task_type, name)
+    task = get_task_by_name(entity, task_type, name, client=client)
     if task is None:
-        task = client.post("data/tasks", data)
+        task = raw.post("data/tasks", data, client=client)
     return task
 
 
-def remove_task(task):
+def remove_task(task, client=default):
     """
     Remove given task from database.
 
@@ -477,10 +505,10 @@ def remove_task(task):
         task (str / dict): The task dict or the task ID.
     """
     task = normalize_model_parameter(task)
-    client.delete("data/tasks/%s" % task["id"], {"force": "true"})
+    raw.delete("data/tasks/%s" % task["id"], {"force": "true"}, client=client)
 
 
-def start_task(task):
+def start_task(task, client=default):
     """
     Change a task status to WIP and set its real start date to now.
 
@@ -492,10 +520,12 @@ def start_task(task):
     """
     task = normalize_model_parameter(task)
     path = "actions/tasks/%s/start" % task["id"]
-    return client.put(path, {})
+    return raw.put(path, {}, client=client)
 
 
-def task_to_review(task, person, comment, revision=1, change_status=True):
+def task_to_review(
+    task, person, comment, revision=1, change_status=True, client=default
+):
     """
     Deprecated.
     Mark given task as pending, waiting for approval. Author is given through
@@ -521,11 +551,11 @@ def task_to_review(task, person, comment, revision=1, change_status=True):
         "change_status": change_status,
     }
 
-    return client.put(path, data)
+    return raw.put(path, data, client=client)
 
 
 @cache
-def get_time_spent(task, date):
+def get_time_spent(task, date, client=default):
     """
     Get the time spent by CG artists on a task at a given date. A field contains
     the total time spent.  Durations are given in seconds. Date format is
@@ -540,10 +570,10 @@ def get_time_spent(task, date):
     """
     task = normalize_model_parameter(task)
     path = "actions/tasks/%s/time-spents/%s" % (task["id"], date)
-    return client.get(path)
+    return raw.get(path, client=client)
 
 
-def set_time_spent(task, person, date, duration):
+def set_time_spent(task, person, date, duration, client=default):
     """
     Set the time spent by a CG artist on a given task at a given date. Durations
     must be set in seconds. Date format is YYYY-MM-DD.
@@ -564,10 +594,10 @@ def set_time_spent(task, person, date, duration):
         date,
         person["id"],
     )
-    return client.post(path, {"duration": duration})
+    return raw.post(path, {"duration": duration}, client=client)
 
 
-def add_time_spent(task, person, date, duration):
+def add_time_spent(task, person, date, duration, client=default):
     """
     Add given duration to the already logged duration for given task and person
     at a given date. Durations must be set in seconds. Date format is
@@ -589,7 +619,7 @@ def add_time_spent(task, person, date, duration):
         date,
         person["id"],
     )
-    return client.post(path, {"duration": duration})
+    return raw.post(path, {"duration": duration}, client=client)
 
 
 def add_comment(
@@ -598,7 +628,8 @@ def add_comment(
     comment="",
     person=None,
     attachments=[],
-    created_at=None
+    created_at=None,
+    client=default
 ):
     """
     Add comment to given task. Each comment requires a task_status. Since the
@@ -627,19 +658,24 @@ def add_comment(
         data["created_at"] = created_at
 
     if len(attachments) == 0:
-        return client.post("actions/tasks/%s/comment" % task["id"], data)
+        return raw.post(
+            "actions/tasks/%s/comment" % task["id"],
+            data,
+            client=client
+        )
 
     else:
         attachment = attachments.pop()
-        return client.upload(
+        return raw.upload(
             "actions/tasks/%s/comment" % task["id"],
             attachment,
             data=data,
-            extra_files=attachments
+            extra_files=attachments,
+            client=client
         )
 
 
-def remove_comment(comment):
+def remove_comment(comment, client=default):
     """
     Remove given comment and related (previews, news, notifications) from
     database.
@@ -648,10 +684,10 @@ def remove_comment(comment):
         comment (str / dict): The comment dict or the comment ID.
     """
     comment = normalize_model_parameter(comment)
-    return client.delete("data/comments/%s" % comment["id"])
+    return raw.delete("data/comments/%s" % comment["id"], client=client)
 
 
-def create_preview(task, comment):
+def create_preview(task, comment, client=default):
     """
     Create a preview into given comment.
 
@@ -668,10 +704,10 @@ def create_preview(task, comment):
         task["id"],
         comment["id"],
     )
-    return client.post(path, {})
+    return raw.post(path, {}, client=client)
 
 
-def upload_preview_file(preview, file_path):
+def upload_preview_file(preview, file_path, client=default):
     """
     Create a preview into given comment.
 
@@ -680,10 +716,10 @@ def upload_preview_file(preview, file_path):
         file_path (str): Path of the file to upload as preview.
     """
     path = "pictures/preview-files/%s" % preview["id"]
-    client.upload(path, file_path)
+    raw.upload(path, file_path, client=client)
 
 
-def add_preview(task, comment, preview_file_path):
+def add_preview(task, comment, preview_file_path, client=default):
     """
     Add a preview to given comment.
 
@@ -696,11 +732,11 @@ def add_preview(task, comment, preview_file_path):
         dict: Created preview file model.
     """
     preview_file = create_preview(task, comment)
-    upload_preview_file(preview_file, preview_file_path)
+    upload_preview_file(preview_file, preview_file_path, client=client)
     return preview_file
 
 
-def set_main_preview(preview_file):
+def set_main_preview(preview_file, client=default):
     """
     Set given preview as thumbnail of given entity.
 
@@ -712,11 +748,11 @@ def set_main_preview(preview_file):
     """
     preview_file = normalize_model_parameter(preview_file)
     path = "actions/preview-files/%s/set-main-preview" % preview_file["id"]
-    return client.put(path, {})
+    return raw.put(path, {}, client=client)
 
 
 @cache
-def all_comments_for_task(task):
+def all_comments_for_task(task, client=default):
     """
     Args:
         task (str / dict): The task dict or the task ID.
@@ -725,11 +761,11 @@ def all_comments_for_task(task):
         Comments linked to the given task.
     """
     task = normalize_model_parameter(task)
-    return client.fetch_all("tasks/%s/comments" % task["id"])
+    return raw.fetch_all("tasks/%s/comments" % task["id"], client=client)
 
 
 @cache
-def get_last_comment_for_task(task):
+def get_last_comment_for_task(task, client=default):
     """
     Args:
         task (str / dict): The task dict or the task ID.
@@ -738,11 +774,11 @@ def get_last_comment_for_task(task):
         Last comment posted for given task.
     """
     task = normalize_model_parameter(task)
-    return client.fetch_first("tasks/%s/comments" % task["id"])
+    return raw.fetch_first("tasks/%s/comments" % task["id"], client=client)
 
 
 @cache
-def assign_task(task, person):
+def assign_task(task, person, client=default):
     """
     Assign one Person to a Task.
     Args:
@@ -754,11 +790,11 @@ def assign_task(task, person):
     """
     person = normalize_model_parameter(person)
     task = normalize_model_parameter(task)
-    route = "/actions/persons/%s/assign" % person["id"]
-    return client.put(route, {"task_ids": task["id"]})
+    path = "/actions/persons/%s/assign" % person["id"]
+    return raw.put(path, {"task_ids": task["id"]}, client=client)
 
 
-def new_task_type(name):
+def new_task_type(name, client=default):
     """
     Create a new task type with the given name.
 
@@ -769,10 +805,10 @@ def new_task_type(name):
         dict: The created task type
     """
     data = {"name": name}
-    return client.post("data/task-types", data)
+    return raw.post("data/task-types", data, client=client)
 
 
-def new_task_status(name, short_name, color):
+def new_task_status(name, short_name, color, client=default):
     """
     Create a new task status with the given name, short name and color.
 
@@ -789,10 +825,10 @@ def new_task_status(name, short_name, color):
     assert all(c in string.hexdigits for c in color[1:])
 
     data = {"name": name, "short_name": short_name, "color": color}
-    return client.post("data/task-status", data)
+    return raw.post("data/task-status", data, client=client)
 
 
-def update_task(task):
+def update_task(task, client=default):
     """
     Save given task data into the API. Metadata are fully replaced by the ones
     set on given task.
@@ -803,10 +839,10 @@ def update_task(task):
     Returns:
         dict: Updated task.
     """
-    return client.put("data/tasks/%s" % task["id"], task)
+    return raw.put("data/tasks/%s" % task["id"], task, client=client)
 
 
-def update_task_data(task, data={}):
+def update_task_data(task, data={}, client=default):
     """
     Update the metadata for the provided task. Keys that are not provided are
     not changed.
@@ -819,17 +855,17 @@ def update_task_data(task, data={}):
         dict: Updated task.
     """
     task = normalize_model_parameter(task)
-    current_task = get_task(task["id"])
+    current_task = get_task(task["id"], client=client)
 
     updated_task = {"id": current_task["id"], "data": current_task["data"]}
     if updated_task["data"] is None:
         updated_task["data"] = {}
     updated_task["data"].update(data)
-    update_task(updated_task)
+    update_task(updated_task, client=client)
 
 
 @cache
-def get_task_url(task):
+def get_task_url(task, client=default):
     """
     Args:
         task (str / dict): The task dict or the task ID.
@@ -840,7 +876,7 @@ def get_task_url(task):
     task = normalize_model_parameter(task)
     path = "{host}/productions/{project_id}/shots/tasks/{task_id}/"
     return path.format(
-        host=client.get_zou_url_from_host(),
+        host=raw.get_api_url_from_host(client=client),
         project_id=task["project_id"],
         task_id=task["id"],
     )

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -880,3 +880,16 @@ def get_task_url(task, client=default):
         project_id=task["project_id"],
         task_id=task["id"],
     )
+
+
+def all_tasks_for_project(project, client=default):
+    """
+    Args:
+        project (str / dict): The project
+
+    Returns:
+        dict: Tasks related to given project.
+    """
+    project = normalize_model_parameter(project)
+    path = "/data/projects/%s/tasks" % project["id"]
+    return raw.get(path, client=client)

--- a/gazu/user.py
+++ b/gazu/user.py
@@ -1,25 +1,27 @@
 import datetime
 
-from . import client
+from . import client as raw
 from .sorting import sort_by_name
 from .helpers import normalize_model_parameter
 
 from .cache import cache
 
+default = raw.default_client
+
 
 @cache
-def all_open_projects():
+def all_open_projects(client=default):
     """
     Returns:
         list: Projects for which the user is part of the team. Admins see all
         projects
     """
-    projects = client.fetch_all("user/projects/open")
+    projects = raw.fetch_all("user/projects/open", client=client)
     return sort_by_name(projects)
 
 
 @cache
-def all_asset_types_for_project(project):
+def all_asset_types_for_project(project, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -30,12 +32,12 @@ def all_asset_types_for_project(project):
     """
     project = normalize_model_parameter(project)
     path = "user/projects/%s/asset-types" % project["id"]
-    asset_types = client.fetch_all(path)
+    asset_types = raw.fetch_all(path, client=client)
     return sort_by_name(asset_types)
 
 
 @cache
-def all_assets_for_asset_type_and_project(project, asset_type):
+def all_assets_for_asset_type_and_project(project, asset_type, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -51,12 +53,12 @@ def all_assets_for_asset_type_and_project(project, asset_type):
         project["id"],
         asset_type["id"],
     )
-    assets = client.fetch_all(path)
+    assets = raw.fetch_all(path, client=client)
     return sort_by_name(assets)
 
 
 @cache
-def all_tasks_for_asset(asset):
+def all_tasks_for_asset(asset, client=default):
     """
     Args:
         asset (str / dict): The asset dict or the asset ID.
@@ -66,12 +68,12 @@ def all_tasks_for_asset(asset):
     """
     asset = normalize_model_parameter(asset)
     path = "user/assets/%s/tasks" % asset["id"]
-    tasks = client.fetch_all(path)
+    tasks = raw.fetch_all(path, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_shot(shot):
+def all_tasks_for_shot(shot, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
@@ -81,12 +83,12 @@ def all_tasks_for_shot(shot):
     """
     shot = normalize_model_parameter(shot)
     path = "user/shots/%s/tasks" % shot["id"]
-    tasks = client.fetch_all(path)
+    tasks = raw.fetch_all(path, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_scene(scene):
+def all_tasks_for_scene(scene, client=default):
     """
     Args:
         scene (str / dict): The scene dict or the scene ID.
@@ -96,23 +98,23 @@ def all_tasks_for_scene(scene):
     """
     scene = normalize_model_parameter(scene)
     path = "user/scene/%s/tasks" % scene["id"]
-    tasks = client.fetch_all(path)
+    tasks = raw.fetch_all(path, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_tasks_for_sequence(sequence):
+def all_tasks_for_sequence(sequence, client=default):
     """
     Return the list of tasks for given asset and current user.
     """
     sequence = normalize_model_parameter(sequence)
     path = "user/sequences/%s/tasks" % sequence["id"]
-    tasks = client.fetch_all(path)
+    tasks = raw.fetch_all(path, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_task_types_for_asset(asset):
+def all_task_types_for_asset(asset, client=default):
     """
     Args:
         asset (str / dict): The asset dict or the asset ID.
@@ -122,12 +124,12 @@ def all_task_types_for_asset(asset):
     """
     asset = normalize_model_parameter(asset)
     path = "user/assets/%s/task-types" % asset["id"]
-    tasks = client.fetch_all(path)
+    tasks = raw.fetch_all(path, client=client)
     return sort_by_name(tasks)
 
 
 @cache
-def all_task_types_for_shot(shot):
+def all_task_types_for_shot(shot, client=default):
     """
     Args:
         shot (str / dict): The shot dict or the shot ID.
@@ -137,12 +139,12 @@ def all_task_types_for_shot(shot):
     """
     shot = normalize_model_parameter(shot)
     path = "user/shots/%s/task-types" % shot["id"]
-    task_types = client.fetch_all(path)
+    task_types = raw.fetch_all(path, client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_task_types_for_scene(scene):
+def all_task_types_for_scene(scene, client=default):
     """
     Args:
         scene (str / dict): The scene dict or the scene ID.
@@ -152,23 +154,23 @@ def all_task_types_for_scene(scene):
     """
     scene = normalize_model_parameter(scene)
     path = "user/scenes/%s/task-types" % scene["id"]
-    task_types = client.fetch_all(path)
+    task_types = raw.fetch_all(path, client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_task_types_for_sequence(sequence):
+def all_task_types_for_sequence(sequence, client=default):
     """
     return the list of task_tyes for given asset and current user.
     """
     sequence = normalize_model_parameter(sequence)
     path = "user/sequences/%s/task-types" % sequence["id"]
-    task_types = client.fetch_all(path)
+    task_types = raw.fetch_all(path, client=client)
     return sort_by_name(task_types)
 
 
 @cache
-def all_sequences_for_project(project):
+def all_sequences_for_project(project, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -178,12 +180,12 @@ def all_sequences_for_project(project):
     """
     project = normalize_model_parameter(project)
     path = "user/projects/%s/sequences" % project["id"]
-    sequences = client.fetch_all(path)
+    sequences = raw.fetch_all(path, client=client)
     return sort_by_name(sequences)
 
 
 @cache
-def all_episodes_for_project(project):
+def all_episodes_for_project(project, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -192,12 +194,12 @@ def all_episodes_for_project(project):
         list: Episodes for which user has tasks assigned for given project.
     """
     path = "user/projects/%s/episodes" % project["id"]
-    asset_types = client.fetch_all(path)
+    asset_types = raw.fetch_all(path, client=client)
     return sort_by_name(asset_types)
 
 
 @cache
-def all_shots_for_sequence(sequence):
+def all_shots_for_sequence(sequence, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -207,12 +209,12 @@ def all_shots_for_sequence(sequence):
     """
     sequence = normalize_model_parameter(sequence)
     path = "user/sequences/%s/shots" % sequence["id"]
-    shots = client.fetch_all(path)
+    shots = raw.fetch_all(path, client=client)
     return sort_by_name(shots)
 
 
 @cache
-def all_scenes_for_sequence(sequence):
+def all_scenes_for_sequence(sequence, client=default):
     """
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
@@ -222,20 +224,20 @@ def all_scenes_for_sequence(sequence):
     """
     sequence = normalize_model_parameter(sequence)
     path = "user/sequences/%s/scenes" % sequence["id"]
-    scenes = client.fetch_all(path)
+    scenes = raw.fetch_all(path, client=client)
     return sort_by_name(scenes)
 
 
 @cache
-def all_tasks_to_do():
+def all_tasks_to_do(client=default):
     """
     Returns:
         list: Tasks assigned to current user which are not complete.
     """
-    return client.fetch_all("user/tasks")
+    return raw.fetch_all("user/tasks", client=client)
 
 
-def log_desktop_session_log_in():
+def log_desktop_session_log_in(client=default):
     """
     Add a log entry to mention that the user logged in his computer.
 
@@ -244,4 +246,4 @@ def log_desktop_session_log_in():
     """
     path = "/data/user/desktop-login-logs"
     data = {"date": datetime.datetime.now().isoformat()}
-    return client.post(path, data)
+    return raw.post(path, data, client=client)

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -115,3 +115,12 @@ class CastingTestCase(unittest.TestCase):
             asset = {"id": fakeid("asset-01")}
             casting = gazu.casting.get_asset_cast_in(asset)
             self.assertEqual(casting[0]["id"], fakeid("shot-1"))
+
+    def test_all_entity_links_for_project(self):
+        links = [{"id": fakeid("link-1")}]
+        path = "data/projects/%s/entity-links" % fakeid("project-01")
+        with requests_mock.mock() as mock:
+            mock.get(gazu.client.get_full_url(path), text=json.dumps(links))
+            project = {"id": fakeid("project-01")}
+            links = gazu.casting.all_entity_links_for_project(project)
+            self.assertEqual(links[0]["id"], fakeid("link-1"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ import unittest
 import requests_mock
 import gazu
 
-from gazu import client
+from gazu import client as raw
 from gazu.exception import (
     RouteNotFoundException,
     AuthFailedException,
@@ -29,16 +29,16 @@ class ClientTestCase(unittest.TestCase):
 class BaseFuncTestCase(ClientTestCase):
     def test_host_is_up(self):
         with requests_mock.mock() as mock:
-            mock.head(client.get_host())
-            self.assertTrue(client.host_is_up())
+            mock.head(raw.get_host())
+            self.assertTrue(raw.host_is_up())
 
     def test_get_host(self):
-        self.assertEqual(client.get_host(), client.HOST)
+        self.assertEqual(raw.get_host(), raw.default_client.host)
 
     def test_set_host(self):
-        client.set_host("newhost")
-        self.assertEqual(client.get_host(), "newhost")
-        client.set_host("http://gazu-server/")
+        raw.set_host("newhost")
+        self.assertEqual(raw.get_host(), "newhost")
+        raw.set_host("http://gazu-server/")
 
     def test_set_tokens(self):
         pass
@@ -47,36 +47,62 @@ class BaseFuncTestCase(ClientTestCase):
         pass
 
     def test_url_path_join(self):
-        root = client.get_host()
+        root = raw.get_host()
         items = ["data", "persons"]
-        expected_url = "{host}data/persons".format(host=client.get_host())
+        expected_url = "{host}data/persons".format(host=raw.get_host())
 
-        self.assertEqual(client.url_path_join(root, *items), expected_url)
+        self.assertEqual(raw.url_path_join(root, *items), expected_url)
 
     def test_get_full_url(self):
         test_route = "test_route"
-        expected_url = client.url_path_join(client.get_host(), test_route)
+        expected_url = raw.url_path_join(raw.get_host(), test_route)
 
-        self.assertEqual(client.get_full_url(test_route), expected_url)
+        self.assertEqual(raw.get_full_url(test_route), expected_url)
 
     def test_get(self):
         with requests_mock.mock() as mock:
             mock.get(
-                client.get_full_url("data/persons"),
+                raw.get_full_url("data/persons"),
                 text='{"first_name": "John"}',
             )
             self.assertEqual(
-                client.get("data/persons"), {"first_name": "John"}
+                raw.get("data/persons"), {"first_name": "John"}
             )
+
+    def test_get_two_clients(self):
+        with requests_mock.mock() as mock:
+            second_client = gazu.raw.create_client("http://second.host/api")
+            mock.get(
+                raw.get_full_url("data/persons"),
+                text='{"first_name": "John"}',
+            )
+            self.assertEqual(
+                raw.get("data/persons"), {"first_name": "John"}
+            )
+            self.assertRaises(
+                requests_mock.exceptions.NoMockAddress,
+                raw.get,
+                "data/persons",
+                client=second_client
+            )
+            mock.get(
+                raw.get_full_url("data/persons", client=second_client),
+                text='{"first_name": "John2"}',
+            )
+            self.assertEqual(
+                raw.get("data/persons", client=second_client),
+                {"first_name": "John2"},
+            )
+
 
     def test_post(self):
         with requests_mock.mock() as mock:
             mock.post(
-                client.get_full_url("data/persons"),
+                raw.get_full_url("data/persons"),
                 text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.post("data/persons", "person-01"),
+                raw.post("data/persons", "person-01"),
                 {"id": "person-01", "first_name": "John"},
             )
 
@@ -84,108 +110,108 @@ class BaseFuncTestCase(ClientTestCase):
         now = datetime.datetime.now()
         with requests_mock.mock() as mock:
             mock.post(
-                client.get_full_url("data/persons"),
+                raw.get_full_url("data/persons"),
                 text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.post("data/persons", {"birth_date": now}),
+                raw.post("data/persons", {"birth_date": now}),
                 {"id": "person-01", "first_name": "John"},
             )
 
     def test_put(self):
         with requests_mock.mock() as mock:
             mock.put(
-                client.get_full_url("data/persons"),
+                raw.get_full_url("data/persons"),
                 text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.put("data/persons", "person-01"),
+                raw.put("data/persons", "person-01"),
                 {"id": "person-01", "first_name": "John"},
             )
 
     def test_delete(self):
         with requests_mock.mock() as mock:
-            mock.delete(client.get_full_url("data/persons/person-01"), text="")
-            self.assertEqual(client.delete("data/persons/person-01"), "")
+            mock.delete(raw.get_full_url("data/persons/person-01"), text="")
+            self.assertEqual(raw.delete("data/persons/person-01"), "")
 
     def test_fetch_all(self):
         with requests_mock.mock() as mock:
             mock.get(
-                client.get_full_url("data/persons"),
+                raw.get_full_url("data/persons"),
                 text='[{"first_name": "John"}]',
             )
             self.assertEqual(
-                client.fetch_all("persons"), [{"first_name": "John"}]
+                raw.fetch_all("persons"), [{"first_name": "John"}]
             )
 
     def test_fetch_first(self):
         with requests_mock.mock() as mock:
             mock.get(
-                client.get_full_url("data/persons"),
+                raw.get_full_url("data/persons"),
                 text=json.dumps(
                     [{"first_name": "John"}, {"first_name": "Jane"}]
                 ),
             )
             self.assertEqual(
-                client.fetch_first("persons"), {"first_name": "John"}
+                raw.fetch_first("persons"), {"first_name": "John"}
             )
 
-            mock.get(client.get_full_url("data/persons"), text=json.dumps([]))
-            self.assertIsNone(client.fetch_first("persons"))
+            mock.get(raw.get_full_url("data/persons"), text=json.dumps([]))
+            self.assertIsNone(raw.fetch_first("persons"))
 
     def test_query_string(self):
         with requests_mock.mock() as mock:
             mock.get(
-                client.get_full_url("data/projects?name=Test"),
+                raw.get_full_url("data/projects?name=Test"),
                 text=json.dumps([{"name": "Project"}]),
             )
             self.assertEqual(
-                client.fetch_first("projects", {"name": "Test"}),
+                raw.fetch_first("projects", {"name": "Test"}),
                 {"name": "Project"},
             )
 
-            mock.get(client.get_full_url("data/persons"), text=json.dumps([]))
-            self.assertIsNone(client.fetch_first("persons"))
+            mock.get(raw.get_full_url("data/persons"), text=json.dumps([]))
+            self.assertIsNone(raw.fetch_first("persons"))
 
     def test_fetch_one(self):
         with requests_mock.mock() as mock:
             mock.get(
-                client.get_full_url("data/persons/person-01"),
+                raw.get_full_url("data/persons/person-01"),
                 text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.fetch_one("persons", "person-01"),
+                raw.fetch_one("persons", "person-01"),
                 {"id": "person-01", "first_name": "John"},
             )
 
     def test_create(self):
         with requests_mock.mock() as mock:
             mock.post(
-                client.get_full_url("data/persons"),
+                raw.get_full_url("data/persons"),
                 text='{"id": "person-01", "first_name": "John"}',
             )
             self.assertEqual(
-                client.create("persons", {"first_name": "John"}),
+                raw.create("persons", {"first_name": "John"}),
                 {"id": "person-01", "first_name": "John"},
             )
 
     def test_version(self):
         with requests_mock.mock() as mock:
-            mock.get(client.get_host(), text='{"version": "0.2.0"}')
-            self.assertEqual(client.get_api_version(), "0.2.0")
+            mock.get(raw.get_host(), text='{"version": "0.2.0"}')
+            self.assertEqual(raw.get_api_version(), "0.2.0")
 
     def test_make_auth_token(self):
         tokens = {"access_token": "token_test"}
-        client.set_tokens(tokens)
+        raw.set_tokens(tokens)
         self.assertEqual(
-            client.make_auth_header(), {"Authorization": "Bearer token_test"}
+            raw.make_auth_header(), {"Authorization": "Bearer token_test"}
         )
 
     def test_upload(self):
         with open("./tests/fixtures/v1.png", "rb") as test_file:
             with requests_mock.Mocker() as mock:
                 mock.post(
-                    client.get_full_url("data/new-file"),
+                    raw.get_full_url("data/new-file"),
                     text='{"id": "person-01", "first_name": "John"}',
                 )
 
@@ -203,7 +229,7 @@ class BaseFuncTestCase(ClientTestCase):
                     return None
                 mock.post("data/new-file", json={})
                 mock.add_matcher(verify_file_callback)
-                client.upload("data/new-file", "./tests/fixtures/v1.png", data={
+                raw.upload("data/new-file", "./tests/fixtures/v1.png", data={
                     "test": True
                 })
 
@@ -211,7 +237,7 @@ class BaseFuncTestCase(ClientTestCase):
         with open("./tests/fixtures/v1.png", "rb") as test_file:
             with requests_mock.Mocker() as mock:
                 mock.post(
-                    client.get_full_url("data/new-file"),
+                    raw.get_full_url("data/new-file"),
                     text='{"id": "person-01", "first_name": "John"}',
                 )
 
@@ -231,7 +257,7 @@ class BaseFuncTestCase(ClientTestCase):
                     return None
                 mock.post("data/new-file", json={})
                 mock.add_matcher(verify_file_callback)
-                client.upload(
+                raw.upload(
                     "data/new-file",
                     "./tests/fixtures/v1.png",
                     data={
@@ -246,39 +272,41 @@ class BaseFuncTestCase(ClientTestCase):
                 self.status_code = status_code
 
         self.assertRaises(
-            NotAuthenticatedException, client.check_status, Request(401), "/"
+            NotAuthenticatedException, raw.check_status, Request(401), "/"
         )
         self.assertRaises(
-            NotAllowedException, client.check_status, Request(403), "/"
+            NotAllowedException, raw.check_status, Request(403), "/"
         )
         self.assertRaises(
-            RouteNotFoundException, client.check_status, Request(404), "/"
+            RouteNotFoundException, raw.check_status, Request(404), "/"
         )
         self.assertRaises(
-            MethodNotAllowedException, client.check_status, Request(405), "/"
+            MethodNotAllowedException, raw.check_status, Request(405), "/"
         )
 
     def test_init_host(self):
         gazu.set_host("newhost")
         self.assertEqual(gazu.get_host(), "newhost")
         gazu.set_host("http://gazu-server/")
-        self.assertEqual(gazu.get_host(), gazu.client.HOST)
+        self.assertEqual(gazu.get_host(), gazu.raw.default_client.host)
 
     def test_init_log_in(self):
         with requests_mock.mock() as mock:
             mock.post(
-                client.get_full_url("auth/login"),
+                raw.get_full_url("auth/login"),
                 text=json.dumps(
                     {"login": True, "tokens": {"access_token": "tokentest"}}
                 ),
             )
             gazu.log_in("frank", "test")
-        self.assertEqual(client.tokens["tokens"]["access_token"], "tokentest")
+        self.assertEqual(
+            raw.default_client.tokens["tokens"]["access_token"], "tokentest"
+        )
 
     def test_init_log_in_fail(self):
         with requests_mock.mock() as mock:
             mock.post(
-                client.get_full_url("auth/login"),
+                raw.get_full_url("auth/login"),
                 text=json.dumps({"login": False}),
             )
             self.assertRaises(
@@ -288,8 +316,8 @@ class BaseFuncTestCase(ClientTestCase):
     def test_get_current_user(self):
         with requests_mock.mock() as mock:
             mock.get(
-                client.get_full_url("auth/authenticated"),
+                raw.get_full_url("auth/authenticated"),
                 text=json.dumps({"user": {"id": "123"}}),
             )
-            current_user = client.get_current_user()
+            current_user = raw.get_current_user()
             self.assertEqual(current_user["id"], "123")

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -363,7 +363,6 @@ class TaskTestCase(unittest.TestCase):
             comment = {"id": "comment-01"}
             gazu.task.remove_comment(comment)
 
-
     def test_comments_for_task(self):
         with requests_mock.mock() as mock:
             result = [{"id": "comment-1"}]
@@ -420,7 +419,6 @@ class TaskTestCase(unittest.TestCase):
                 gazu.task.new_task_status(name, short_name, color), status
             )
 
-
     def test_set_main_preview(self):
         with requests_mock.mock() as mock:
             result = {
@@ -437,3 +435,12 @@ class TaskTestCase(unittest.TestCase):
             self.assertEqual(
                 gazu.task.set_main_preview(preview_file), result
             )
+
+    def test_all_tasks_for_project(self):
+        tasks = [{"id": fakeid("task-1")}]
+        path = "data/projects/%s/tasks" % fakeid("project-01")
+        with requests_mock.mock() as mock:
+            mock.get(gazu.client.get_full_url(path), text=json.dumps(tasks))
+            project = {"id": fakeid("project-01")}
+            tasks = gazu.task.all_tasks_for_project(project)
+            self.assertEqual(tasks[0]["id"], fakeid("task-1"))


### PR DESCRIPTION
**Problem**

* It is not possible to manage two hosts easily with Gazu. It makes things complicated when dealing with synchronisation.
* Some utilities would be nice to perform synchronizations.

**Solution**

* Add a client option to all functions. It allows us to instantiate a Kitsu client and pass it to functions call where targeting another host is needed. 
* A default client is given to all functions to not bring any breaking changes to Gazu.
* Add a function to create clients.
* Add functions to import data.
* Add functions to retrieve in a single request all tasks or links for a given project.
* Add diff functions to quickly build differential between two model lists.