### PR TITLE
Fix user rights issue when accessing assets from an episode

### DIFF
--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -52,7 +52,7 @@ def all_assets_for_episode(episode, client=default):
     episode = normalize_model_parameter(episode)
 
     return sort_by_name(
-        raw.fetch_all("assets", {"source_id": episode["id"]}, client=client)
+        raw.fetch_all("assets", {"source_id": episode["id"], "project_id": episode["project_id"]}, client=client)
     )
 
 


### PR DESCRIPTION

**Problem**
Calling `all_assets_for_episode` when logged in as a *Supervisor* (or *Artist*) will fail due to permission restrictions.

As `project_id` is not provided in the request arguments, user will need to have access to all projects for the request to succeed (will only work for studio managers).

**Solution**
Infer the project from the episode provided as an argument, and do a request limited to a given project, so that the rights required are properly evaluated by zou.

Notice that the proposed fix does not handle the situation where an episode ID is provided.