### PR TITLE
patch missing client keyword argument

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -100,7 +100,7 @@ def get_output_file(output_file_id, client=default):
         dict: Output file matching given ID.
     """
     path = "data/output-files/%s" % (output_file_id)
-    return raw.get(path)
+    return raw.get(path, client=client)
 
 
 @cache
@@ -978,7 +978,7 @@ def update_output_file(output_file, data, client=default):
     """
     output_file = normalize_model_parameter(output_file)
     path = "/data/output-files/%s" % output_file["id"]
-    return raw.put(path, data, client)
+    return raw.put(path, data, client=client)
 
 
 def set_project_file_tree(project, file_tree_name, client=default):

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -104,7 +104,7 @@ def get_episode(episode_id, client=default):
     Returns:
         dict: Episode corresponding to given episode ID.
     """
-    return raw.fetch_one("episodes", episode_id)
+    return raw.fetch_one("episodes", episode_id, client=client)
 
 
 @cache


### PR DESCRIPTION
using KitsuClient to call some gazu functions don't work.
the client is not used by the subcall.

patch:
gazu.files.get_output_file       => missing client kwargs calling raw.get
gazu.files.update_output_file => raw.put use client as arg (not kwarg)
gazu.shot.get_episode           => missing client kwargs calling raw.get

**Problem**
using a KitsuClient to call some functions don't work
=> issue discovered calling get_episode(episode_id, client=myKitsuClient)

**Solution**
=> make sure to pass the client to the subcall (raw.get, put, fetch_...)
