### PR TITLE
Fix output_type_id to software_id

### DIFF
--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -349,7 +349,7 @@ softwares = gazu.files.all_softwares()
 Retrieve given software:
 
 ```python
-software = gazu.files.get_software(output_type_id)
+software = gazu.files.get_software(software_id)
 software = gazu.files.get_software_by_name("Maya")
 ```
 


### PR DESCRIPTION
**Problem**
<!--- Explain the problem -->

In the documentation examples, when retrieving a software, it was : 

```python
software = gazu.files.get_software(output_type_id)
```

**Solution**
<!--- Describe the change, including rationale and design decisions -->

It should use the software id instead : 

```python
software = gazu.files.get_software(software_id)
```
