### PR TITLE
Url functions fixes

### DIFF
--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -140,11 +140,22 @@ def get_asset_url(asset, client=default):
         url (str): Web url associated to the given asset
     """
     asset = normalize_model_parameter(asset)
-    path = "{host}/productions/{project_id}/assets/{asset_id}/"
+    asset = get_asset(asset["id"])
+    project = gazu_project.get_project(asset["project_id"])
+    episode_id = "main"
+    path = "{host}/productions/{project_id}/"
+    if project["production_type"] != "tvshow":
+        path += "assets/{asset_id}/"
+    else:
+        path += "episodes/{episode_id}/assets/{asset_id}/"
+        if len(asset["episode_id"]) > 0:
+            episode_id = asset["episode_id"]
+
     return path.format(
         host=raw.get_api_url_from_host(),
         project_id=asset["project_id"],
         asset_id=asset["id"],
+        episode_id=episode_id,
         client=client
     )
 

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -177,5 +177,4 @@ def close_project(project, client=default):
 
     project["project_status_id"] = closed_status_id
     update_project(project, client=client)
-
     return project

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -36,6 +36,21 @@ def all_shots_for_project(project, client=default):
 
 
 @cache
+def all_shots_for_episode(episode, client=default):
+    """
+    Args:
+        episode (str / dict): The episode dict or the episode ID.
+
+    Returns:
+        list: Shots which are children of given episode.
+    """
+    episode = normalize_model_parameter(episode)
+    return sort_by_name(
+        raw.fetch_all("episodes/%s/shots" % episode["id"], client=client)
+    )
+
+
+@cache
 def all_shots_for_sequence(sequence, client=default):
     """
     Args:

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -230,6 +230,25 @@ def get_shot_by_name(sequence, shot_name, client=default):
 
 
 @cache
+def get_episode_url(episode, client=default):
+    """
+    Args:
+        episode (str / dict): The episode dict or the episode ID.
+
+    Returns:
+        url (str): Web url associated to the given episode
+    """
+    episode = normalize_model_parameter(episode)
+    episode = get_episode(episode["id"])
+    path = "{host}/productions/{project_id}/episodes/{episode_id}/shots"
+    return path.format(
+        host=raw.get_api_url_from_host(client=client),
+        project_id=episode["project_id"],
+        episode_id=episode["id"],
+    )
+
+
+@cache
 def get_shot_url(shot, client=default):
     """
     Args:

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -255,16 +255,21 @@ def get_shot_url(shot, client=default):
         shot (str / dict): The shot dict or the shot ID.
 
     Returns:
-        url (str, client=default): Web url associated to the given shot
+        url (str): Web url associated to the given shot
     """
     shot = normalize_model_parameter(shot)
-    path = "{host}/productions/{project_id}/shots/{shot_id}/"
+    shot = get_shot(shot["id"])
+    path = "{host}/productions/{project_id}/"
+    if shot["episode_id"] is None:
+        path += "shots/{shot_id}/"
+    else:
+        path += "episodes/{episode_id}/shots/{shot_id}/"
     return path.format(
         host=raw.get_api_url_from_host(client=client),
         project_id=shot["project_id"],
         shot_id=shot["id"],
+        episode_id=shot["episode_id"],
     )
