### PR TITLE
[qa] Add pre-commit-hook for black python code formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 21.8b0
+    hooks:
+    -   id: black

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: black
+  name: black
+  description: "Black: The uncompromising Python code formatter"
+  entry: black
+  language: python
+  minimum_pre_commit_version: 2.9.2
+  require_serial: true
+  types_or: [python, pyi]

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
    :alt: Gazu Logo
 
 
-Gazu, Python client for the Kitsu API 
+Gazu, Python client for the Kitsu API
 =====================================
 
 Gazu is a Python client that allows to fetch data easily from your animation
@@ -66,9 +66,9 @@ your Kitsu instance. They are listed below:
 * `Nagato <https://github.com/eaxum/nagato>`__: Publishing and file versioning
   for Blender.
 * `Bamboo <https://github.com/nervYu/Bamboo>`__: Pyside2 widgets to publish
-  previews to Kitsu. 
+  previews to Kitsu.
 * `Gazu Publisher <https://github.com/cgwire/gazu-publisher>`__: Our work in
-  progress publisher tool. 
+  progress publisher tool.
 
 
 Contributions
@@ -78,6 +78,14 @@ All contributions are welcome as long as they respect the `C4
 contract <https://rfc.zeromq.org/spec:42/C4>`__.
 
 Code must follow the pep8 convention.
+
+You can use the pre-commit hook for Black (a python code formatter) before commiting :
+
+.. code:: bash
+
+    pip install pre-commit
+    pre-commit install
+
 
 Contributors
 ------------

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
-pytest==4.6.11
-pytest-cov==2.10.0
-requests_mock==1.5.2
+pytest==6.2.5
+pytest-cov==2.12.1 
+requests_mock==1.9.3
+pre-commit==2.15.0


### PR DESCRIPTION
**Problem**
No pre-commit hook for black python code formatter

**Solution**
Add a pre-commit hook
To use it : 
`pip install pre-commit`
`pre-commit install`

