### PR TITLE
Change get_task_status to match other getters specs

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -377,20 +377,15 @@ def get_task_by_path(project, file_path, entity_type="shot", client=default):
 
 
 @cache
-def get_task_status(task, client=default):
+def get_task_status(task_status_id, client=default):
     """
     Args:
-        task (str / dict): The task dict or the task ID.
+        task_status_id (str): Id of claimed task status.
 
     Returns:
-        A task status object corresponding to status set on given task.
+        dict: Task status matching given ID.
     """
-    task = normalize_model_parameter(task)
-    return raw.fetch_first(
-        "task-status",
-        {"id": task["task_status_id"]},
-        client=client
-    )
+    return raw.fetch_one("task-status", task_status_id, client=client)
 
 
 @cache

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -174,9 +174,7 @@ class TaskTestCase(unittest.TestCase):
                 gazu.client.get_full_url(path),
                 text=json.dumps([{"name": "WIP", "id": "status-01"}]),
             )
-            status = gazu.task.get_task_status(
-                {"id": "task-01", "task_status_id": "status-01"}
-            )
+            status = gazu.task.get_task_status("status-01")
             self.assertEqual(status["id"], "status-01")
 
     def test_get_task(self):


### PR DESCRIPTION

⚠️ ⚠️ This PR breaks backward compatibility ⚠️ ⚠️ 

**Problem**

The method `get_task_status` is inconsistent with the other getters as it expects a `task` or `task_id`.

Not only this is inconsistent, but it also results in a huge performance bottleneck as it breaks the caching when you are getting statuses for a lot of tasks (see profiling screenshot below where `get_task_status` takes 90% of the execution time).

![image](https://user-images.githubusercontent.com/5718135/98362617-da1ec980-202d-11eb-8ad2-eeb3bf55f0e3.png)


**Solution**

Change the expected argument for  `get_task_status` (to have it work like, for instance,  `get_task_type`).