-
 
 def new_sequence(project, name, episode=None, client=default):
     """

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -320,3 +320,31 @@ class CastingTestCase(unittest.TestCase):
                 asset, asset_to_instantiate
             )
             self.assertEqual(asset_instance, result)
+
+    def test_get_url(self):
+        with requests_mock.mock() as mock:
+            asset = {
+                "id": "asset-01",
+                "project_id": "project-01",
+                "episode_id": "episode-01"
+            }
+            project = {
+                "id": "project-01",
+                "production_type": "tvshow",
+            }
+            mock.get(
+                gazu.client.get_full_url(
+                    "data/projects/" + "project-01"
+                ),
+                text=json.dumps(project),
+            )
+            mock.get(
+                gazu.client.get_full_url("data/assets/" + fakeid("asset-01")),
+                text=json.dumps(asset),
+            )
+            url = gazu.asset.get_asset_url(fakeid("asset-01"))
+            self.assertEqual(
+                url,
+                "http://gazu.change.serverhost/productions/project-01/"
+                "episodes/episode-01/assets/asset-01/"
+            )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,7 +41,7 @@ class BaseFuncTestCase(ClientTestCase):
     def test_set_host(self):
         raw.set_host("newhost")
         self.assertEqual(raw.get_host(), "newhost")
-        raw.set_host("http://gazu-server/")
+        raw.set_host("http://gazu-server/api")
 
     def test_set_tokens(self):
         pass
@@ -52,7 +52,7 @@ class BaseFuncTestCase(ClientTestCase):
     def test_url_path_join(self):
         root = raw.get_host()
         items = ["data", "persons"]
-        expected_url = "{host}data/persons".format(host=raw.get_host())
+        expected_url = "{host}/data/persons".format(host=raw.get_host())
 
         self.assertEqual(raw.url_path_join(root, *items), expected_url)
 
@@ -200,7 +200,7 @@ class BaseFuncTestCase(ClientTestCase):
 
     def test_version(self):
         with requests_mock.mock() as mock:
-            mock.get(raw.get_host(), text='{"version": "0.2.0"}')
+            mock.get(raw.get_host() + "/", text='{"version": "0.2.0"}')
             self.assertEqual(raw.get_api_version(), "0.2.0")
 
     def test_make_auth_token(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -52,3 +52,10 @@ class ProjectTestCase(unittest.TestCase):
             )
             project = {"id": "project-01", "name": "S02"}
             gazu.project.remove_project(project)
+
+    def test_get_url(self):
+        url = gazu.project.get_project_url({"id": "project-01"})
+        self.assertEqual(
+            url,
+            "http://gazu-server/productions/project-01/assets/"
+        )

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -5,6 +5,8 @@ import requests_mock
 import gazu.client
 import gazu.shot
 
+from utils import fakeid
+
 
 class ShotTestCase(unittest.TestCase):
     def test_all_shots_for_project(self):
@@ -347,4 +349,32 @@ class ShotTestCase(unittest.TestCase):
             asset_instance = {"id": "asset-instance-1"}
             asset_instance = gazu.shot.remove_asset_instance_from_shot(
                 shot, asset_instance
+            )
+
+    def test_get_url(self):
+        with requests_mock.mock() as mock:
+            shot = {
+                "id": "shot-01",
+                "project_id": "project-01",
+                "episode_id": "episode-01"
+            }
+            project = {
+                "id": "project-01",
+                "production_type": "tvshow",
+            }
+            mock.get(
+                gazu.client.get_full_url(
+                    "data/projects/" + "project-01"
+                ),
+                text=json.dumps(project),
+            )
+            mock.get(
+                gazu.client.get_full_url("data/shots/" + fakeid("shot-01")),
+                text=json.dumps(shot),
+            )
+            url = gazu.shot.get_shot_url(fakeid("shot-01"))
+            self.assertEqual(
+                url,
+                "http://gazu.change.serverhost/productions/project-01/"
+                "episodes/episode-01/shots/shot-01/"
             )

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -42,6 +42,28 @@ class ShotTestCase(unittest.TestCase):
             self.assertEqual(shot_instance["project_id"], "project-01")
             self.assertEqual(shot_instance["parent_id"], "sequence-01")
 
+    def test_all_shots_for_episode(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url("data/episodes/episode-01/shots"),
+                text=json.dumps(
+                    [
+                        {
+                            "name": "Shot 01",
+                            "project_id": "project-01",
+                            "parent_id": "sequence-01",
+                        }
+                    ]
+                ),
+            )
+            episode = {"id": "episode-01"}
+            shots = gazu.shot.all_shots_for_episode(episode)
+            self.assertEqual(len(shots), 1)
+            shot_instance = shots[0]
+            self.assertEqual(shot_instance["name"], "Shot 01")
+            self.assertEqual(shot_instance["project_id"], "project-01")
+            self.assertEqual(shot_instance["parent_id"], "sequence-01")
+
     def test_all_sequences_for_project(self):
         with requests_mock.mock() as mock:
             mock.get(


### PR DESCRIPTION
**Problem**

* It's not possible to give a simple ID to `get_asset_url` and `get_shot_url` functions.
* TV series are not supported by `get_asset_url` and `get_shot_url` functions.
* `get_episode_url` function is missing

**Solution**

* Retrieve data from server to build a proper Kitsu url.
* Handle TV series case when building urls (add episode parameter).
* Add missing function.
