### PR TITLE
[qa] Black python code formater with line-length at 79

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -37,7 +37,9 @@ def log_in(email, password, client=raw.default_client):
     except ParameterException:
         pass
 
-    if not tokens or ("login" in tokens and tokens.get("login", False) == False):
+    if not tokens or (
+        "login" in tokens and tokens.get("login", False) == False
+    ):
         raise AuthFailedException
     else:
         raw.set_tokens(tokens, client=client)

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -466,5 +466,7 @@ def new_asset_asset_instance(
         "description": description,
     }
     return raw.post(
-        "data/assets/%s/asset-asset-instances" % asset["id"], data, client=client
+        "data/assets/%s/asset-asset-instances" % asset["id"],
+        data,
+        client=client,
     )

--- a/gazu/cache.py
+++ b/gazu/cache.py
@@ -195,7 +195,9 @@ def cache(function, maxsize=300, expire=120):
 
             else:
                 statistics["misses"] += 1
-                returned_value = insert_value(function, cache_store, args, kwargs)
+                returned_value = insert_value(
+                    function, cache_store, args, kwargs
+                )
                 remove_oldest_entry(cache_store, state["maxsize"])
                 return returned_value
 

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -188,7 +188,8 @@ def get(path, json_response=True, params=None, client=default_client):
     """
     path = build_path_with_params(path, params)
     response = client.session.get(
-        get_full_url(path, client=client), headers=make_auth_header(client=client)
+        get_full_url(path, client=client),
+        headers=make_auth_header(client=client),
     )
     check_status(response, path)
 
@@ -206,7 +207,9 @@ def post(path, data, client=default_client):
         The request result.
     """
     response = client.session.post(
-        get_full_url(path, client), json=data, headers=make_auth_header(client=client)
+        get_full_url(path, client),
+        json=data,
+        headers=make_auth_header(client=client),
     )
     check_status(response, path)
     return response.json()
@@ -220,7 +223,9 @@ def put(path, data, client=default_client):
         The request result.
     """
     response = client.session.put(
-        get_full_url(path, client), json=data, headers=make_auth_header(client=client)
+        get_full_url(path, client),
+        json=data,
+        headers=make_auth_header(client=client),
     )
     check_status(response, path)
     return response.json()
@@ -284,7 +289,9 @@ def check_status(request, path):
             stacktrace = request.json().get(
                 "stacktrace", "No stacktrace sent by the server"
             )
-            message = request.json().get("message", "No message sent by the server")
+            message = request.json().get(
+                "message", "No message sent by the server"
+            )
             print("A server error occured!\n")
             print("Server stacktrace:\n%s" % stacktrace)
             print("Error message:\n%s\n" % message)
@@ -362,7 +369,9 @@ def update(model_name, model_id, data, client=default_client):
     Returns:
         dict: Updated entry
     """
-    return put(url_path_join("data", model_name, model_id), data, client=client)
+    return put(
+        url_path_join("data", model_name, model_id), data, client=client
+    )
 
 
 def upload(path, file_path, data={}, extra_files=[], client=default_client):

--- a/gazu/context.py
+++ b/gazu/context.py
@@ -36,13 +36,17 @@ def all_asset_types_for_project(project, user_context=False):
         return gazu_asset.all_asset_types_for_project(project)
 
 
-def all_assets_for_asset_type_and_project(project, asset_type, user_context=False):
+def all_assets_for_asset_type_and_project(
+    project, asset_type, user_context=False
+):
     """
     Return the list of assets for given project and asset_type and for which
     the user has a task.
     """
     if user_context:
-        return gazu_user.all_assets_for_asset_type_and_project(project, asset_type)
+        return gazu_user.all_assets_for_asset_type_and_project(
+            project, asset_type
+        )
     else:
         return gazu_asset.all_assets_for_project_and_type(project, asset_type)
 

--- a/gazu/entity.py
+++ b/gazu/entity.py
@@ -71,7 +71,9 @@ def get_entity_type_by_name(entity_type_name, client=default):
     Returns:
         Retrieve entity type matching given name.
     """
-    return raw.fetch_first("entity-types", {"name": entity_type_name}, client=client)
+    return raw.fetch_first(
+        "entity-types", {"name": entity_type_name}, client=client
+    )
 
 
 def new_entity_type(name, client=default):

--- a/gazu/events.py
+++ b/gazu/events.py
@@ -14,7 +14,9 @@ def init(client=default_client, ssl_verify=True):
     from gazu.client import make_auth_header
 
     path = get_event_host(client)
-    event_client = SocketIO(path, None, headers=make_auth_header(), verify=ssl_verify)
+    event_client = SocketIO(
+        path, None, headers=make_auth_header(), verify=ssl_verify
+    )
     main_namespace = event_client.define(BaseNamespace, "/events")
     event_client.main_namespace = main_namespace
     event_client.on("error", connect_error)

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -25,7 +25,9 @@ def all_output_types_for_entity(entity, client=default):
         list: All output types linked to output files for given entity.
     """
     entity = normalize_model_parameter(entity)
-    return raw.fetch_all("entities/%s/output-types" % entity["id"], client=client)
+    return raw.fetch_all(
+        "entities/%s/output-types" % entity["id"], client=client
+    )
 
 
 @cache
@@ -64,7 +66,9 @@ def get_output_type_by_name(output_type_name, client=default):
     Returns:
         dict: Output type matching given name.
     """
-    return raw.fetch_first("output-types", {"name": output_type_name}, client=client)
+    return raw.fetch_first(
+        "output-types", {"name": output_type_name}, client=client
+    )
 
 
 def new_output_type(name, short_name, client=default):
@@ -112,7 +116,9 @@ def get_output_file_by_path(path, client=default):
 
 
 @cache
-def get_all_working_files_for_entity(entity, task=None, name=None, client=default):
+def get_all_working_files_for_entity(
+    entity, task=None, name=None, client=default
+):
     """
     Retrieves all the working files of a given entity and specied parameters
     """
@@ -150,7 +156,9 @@ def get_all_preview_files_for_task(task, client=default):
         task (str, id): Target task
     """
     task = normalize_model_parameter(task)
-    return raw.fetch_all("preview-files", {"task_id": task["id"]}, client=client)
+    return raw.fetch_all(
+        "preview-files", {"task_id": task["id"]}, client=client
+    )
 
 
 def all_output_files_for_entity(
@@ -508,7 +516,9 @@ def new_working_file(
     if software is not None:
         data["software_id"] = software["id"]
 
-    return raw.post("data/tasks/%s/working-files/new" % task["id"], data, client=client)
+    return raw.post(
+        "data/tasks/%s/working-files/new" % task["id"], data, client=client
+    )
 
 
 def new_entity_output_file(
@@ -957,7 +967,9 @@ def update_modification_date(working_file, client=default):
         dict: Modified working file
     """
     return raw.put(
-        "/actions/working-files/%s/modified" % working_file["id"], {}, client=client
+        "/actions/working-files/%s/modified" % working_file["id"],
+        {},
+        client=client,
     )
 
 
@@ -1037,10 +1049,14 @@ def download_working_file(working_file, file_path=None, client=default):
     """
     working_file = normalize_model_parameter(working_file)
     if file_path is None:
-        working_file = raw.fetch_one("working-files", working_file["id"], client=client)
+        working_file = raw.fetch_one(
+            "working-files", working_file["id"], client=client
+        )
         file_path = working_file["path"]
     return raw.download(
-        "data/working-files/%s/file" % (working_file["id"]), file_path, client=client
+        "data/working-files/%s/file" % (working_file["id"]),
+        file_path,
+        client=client,
     )
 
 
@@ -1053,7 +1069,9 @@ def download_preview_file(preview_file, file_path, client=default):
         file_path (str): Location on hard drive where to save the file.
     """
     preview_file = normalize_model_parameter(preview_file)
-    preview_file = raw.fetch_one("preview-files", preview_file["id"], client=client)
+    preview_file = raw.fetch_one(
+        "preview-files", preview_file["id"], client=client
+    )
     file_type = "movies" if preview_file["extension"] == "mp4" else "pictures"
     return raw.download(
         "%s/originals/preview-files/%s.%s"

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -46,7 +46,9 @@ def get_person_by_desktop_login(desktop_login, client=default):
     Returns:
         dict: Person corresponding to given desktop computer login.
     """
-    return raw.fetch_first("persons", {"desktop_login": desktop_login}, client=client)
+    return raw.fetch_first(
+        "persons", {"desktop_login": desktop_login}, client=client
+    )
 
 
 @cache
@@ -75,7 +77,9 @@ def get_person_by_full_name(full_name, client=default):
     else:
         first_name, last_name = full_name.lower().strip(), ""
     for person in all_persons():
-        is_right_first_name = first_name == person["first_name"].lower().strip()
+        is_right_first_name = (
+            first_name == person["first_name"].lower().strip()
+        )
         is_right_last_name = (
             len(last_name) == 0 or last_name == person["last_name"].lower()
         )
@@ -163,7 +167,9 @@ def set_avatar(person, file_path, client=default):
     """
     person = normalize_model_parameter(person)
     return raw.upload(
-        "/pictures/thumbnails/persons/%s" % person["id"], file_path, client=client
+        "/pictures/thumbnails/persons/%s" % person["id"],
+        file_path,
+        client=client,
     )
 
 

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -104,7 +104,12 @@ def get_playlist_by_name(project, name, client=default):
 
 
 def new_playlist(
-    project, name, episode=None, for_entity="shot", for_client=False, client=default
+    project,
+    name,
+    episode=None,
+    for_entity="shot",
+    for_client=False,
+    client=default,
 ):
     """
     Create a new playlist in the database for given project.
@@ -143,4 +148,6 @@ def update_playlist(playlist, client=default):
     Returns:
         dict: Updated playlist.
     """
-    return raw.put("data/playlists/%s" % playlist["id"], playlist, client=client)
+    return raw.put(
+        "data/playlists/%s" % playlist["id"], playlist, client=client
+    )

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -73,7 +73,9 @@ def get_project_url(project, section="assets", client=default):
     project = normalize_model_parameter(project)
     path = "{host}/productions/{project_id}/{section}/"
     return path.format(
-        host=raw.get_api_url_from_host(), project_id=project["id"], section=section
+        host=raw.get_api_url_from_host(),
+        project_id=project["id"],
+        section=section,
     )
 
 

--- a/gazu/scene.py
+++ b/gazu/scene.py
@@ -15,7 +15,9 @@ def new_scene(project, sequence, name, client=default):
     project = normalize_model_parameter(project)
     sequence = normalize_model_parameter(sequence)
     shot = {"name": name, "sequence_id": sequence["id"]}
-    return raw.post("data/projects/%s/scenes" % project["id"], shot, client=client)
+    return raw.post(
+        "data/projects/%s/scenes" % project["id"], shot, client=client
+    )
 
 
 @cache
@@ -25,7 +27,9 @@ def all_scenes(project=None, client=default):
     """
     project = normalize_model_parameter(project)
     if project is not None:
-        scenes = raw.fetch_all("projects/%s/scenes" % project["id"], client=client)
+        scenes = raw.fetch_all(
+            "projects/%s/scenes" % project["id"], client=client
+        )
     else:
         scenes = raw.fetch_all("scenes", client=client)
     return sort_by_name(scenes)
@@ -67,7 +71,9 @@ def get_scene_by_name(sequence, scene_name, client=default):
     """
     sequence = normalize_model_parameter(sequence)
     result = raw.fetch_all(
-        "scenes/all", {"parent_id": sequence["id"], "name": scene_name}, client=client
+        "scenes/all",
+        {"parent_id": sequence["id"], "name": scene_name},
+        client=client,
     )
     return next(iter(result or []), None)
 
@@ -87,7 +93,9 @@ def new_scene_asset_instance(scene, asset, description="", client=default):
     scene = normalize_model_parameter(scene)
     asset = normalize_model_parameter(asset)
     data = {"asset_id": asset["id"], "description": description}
-    return raw.post("data/scenes/%s/asset-instances" % scene["id"], data, client=client)
+    return raw.post(
+        "data/scenes/%s/asset-instances" % scene["id"], data, client=client
+    )
 
 
 @cache
@@ -96,7 +104,9 @@ def all_asset_instances_for_scene(scene, client=default):
     Return the list of asset instances listed in a scene.
     """
     scene = normalize_model_parameter(scene)
-    return raw.get("data/scenes/%s/asset-instances" % scene["id"], client=client)
+    return raw.get(
+        "data/scenes/%s/asset-instances" % scene["id"], client=client
+    )
 
 
 @cache
@@ -105,7 +115,9 @@ def get_asset_instance_by_name(scene, name, client=default):
     Returns the asset instance of the scene that has the given name.
     """
     return raw.fetch_first(
-        "asset-instances", {"name": name, "scene_id": scene["id"]}, client=client
+        "asset-instances",
+        {"name": name, "scene_id": scene["id"]},
+        client=client,
     )
 
 
@@ -115,7 +127,9 @@ def all_camera_instances_for_scene(scene, client=default):
     Return the list of camera instances listed in a scene.
     """
     scene = normalize_model_parameter(scene)
-    return raw.get("data/scenes/%s/camera-instances" % scene["id"], client=client)
+    return raw.get(
+        "data/scenes/%s/camera-instances" % scene["id"], client=client
+    )
 
 
 @cache

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -134,7 +134,9 @@ def get_episode_by_name(project, episode_name, client=default):
     """
     project = normalize_model_parameter(project)
     return raw.fetch_first(
-        "episodes", {"project_id": project["id"], "name": episode_name}, client=client
+        "episodes",
+        {"project_id": project["id"], "name": episode_name},
+        client=client,
     )
 
 
@@ -221,7 +223,9 @@ def get_shot_by_name(sequence, shot_name, client=default):
     """
     sequence = normalize_model_parameter(sequence)
     return raw.fetch_first(
-        "shots/all", {"sequence_id": sequence["id"], "name": shot_name}, client=client
+        "shots/all",
+        {"sequence_id": sequence["id"], "name": shot_name},
+        client=client,
     )
 
 
@@ -287,7 +291,9 @@ def new_sequence(project, name, episode=None, client=default):
         episode = normalize_model_parameter(episode)
         data["episode_id"] = episode["id"]
 
-    sequence = get_sequence_by_name(project, name, episode=episode, client=client)
+    sequence = get_sequence_by_name(
+        project, name, episode=episode, client=client
+    )
     if sequence is None:
         path = "data/projects/%s/sequences" % project["id"]
         return raw.post(path, data, client=client)
@@ -365,7 +371,9 @@ def update_sequence(sequence, client=default):
     Returns:
         dict: Updated sequence.
     """
-    return raw.put("data/entities/%s" % sequence["id"], sequence, client=client)
+    return raw.put(
+        "data/entities/%s" % sequence["id"], sequence, client=client
+    )
 
 
 @cache
@@ -414,7 +422,10 @@ def update_sequence_data(sequence, data={}, client=default):
     if not current_sequence.get("data"):
         current_sequence["data"] = {}
 
-    updated_sequence = {"id": current_sequence["id"], "data": current_sequence["data"]}
+    updated_sequence = {
+        "id": current_sequence["id"],
+        "data": current_sequence["data"],
+    }
     updated_sequence["data"].update(data)
     return update_sequence(updated_sequence, client)
 
@@ -497,7 +508,10 @@ def update_episode_data(episode, data={}, client=default):
     """
     episode = normalize_model_parameter(episode)
     current_episode = get_sequence(episode["id"], client=client)
-    updated_episode = {"id": current_episode["id"], "data": current_episode["data"]}
+    updated_episode = {
+        "id": current_episode["id"],
+        "data": current_episode["data"],
+    }
     updated_episode["data"].update(data)
     return update_episode(updated_episode, client=client)
 

--- a/gazu/sync.py
+++ b/gazu/sync.py
@@ -88,7 +88,9 @@ def get_model_list_diff(source_list, target_list):
     for model in source_list:
         if model["id"] not in target_ids:
             missing.append(model)
-    unexpected = [model for model in target_list if model["id"] not in source_ids]
+    unexpected = [
+        model for model in target_list if model["id"] not in source_ids
+    ]
     return (missing, unexpected)
 
 

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -37,7 +37,9 @@ def all_task_types_for_project(project, client=default):
         list: Task types stored in database.
     """
     project = normalize_model_parameter(project)
-    task_types = raw.fetch_all("projects/%s/task-types" % project["id"], client=client)
+    task_types = raw.fetch_all(
+        "projects/%s/task-types" % project["id"], client=client
+    )
     return sort_by_name(task_types)
 
 
@@ -226,7 +228,9 @@ def all_task_types_for_asset(asset, client=default):
         list: Task types of tasks related to given asset.
     """
     asset = normalize_model_parameter(asset)
-    task_types = raw.fetch_all("assets/%s/task-types" % asset["id"], client=client)
+    task_types = raw.fetch_all(
+        "assets/%s/task-types" % asset["id"], client=client
+    )
     return sort_by_name(task_types)
 
 
@@ -360,7 +364,9 @@ def get_task_type_by_name(task_type_name, client=default):
     Returns:
         dict: Task type object for given name.
     """
-    return raw.fetch_first("task-types", {"name": task_type_name}, client=client)
+    return raw.fetch_first(
+        "task-types", {"name": task_type_name}, client=client
+    )
 
 
 @cache
@@ -431,7 +437,9 @@ def remove_task_status(task_status, client=default):
     """
     task_status = normalize_model_parameter(task_status)
     return raw.delete(
-        "data/task-status/%s" % task_status["id"], {"force": "true"}, client=client
+        "data/task-status/%s" % task_status["id"],
+        {"force": "true"},
+        client=client,
     )
 
 
@@ -666,7 +674,9 @@ def add_comment(
         data["created_at"] = validate_date_format(created_at)
 
     if len(attachments) == 0:
-        return raw.post("actions/tasks/%s/comment" % task["id"], data, client=client)
+        return raw.post(
+            "actions/tasks/%s/comment" % task["id"], data, client=client
+        )
 
     else:
         attachment = attachments.pop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -61,7 +61,9 @@ class CastingTestCase(unittest.TestCase):
             )
             project = {"id": "project-01"}
             asset_type = {"id": "asset-type-01"}
-            assets = gazu.asset.all_assets_for_project_and_type(project, asset_type)
+            assets = gazu.asset.all_assets_for_project_and_type(
+                project, asset_type
+            )
             self.assertEqual(len(assets), 1)
             asset = assets[0]
             self.assertEqual(asset["name"], "Asset 01")
@@ -106,7 +108,9 @@ class CastingTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/assets/asset-01"),
-                text=json.dumps({"name": "Asset 01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"name": "Asset 01", "project_id": "project-01"}
+                ),
             )
             asset = gazu.asset.get_asset("asset-01")
             self.assertEqual(asset["name"], "Asset 01")
@@ -117,7 +121,9 @@ class CastingTestCase(unittest.TestCase):
                 gazu.client.get_full_url(
                     "data/assets/all?project_id=project-01&name=test"
                 ),
-                text=json.dumps([{"name": "Asset 01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Asset 01", "project_id": "project-01"}]
+                ),
             )
             project = {"id": "project-01"}
             asset = gazu.asset.get_asset_by_name(project, "test")
@@ -127,7 +133,9 @@ class CastingTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/asset-types/asset-type-01"),
-                text=json.dumps({"name": "Asset Type 01", "id": "asset-type-01"}),
+                text=json.dumps(
+                    {"name": "Asset Type 01", "id": "asset-type-01"}
+                ),
             )
             asset = gazu.asset.get_asset_type("asset-type-01")
             self.assertEqual(asset["name"], "Asset Type 01")
@@ -142,7 +150,8 @@ class CastingTestCase(unittest.TestCase):
             )
             mock.post(
                 gazu.client.get_full_url(
-                    "data/projects/project-id/asset-types/" "asset-type-id/assets/new"
+                    "data/projects/project-id/asset-types/"
+                    "asset-type-id/assets/new"
                 ),
                 text=json.dumps({"name": "Car"}),
             )
@@ -220,7 +229,9 @@ class CastingTestCase(unittest.TestCase):
     def test_all_shot_asset_instances_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/assets/asset-01/shot-asset-instances"),
+                gazu.client.get_full_url(
+                    "data/assets/asset-01/shot-asset-instances"
+                ),
                 text=json.dumps(
                     [
                         {
@@ -241,7 +252,9 @@ class CastingTestCase(unittest.TestCase):
     def test_get_scene_asset_instances_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/assets/asset-01/scene-asset-instances"),
+                gazu.client.get_full_url(
+                    "data/assets/asset-01/scene-asset-instances"
+                ),
                 text=json.dumps(
                     [
                         {
@@ -273,9 +286,9 @@ class CastingTestCase(unittest.TestCase):
                     ]
                 ),
             )
-            shot_instance = gazu.asset.all_asset_instances_for_shot({"id": "shot-01"})[
-                0
-            ]
+            shot_instance = gazu.asset.all_asset_instances_for_shot(
+                {"id": "shot-01"}
+            )[0]
             self.assertEqual(shot_instance["asset_id"], "asset-01")
             self.assertEqual(shot_instance["shot_id"], "shot-01")
             self.assertEqual(shot_instance["number"], 1)
@@ -284,7 +297,9 @@ class CastingTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/assets/{}/asset-asset-instances".format(fakeid("asset-01"))
+                    "data/assets/{}/asset-asset-instances".format(
+                        fakeid("asset-01")
+                    )
                 ),
                 text=json.dumps(
                     [
@@ -301,7 +316,9 @@ class CastingTestCase(unittest.TestCase):
             )
             asset_instance = asset_instances[0]
             self.assertEqual(asset_instance["asset_id"], fakeid("asset-02"))
-            self.assertEqual(asset_instance["target_asset_id"], fakeid("asset-01"))
+            self.assertEqual(
+                asset_instance["target_asset_id"], fakeid("asset-01")
+            )
             self.assertEqual(asset_instance["number"], 1)
 
     def test_new_asset_asset_instance(self):
@@ -312,7 +329,9 @@ class CastingTestCase(unittest.TestCase):
                 "target_asset_id": "asset-02",
             }
             mock = mock.post(
-                gazu.client.get_full_url("data/assets/asset-01/asset-asset-instances"),
+                gazu.client.get_full_url(
+                    "data/assets/asset-01/asset-asset-instances"
+                ),
                 text=json.dumps(result),
             )
             asset = {"id": "asset-01"}
@@ -362,7 +381,9 @@ class CastingTestCase(unittest.TestCase):
                 text=json.dumps(project),
             )
             mock.get(
-                gazu.client.get_full_url("data/assets/%s" % fakeid("asset-01")),
+                gazu.client.get_full_url(
+                    "data/assets/%s" % fakeid("asset-01")
+                ),
                 text=json.dumps(asset),
             )
             url = gazu.asset.get_asset_url(fakeid("asset-01"))
@@ -385,11 +406,15 @@ class CastingTestCase(unittest.TestCase):
             )
             mock.get(
                 gazu.client.get_full_url("data/projects/project-01/assets"),
-                text=json.dumps([{"name": "Asset 01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Asset 01", "project_id": "project-01"}]
+                ),
             )
             mock.get(
                 gazu.client.get_full_url("data/projects/project-02/assets"),
-                text=json.dumps([{"name": "Asset 02", "project_id": "project-02"}]),
+                text=json.dumps(
+                    [{"name": "Asset 02", "project_id": "project-02"}]
+                ),
             )
             self.assertEqual(
                 [
@@ -420,7 +445,9 @@ class CastingTestCase(unittest.TestCase):
     def test_update_asset(self):
         with requests_mock.mock() as mock:
             mock = mock.put(
-                gazu.client.get_full_url("data/entities/%s" % fakeid("asset-1")),
+                gazu.client.get_full_url(
+                    "data/entities/%s" % fakeid("asset-1")
+                ),
                 text=json.dumps(
                     {
                         "id": fakeid("asset-1"),
@@ -429,7 +456,10 @@ class CastingTestCase(unittest.TestCase):
                     }
                 ),
             )
-            asset = {"id": fakeid("asset-1"), "episode_id": fakeid("episode_1")}
+            asset = {
+                "id": fakeid("asset-1"),
+                "episode_id": fakeid("episode_1"),
+            }
             asset = gazu.asset.update_asset(asset)
             self.assertEqual(asset["id"], fakeid("asset-1"))
             self.assertEqual(asset["source_id"], fakeid("episode_1"))
@@ -441,9 +471,14 @@ class CastingTestCase(unittest.TestCase):
                 text=json.dumps({"id": fakeid("asset-1"), "data": {}}),
             )
             mock.put(
-                gazu.client.get_full_url("data/entities/%s" % fakeid("asset-1")),
+                gazu.client.get_full_url(
+                    "data/entities/%s" % fakeid("asset-1")
+                ),
                 text=json.dumps(
-                    {"id": fakeid("asset-1"), "data": {"metadata-1": "metadata-1"}}
+                    {
+                        "id": fakeid("asset-1"),
+                        "data": {"metadata-1": "metadata-1"},
+                    }
                 ),
             )
             data = {"metadata-1": "metadata-1"}
@@ -454,7 +489,9 @@ class CastingTestCase(unittest.TestCase):
     def test_get_asset_type_by_name(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/entity-types?name=asset-type-1"),
+                gazu.client.get_full_url(
+                    "data/entity-types?name=asset-type-1"
+                ),
                 text=json.dumps(
                     [{"id": fakeid("asset-type-1"), "name": "asset-type-1"}]
                 ),
@@ -467,7 +504,9 @@ class CastingTestCase(unittest.TestCase):
             mock.put(
                 "%s/asset-instances/%s"
                 % (gazu.client.host, fakeid("asset-instance-1")),
-                text=json.dumps({"id": fakeid("asset-instance-1"), "active": False}),
+                text=json.dumps(
+                    {"id": fakeid("asset-instance-1"), "active": False}
+                ),
             )
             asset_instance = gazu.asset.disable_asset_instance(
                 fakeid("asset-instance-1")
@@ -479,7 +518,9 @@ class CastingTestCase(unittest.TestCase):
             mock.put(
                 "%s/asset-instances/%s"
                 % (gazu.client.host, fakeid("asset-instance-1")),
-                text=json.dumps({"id": fakeid("asset-instance-1"), "active": True}),
+                text=json.dumps(
+                    {"id": fakeid("asset-instance-1"), "active": True}
+                ),
             )
             asset_instance = gazu.asset.enable_asset_instance(
                 fakeid("asset-instance-1")

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -32,12 +32,16 @@ class CastingTestCase(unittest.TestCase):
             mock.put(gazu.client.get_full_url(path), text=json.dumps(casting))
             asset = {"id": fakeid("asset-01")}
             project = {"id": fakeid("project-01")}
-            casting = gazu.casting.update_asset_casting(project, asset, casting)
+            casting = gazu.casting.update_asset_casting(
+                project, asset, casting
+            )
             self.assertEqual(casting[0]["asset_id"], fakeid("asset-1"))
 
     def test_get_asset_type_casting(self):
         casting = {
-            fakeid("asset-2"): [{"asset_id": fakeid("asset-1"), "nb_occurences": 3}]
+            fakeid("asset-2"): [
+                {"asset_id": fakeid("asset-1"), "nb_occurences": 3}
+            ]
         }
         path = "data/projects/%s/asset-types/%s/casting" % (
             fakeid("project-01"),
@@ -54,7 +58,9 @@ class CastingTestCase(unittest.TestCase):
 
     def test_get_sequence_casting(self):
         casting = {
-            fakeid("shot-1"): [{"asset_id": fakeid("asset-1"), "nb_occurences": 3}]
+            fakeid("shot-1"): [
+                {"asset_id": fakeid("asset-1"), "nb_occurences": 3}
+            ]
         }
         path = "/data/projects/%s/sequences/%s/casting" % (
             fakeid("project-01"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,7 +41,9 @@ class BaseFuncTestCase(ClientTestCase):
         with requests_mock.mock() as mock:
             mock.head(raw.get_host())
             mock.post(
-                raw.get_full_url("auth/login"), text=json.dumps({}), status_code=400
+                raw.get_full_url("auth/login"),
+                text=json.dumps({}),
+                status_code=400,
             )
             self.assertTrue(raw.host_is_valid())
 
@@ -150,7 +152,11 @@ class BaseFuncTestCase(ClientTestCase):
             mock.put(
                 raw.get_full_url("data/persons/person-1"),
                 text=json.dumps(
-                    {"id": "person-1", "first_name": "John", "last_name": "Doe"}
+                    {
+                        "id": "person-1",
+                        "first_name": "John",
+                        "last_name": "Doe",
+                    }
                 ),
             )
             data = {"last_name": "Doe"}
@@ -170,15 +176,21 @@ class BaseFuncTestCase(ClientTestCase):
                 raw.get_full_url("data/persons"),
                 text=json.dumps([{"first_name": "John"}]),
             )
-            self.assertEqual(raw.fetch_all("persons"), [{"first_name": "John"}])
+            self.assertEqual(
+                raw.fetch_all("persons"), [{"first_name": "John"}]
+            )
 
     def test_fetch_first(self):
         with requests_mock.mock() as mock:
             mock.get(
                 raw.get_full_url("data/persons"),
-                text=json.dumps([{"first_name": "John"}, {"first_name": "Jane"}]),
+                text=json.dumps(
+                    [{"first_name": "John"}, {"first_name": "Jane"}]
+                ),
             )
-            self.assertEqual(raw.fetch_first("persons"), {"first_name": "John"})
+            self.assertEqual(
+                raw.fetch_first("persons"), {"first_name": "John"}
+            )
 
             mock.get(raw.get_full_url("data/persons"), text=json.dumps([]))
             self.assertIsNone(raw.fetch_first("persons"))
@@ -221,7 +233,9 @@ class BaseFuncTestCase(ClientTestCase):
 
     def test_version(self):
         with requests_mock.mock() as mock:
-            mock.get(raw.get_host() + "/", text=json.dumps({"version": "0.2.0"}))
+            mock.get(
+                raw.get_host() + "/", text=json.dumps({"version": "0.2.0"})
+            )
             self.assertEqual(raw.get_api_version(), "0.2.0")
 
     def test_make_auth_token(self):
@@ -245,7 +259,9 @@ class BaseFuncTestCase(ClientTestCase):
 
                 def verify_file_callback(request):
                     body_file = io.BytesIO(request.body)
-                    _, pdict = cgi.parse_header(request.headers["Content-Type"])
+                    _, pdict = cgi.parse_header(
+                        request.headers["Content-Type"]
+                    )
                     if sys.version_info[0] == 3:
                         pdict["boundary"] = bytes(pdict["boundary"], "UTF-8")
                     else:
@@ -259,7 +275,9 @@ class BaseFuncTestCase(ClientTestCase):
                 mock.post("data/new-file", json={})
                 mock.add_matcher(verify_file_callback)
                 raw.upload(
-                    "data/new-file", "./tests/fixtures/v1.png", data={"test": True}
+                    "data/new-file",
+                    "./tests/fixtures/v1.png",
+                    data={"test": True},
                 )
             with requests_mock.Mocker() as mock:
                 mock.post(
@@ -269,7 +287,9 @@ class BaseFuncTestCase(ClientTestCase):
                 mock.post("data/new-file", json={})
                 with self.assertRaises(gazu.client.UploadFailedException):
                     raw.upload(
-                        "data/new-file", "./tests/fixtures/v1.png", data={"test": True}
+                        "data/new-file",
+                        "./tests/fixtures/v1.png",
+                        data={"test": True},
                     )
 
     def test_upload_multiple_files(self):
@@ -282,7 +302,9 @@ class BaseFuncTestCase(ClientTestCase):
 
                 def verify_file_callback(request):
                     body_file = io.BytesIO(request.body)
-                    _, pdict = cgi.parse_header(request.headers["Content-Type"])
+                    _, pdict = cgi.parse_header(
+                        request.headers["Content-Type"]
+                    )
                     if sys.version_info[0] == 3:
                         pdict["boundary"] = bytes(pdict["boundary"], "UTF-8")
                     else:
@@ -327,21 +349,35 @@ class BaseFuncTestCase(ClientTestCase):
         self.assertRaises(
             NotAuthenticatedException, raw.check_status, Request(401), "/"
         )
-        self.assertRaises(NotAllowedException, raw.check_status, Request(403), "/")
-        self.assertRaises(RouteNotFoundException, raw.check_status, Request(404), "/")
+        self.assertRaises(
+            NotAllowedException, raw.check_status, Request(403), "/"
+        )
+        self.assertRaises(
+            RouteNotFoundException, raw.check_status, Request(404), "/"
+        )
         self.assertRaises(
             MethodNotAllowedException, raw.check_status, Request(405), "/"
         )
 
-        self.assertRaises(TooBigFileException, raw.check_status, Request(413), "/")
+        self.assertRaises(
+            TooBigFileException, raw.check_status, Request(413), "/"
+        )
 
-        self.assertRaises(ServerErrorException, raw.check_status, RequestText(500), "/")
+        self.assertRaises(
+            ServerErrorException, raw.check_status, RequestText(500), "/"
+        )
 
-        self.assertRaises(ServerErrorException, raw.check_status, RequestText(502), "/")
+        self.assertRaises(
+            ServerErrorException, raw.check_status, RequestText(502), "/"
+        )
 
-        self.assertRaises(ServerErrorException, raw.check_status, RequestJSON(500), "/")
+        self.assertRaises(
+            ServerErrorException, raw.check_status, RequestJSON(500), "/"
+        )
 
-        self.assertRaises(ServerErrorException, raw.check_status, RequestJSON(502), "/")
+        self.assertRaises(
+            ServerErrorException, raw.check_status, RequestJSON(502), "/"
+        )
 
     def test_init_host(self):
         gazu.set_host("newhost")
@@ -366,7 +402,9 @@ class BaseFuncTestCase(ClientTestCase):
         with requests_mock.mock() as mock:
             mock.head(raw.get_host())
             mock.get(
-                raw.get_full_url("auth/logout"), text=json.dumps({}), status_code=400
+                raw.get_full_url("auth/logout"),
+                text=json.dumps({}),
+                status_code=400,
             )
             gazu.log_out()
             self.assertEqual(raw.default_client.tokens, {})
@@ -377,12 +415,16 @@ class BaseFuncTestCase(ClientTestCase):
                 raw.get_full_url("auth/login"),
                 text=json.dumps({"login": False}),
             )
-            self.assertRaises(AuthFailedException, gazu.log_in, "frank", "test")
+            self.assertRaises(
+                AuthFailedException, gazu.log_in, "frank", "test"
+            )
             self.assertRaises(AuthFailedException, gazu.log_in, "", "")
         with requests_mock.mock() as mock:
             mock.head(raw.get_host())
             mock.post(
-                raw.get_full_url("auth/login"), text=json.dumps({}), status_code=400
+                raw.get_full_url("auth/login"),
+                text=json.dumps({}),
+                status_code=400,
             )
             with self.assertRaises(AuthFailedException):
                 gazu.log_in("", "")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -39,13 +39,16 @@ class CastingTestCase(unittest.TestCase):
                 gazu.context.all_assets_for_asset_type_and_project(
                     project, asset_type, False
                 ),
-                gazu.asset.all_assets_for_project_and_type(project, asset_type),
+                gazu.asset.all_assets_for_project_and_type(
+                    project, asset_type
+                ),
             )
         with requests_mock.mock() as mock:
             mock_route(
                 mock,
                 "GET",
-                "data/user/projects/project-01/asset-types/asset-type-01" "/assets",
+                "data/user/projects/project-01/asset-types/asset-type-01"
+                "/assets",
                 text=[{"name": "Chair", "id": "asset-01"}],
             )
 
@@ -56,7 +59,9 @@ class CastingTestCase(unittest.TestCase):
                 gazu.context.all_assets_for_asset_type_and_project(
                     project, asset_type, True
                 ),
-                gazu.user.all_assets_for_asset_type_and_project(project, asset_type),
+                gazu.user.all_assets_for_asset_type_and_project(
+                    project, asset_type
+                ),
             )
 
     def test_all_asset_types_for_project(self):
@@ -95,7 +100,8 @@ class CastingTestCase(unittest.TestCase):
                 text=[{"name": "Agent 327", "id": "project-01"}],
             )
             self.assertEqual(
-                gazu.context.all_open_projects(False), gazu.project.all_open_projects()
+                gazu.context.all_open_projects(False),
+                gazu.project.all_open_projects(),
             )
         with requests_mock.mock() as mock:
             mock_route(
@@ -105,7 +111,8 @@ class CastingTestCase(unittest.TestCase):
                 text=[{"name": "Big Buck Bunny", "id": "project-01"}],
             )
             self.assertEqual(
-                gazu.context.all_open_projects(True), gazu.user.all_open_projects()
+                gazu.context.all_open_projects(True),
+                gazu.user.all_open_projects(),
             )
 
     def test_all_scenes(self):

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -55,7 +55,9 @@ class AssetTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/entity-types"),
                 text=json.dumps(entity_type),
             )
-            self.assertEqual(gazu.entity.new_entity_type(entity_type_name), entity_type)
+            self.assertEqual(
+                gazu.entity.new_entity_type(entity_type_name), entity_type
+            )
 
     def test_all_entity_types(self):
         with requests_mock.mock() as mock:
@@ -63,8 +65,14 @@ class AssetTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/entity-types"),
                 text=json.dumps(
                     [
-                        {"id": fakeid("entity-type-1"), "name": "entity-type-1"},
-                        {"id": fakeid("entity-type-2"), "name": "entity-type-2"},
+                        {
+                            "id": fakeid("entity-type-1"),
+                            "name": "entity-type-1",
+                        },
+                        {
+                            "id": fakeid("entity-type-2"),
+                            "name": "entity-type-2",
+                        },
                     ]
                 ),
             )
@@ -77,7 +85,9 @@ class AssetTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/entities?name=entity-1"),
-                text=json.dumps([{"id": fakeid("entity-1"), "name": "entity-1"}]),
+                text=json.dumps(
+                    [{"id": fakeid("entity-1"), "name": "entity-1"}]
+                ),
             )
             entity = gazu.entity.get_entity_by_name("entity-1")
             self.assertEqual(entity["id"], fakeid("entity-1"))
@@ -85,7 +95,9 @@ class AssetTestCase(unittest.TestCase):
     def test_get_entity_type_by_name(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/entity-types?name=entity-type-1"),
+                gazu.client.get_full_url(
+                    "data/entity-types?name=entity-type-1"
+                ),
                 text=json.dumps(
                     [{"id": fakeid("entity-type-1"), "name": "entity-type-1"}]
                 ),

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -14,7 +14,9 @@ class FilesTestCase(unittest.TestCase):
     def test_build_working_file_path(self):
         with requests_mock.mock() as mock:
             mock.post(
-                gazu.client.get_full_url("data/tasks/task-01/working-file-path"),
+                gazu.client.get_full_url(
+                    "data/tasks/task-01/working-file-path"
+                ),
                 text=json.dumps(
                     {"path": "U:/PROD/FX/S01/P01/Tree", "name": "filename.max"}
                 ),
@@ -52,7 +54,10 @@ class FilesTestCase(unittest.TestCase):
 
         with requests_mock.mock() as mock:
             mock.post(
-                path, text=json.dumps({"output_file": {"file_name": "filename.max"}})
+                path,
+                text=json.dumps(
+                    {"output_file": {"file_name": "filename.max"}}
+                ),
             )
             result = gazu.files.new_entity_output_file(
                 entity,
@@ -105,7 +110,10 @@ class FilesTestCase(unittest.TestCase):
 
         with requests_mock.mock() as mock:
             mock.post(
-                path, text=json.dumps({"output_file": {"file_name": "filename.max"}})
+                path,
+                text=json.dumps(
+                    {"output_file": {"file_name": "filename.max"}}
+                ),
             )
             result = gazu.files.new_asset_instance_output_file(
                 asset_instance,
@@ -224,8 +232,12 @@ class FilesTestCase(unittest.TestCase):
             )
             task = {"id": "task-01"}
             working_files_dict = gazu.files.get_last_working_files(task)
-            self.assertEqual(working_files_dict["main"]["id"], "working-file-1")
-            self.assertEqual(working_files_dict["hotfix"]["id"], "working-file-7")
+            self.assertEqual(
+                working_files_dict["main"]["id"], "working-file-1"
+            )
+            self.assertEqual(
+                working_files_dict["hotfix"]["id"], "working-file-7"
+            )
 
     def test_get_last_working_file_revision(self):
         with requests_mock.mock() as mock:
@@ -243,7 +255,9 @@ class FilesTestCase(unittest.TestCase):
 
             working_file = gazu.files.get_last_working_file_revision(task)
             self.assertEqual(working_file["revision"], 2)
-            working_file = gazu.files.get_last_working_file_revision(task, "hotfix")
+            working_file = gazu.files.get_last_working_file_revision(
+                task, "hotfix"
+            )
             self.assertEqual(working_file["revision"], 4)
 
     def test_get_last_output_files_for_entity(self):
@@ -259,7 +273,9 @@ class FilesTestCase(unittest.TestCase):
                 ),
             )
             entity = {"id": "entity-01"}
-            output_files_dict = gazu.files.get_last_output_files_for_entity(entity)
+            output_files_dict = gazu.files.get_last_output_files_for_entity(
+                entity
+            )
             self.assertEqual(
                 output_files_dict["output-type-01"]["main"]["id"],
                 "output-file-1",
@@ -310,8 +326,10 @@ class FilesTestCase(unittest.TestCase):
             )
             asset_instance = {"id": "asset-instance-01"}
             scene = {"id": "scene-01"}
-            output_files_dict = gazu.files.get_last_output_files_for_asset_instance(
-                asset_instance, scene
+            output_files_dict = (
+                gazu.files.get_last_output_files_for_asset_instance(
+                    asset_instance, scene
+                )
             )
             self.assertEqual(
                 output_files_dict["output-type-01"]["main"]["id"],
@@ -331,14 +349,16 @@ class FilesTestCase(unittest.TestCase):
                 ),
             )
 
-            output_files_dict = gazu.files.get_last_output_files_for_asset_instance(
-                {"id": "asset-instance-01"},
-                {"id": "scene-01"},
-                {"id": "output-type-01"},
-                {"id": "task-type-01"},
-                "main",
-                "obj",
-                {"id": "file-status-01"},
+            output_files_dict = (
+                gazu.files.get_last_output_files_for_asset_instance(
+                    {"id": "asset-instance-01"},
+                    {"id": "scene-01"},
+                    {"id": "output-type-01"},
+                    {"id": "task-type-01"},
+                    "main",
+                    "obj",
+                    {"id": "file-status-01"},
+                )
             )
             self.assertEqual(
                 output_files_dict["output-type-01"]["main"]["id"],
@@ -395,7 +415,9 @@ class FilesTestCase(unittest.TestCase):
             path = "/data/output-types"
             mock.get(
                 gazu.client.get_full_url(path),
-                text=json.dumps([{"id": "output-type-01", "name": "geometry"}]),
+                text=json.dumps(
+                    [{"id": "output-type-01", "name": "geometry"}]
+                ),
             )
             output_type = gazu.files.all_output_types()
             self.assertEqual(output_type[0]["name"], "geometry")
@@ -405,7 +427,9 @@ class FilesTestCase(unittest.TestCase):
             path = "/data/entities/asset-01/output-types/"
             mock.get(
                 gazu.client.get_full_url(path),
-                text=json.dumps([{"id": "output-type-01", "name": "geometry"}]),
+                text=json.dumps(
+                    [{"id": "output-type-01", "name": "geometry"}]
+                ),
             )
             asset = {"id": "asset-01"}
             output_type = gazu.files.all_output_types_for_entity(asset)
@@ -419,7 +443,9 @@ class FilesTestCase(unittest.TestCase):
             )
             mock.get(
                 gazu.client.get_full_url(path),
-                text=json.dumps([{"id": "output-type-01", "name": "geometry"}]),
+                text=json.dumps(
+                    [{"id": "output-type-01", "name": "geometry"}]
+                ),
             )
             asset_instance = {"id": "asset-instance-1"}
             scene = {"id": "scene-1"}
@@ -443,7 +469,9 @@ class FilesTestCase(unittest.TestCase):
             path = "/data/output-types?name=geometry"
             mock.get(
                 gazu.client.get_full_url(path),
-                text=json.dumps([{"id": "output-type-01", "name": "geometry"}]),
+                text=json.dumps(
+                    [{"id": "output-type-01", "name": "geometry"}]
+                ),
             )
             output_type = gazu.files.get_output_type_by_name("geometry")
             self.assertEqual(output_type["name"], "geometry")
@@ -570,7 +598,9 @@ class FilesTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             result_path = "/path/to/entity/file_name.cache"
             mock.post(
-                gazu.client.get_full_url("data/entities/asset-01/" "output-file-path"),
+                gazu.client.get_full_url(
+                    "data/entities/asset-01/" "output-file-path"
+                ),
                 text=json.dumps(
                     {
                         "folder_path": "/path/to/entity",
@@ -628,7 +658,8 @@ class FilesTestCase(unittest.TestCase):
                 text=json.dumps([{"id": "output-type-01"}]),
             )
             self.assertEqual(
-                gazu.files.new_output_type("Geometry", "Geo"), {"id": "output-type-01"}
+                gazu.files.new_output_type("Geometry", "Geo"),
+                {"id": "output-type-01"},
             )
 
     def test_new_software(self):
@@ -649,7 +680,8 @@ class FilesTestCase(unittest.TestCase):
                 text=json.dumps([{"id": "software-01"}]),
             )
             self.assertEqual(
-                gazu.files.new_software("3DSMax", "max", ".max"), {"id": "software-01"}
+                gazu.files.new_software("3DSMax", "max", ".max"),
+                {"id": "software-01"},
             )
 
     def test_update_project_file_tree(self):
@@ -661,7 +693,9 @@ class FilesTestCase(unittest.TestCase):
             path = "data/projects/{}".format(fakeid("project-01"))
             mock.put(
                 gazu.client.get_full_url(path),
-                text=json.dumps({"id": fakeid("project-01"), "file_tree": file_tree}),
+                text=json.dumps(
+                    {"id": fakeid("project-01"), "file_tree": file_tree}
+                ),
             )
             file_tree = gazu.files.update_project_file_tree(
                 fakeid("project-01"), file_tree
@@ -674,13 +708,17 @@ class FilesTestCase(unittest.TestCase):
                 path = "data/preview-files/{}".format(fakeid("preview-1"))
                 mock.get(
                     gazu.client.get_full_url(path),
-                    text=json.dumps({"id": fakeid("preview-1"), "extension": "png"}),
+                    text=json.dumps(
+                        {"id": fakeid("preview-1"), "extension": "png"}
+                    ),
                 )
                 path = "pictures/originals/preview-files/{}.png".format(
                     fakeid("preview-1")
                 )
                 mock.get(gazu.client.get_full_url(path), body=thumbnail_file)
-                gazu.files.download_preview_file(fakeid("preview-1"), "./test.png")
+                gazu.files.download_preview_file(
+                    fakeid("preview-1"), "./test.png"
+                )
                 self.assertTrue(os.path.exists("./test.png"))
                 self.assertEqual(
                     os.path.getsize("./test.png"),
@@ -692,13 +730,17 @@ class FilesTestCase(unittest.TestCase):
                 path = "data/preview-files/{}".format(fakeid("preview-1"))
                 mock.get(
                     gazu.client.get_full_url(path),
-                    text=json.dumps({"id": fakeid("preview-1"), "extension": "mp4"}),
+                    text=json.dumps(
+                        {"id": fakeid("preview-1"), "extension": "mp4"}
+                    ),
                 )
                 path = "movies/originals/preview-files/{}.mp4".format(
                     fakeid("preview-1")
                 )
                 mock.get(gazu.client.get_full_url(path), body=thumbnail_file)
-                gazu.files.download_preview_file(fakeid("preview-1"), "./test.mp4")
+                gazu.files.download_preview_file(
+                    fakeid("preview-1"), "./test.mp4"
+                )
                 self.assertTrue(os.path.exists("./test.mp4"))
                 self.assertEqual(
                     os.path.getsize("./test.mp4"),
@@ -714,9 +756,13 @@ class FilesTestCase(unittest.TestCase):
                     gazu.client.get_full_url(path),
                     text=json.dumps({"id": attachment_id, "name": "v1.png"}),
                 )
-                path = "data/attachment-files/{}/file/v1.png".format(attachment_id)
+                path = "data/attachment-files/{}/file/v1.png".format(
+                    attachment_id
+                )
                 mock.get(gazu.client.get_full_url(path), body=attachment_file)
-                gazu.files.download_attachment_file(attachment_id, "./test.png")
+                gazu.files.download_attachment_file(
+                    attachment_id, "./test.png"
+                )
                 self.assertTrue(os.path.exists("./test.png"))
                 self.assertEqual(
                     os.path.getsize("./test.png"),
@@ -799,9 +845,13 @@ class FilesTestCase(unittest.TestCase):
             }
 
             path = "/data/file-status/{}".format(file_status["id"])
-            mock.get(gazu.client.get_full_url(path), text=json.dumps(file_status))
+            mock.get(
+                gazu.client.get_full_url(path), text=json.dumps(file_status)
+            )
 
-            self.assertEqual(file_status, gazu.files.get_file_status(file_status["id"]))
+            self.assertEqual(
+                file_status, gazu.files.get_file_status(file_status["id"])
+            )
 
     def test_get_file_status_by_name(self):
         with requests_mock.mock() as mock:
@@ -822,7 +872,8 @@ class FilesTestCase(unittest.TestCase):
             )
 
             self.assertEqual(
-                file_status, gazu.files.get_file_status_by_name(file_status["name"])
+                file_status,
+                gazu.files.get_file_status_by_name(file_status["name"]),
             )
 
     def test_update_comment(self):
@@ -838,7 +889,9 @@ class FilesTestCase(unittest.TestCase):
                 ),
             )
             working_file = {"id": "working-file-01"}
-            working_file = gazu.files.update_comment(working_file, "test-comment")
+            working_file = gazu.files.update_comment(
+                working_file, "test-comment"
+            )
             self.assertEqual(working_file["id"], "working-file-01")
             self.assertEqual(working_file["comment"], "test-comment")
 
@@ -852,7 +905,9 @@ class FilesTestCase(unittest.TestCase):
                         {"id": fakeid("working_file-1"), "path": "test.png"}
                     ),
                 )
-                path = "data/working-files/{}/file".format(fakeid("working_file-1"))
+                path = "data/working-files/{}/file".format(
+                    fakeid("working_file-1")
+                )
                 mock.get(gazu.client.get_full_url(path), body=working_file)
                 gazu.files.download_working_file(
                     fakeid("working_file-1"),
@@ -868,13 +923,17 @@ class FilesTestCase(unittest.TestCase):
                 path = "data/preview-files/{}".format(fakeid("preview-1"))
                 mock.get(
                     gazu.client.get_full_url(path),
-                    text=json.dumps({"id": fakeid("preview-1"), "extension": "mp4"}),
+                    text=json.dumps(
+                        {"id": fakeid("preview-1"), "extension": "mp4"}
+                    ),
                 )
                 path = "movies/originals/preview-files/{}.mp4".format(
                     fakeid("preview-1")
                 )
                 mock.get(gazu.client.get_full_url(path), body=thumbnail_file)
-                gazu.files.download_preview_file(fakeid("preview-1"), "./test.mp4")
+                gazu.files.download_preview_file(
+                    fakeid("preview-1"), "./test.mp4"
+                )
                 self.assertTrue(os.path.exists("./test.mp4"))
                 self.assertEqual(
                     os.path.getsize("./test.mp4"),
@@ -883,7 +942,9 @@ class FilesTestCase(unittest.TestCase):
 
     def test_upload_working_file(self):
         with requests_mock.mock() as mock:
-            path = "data/working-files/{}/file".format(fakeid("working_file-1"))
+            path = "data/working-files/{}/file".format(
+                fakeid("working_file-1")
+            )
             mock.post(
                 gazu.client.get_full_url(path),
                 text=json.dumps({"id": fakeid("working_file-1")}),
@@ -902,7 +963,10 @@ class FilesTestCase(unittest.TestCase):
             mock.get(
                 gazu.client.get_full_url(path),
                 text=json.dumps(
-                    [{"id": fakeid("working_file-1")}, {"id": fakeid("working_file-2")}]
+                    [
+                        {"id": fakeid("working_file-1")},
+                        {"id": fakeid("working_file-2")},
+                    ]
                 ),
             )
             working_files = gazu.files.get_all_working_files_for_entity(
@@ -926,7 +990,9 @@ class FilesTestCase(unittest.TestCase):
                     }
                 ),
             )
-            preview_file = gazu.files.get_preview_file(fakeid("preview-file-1"))
+            preview_file = gazu.files.get_preview_file(
+                fakeid("preview-file-1")
+            )
             self.assertEqual(preview_file["name"], "preview-file-1")
 
     def test_get_all_preview_files_for_task(self):
@@ -937,12 +1003,20 @@ class FilesTestCase(unittest.TestCase):
                 ),
                 text=json.dumps(
                     [
-                        {"id": fakeid("preview-file-1"), "name": "preview-file-1"},
-                        {"id": fakeid("preview-file-2"), "name": "preview-file-2"},
+                        {
+                            "id": fakeid("preview-file-1"),
+                            "name": "preview-file-1",
+                        },
+                        {
+                            "id": fakeid("preview-file-2"),
+                            "name": "preview-file-2",
+                        },
                     ]
                 ),
             )
-            preview_files = gazu.files.get_all_preview_files_for_task(fakeid("task-1"))
+            preview_files = gazu.files.get_all_preview_files_for_task(
+                fakeid("task-1")
+            )
             self.assertEqual(len(preview_files), 2)
             self.assertEqual(preview_files[0]["name"], "preview-file-1")
             self.assertEqual(preview_files[1]["name"], "preview-file-2")
@@ -960,7 +1034,9 @@ class FilesTestCase(unittest.TestCase):
                 ),
             )
             data = {"name": "test-name"}
-            output_file = gazu.files.update_output_file(fakeid("output-file-1"), data)
+            output_file = gazu.files.update_output_file(
+                fakeid("output-file-1"), data
+            )
             self.assertEqual(output_file["id"], fakeid("output-file-1"))
             self.assertEqual(output_file["name"], "test-name")
 
@@ -977,6 +1053,8 @@ class FilesTestCase(unittest.TestCase):
                 ),
             )
             data = {"name": "test-name"}
-            preview_file = gazu.files.update_preview(fakeid("preview-file-1"), data)
+            preview_file = gazu.files.update_preview(
+                fakeid("preview-file-1"), data
+            )
             self.assertEqual(preview_file["id"], fakeid("preview-file-1"))
             self.assertEqual(preview_file["name"], "test-name")

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -70,12 +70,16 @@ class PersonTestCase(unittest.TestCase):
             )
             person = gazu.person.get_person_by_full_name("JohnDid")
             self.assertEqual(person["id"], "person-2")
-            self.assertEqual(gazu.person.get_person_by_full_name("Unknown"), None)
+            self.assertEqual(
+                gazu.person.get_person_by_full_name("Unknown"), None
+            )
 
     def test_get_person_by_desktop_login(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/persons?desktop_login=john.doe"),
+                gazu.client.get_full_url(
+                    "data/persons?desktop_login=john.doe"
+                ),
                 text=json.dumps(
                     [
                         {
@@ -147,17 +151,23 @@ class PersonTestCase(unittest.TestCase):
         result = {"id": fakeid("John Doe"), "full_name": "John Doe"}
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/persons/%s" % (fakeid("John Doe"))),
+                gazu.client.get_full_url(
+                    "data/persons/%s" % (fakeid("John Doe"))
+                ),
                 text=json.dumps(result),
             )
-            self.assertEqual(gazu.person.get_person(fakeid("John Doe")), result)
+            self.assertEqual(
+                gazu.person.get_person(fakeid("John Doe")), result
+            )
 
     def test_get_person_url(self):
         wanted_result = "%s/people/%s/" % (
             gazu.client.get_api_url_from_host(),
             fakeid("person-1"),
         )
-        self.assertEqual(wanted_result, gazu.person.get_person_url(fakeid("person-1")))
+        self.assertEqual(
+            wanted_result, gazu.person.get_person_url(fakeid("person-1"))
+        )
 
     def test_get_organisation(self):
         with requests_mock.mock() as mock:
@@ -166,7 +176,9 @@ class PersonTestCase(unittest.TestCase):
                 gazu.client.get_full_url("auth/authenticated"),
                 text=json.dumps(result),
             )
-            self.assertEqual(gazu.person.get_organisation(), "test-organisation")
+            self.assertEqual(
+                gazu.person.get_organisation(), "test-organisation"
+            )
 
     def test_get_presence_log(self):
         result = """
@@ -184,7 +196,9 @@ class PersonTestCase(unittest.TestCase):
             path = "/pictures/thumbnails/persons/%s" % fakeid("person-1")
             mock.post(
                 gazu.client.get_full_url(path),
-                text=json.dumps({"id": fakeid("person-1"), "name": "test-name"}),
+                text=json.dumps(
+                    {"id": fakeid("person-1"), "name": "test-name"}
+                ),
             )
             person_id = gazu.person.set_avatar(
                 fakeid("person-1"), "./tests/fixtures/v1.png"

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -27,7 +27,9 @@ class TaskTestCase(unittest.TestCase):
     def test_all_shots_for_playlist(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/playlists/%s" % fakeid("playlist-1")),
+                gazu.client.get_full_url(
+                    "data/playlists/%s" % fakeid("playlist-1")
+                ),
                 text=json.dumps(
                     {
                         "shots": [
@@ -78,7 +80,10 @@ class TaskTestCase(unittest.TestCase):
                     ]
                 ),
             )
-            episode = {"id": fakeid("episode-1"), "project_id": fakeid("project-1")}
+            episode = {
+                "id": fakeid("episode-1"),
+                "project_id": fakeid("project-1"),
+            }
             playlists = gazu.playlist.all_playlists_for_episode(episode)
             self.assertEqual(len(playlists), 2)
             self.assertEqual(playlists[0]["name"], "playlist-1")
@@ -87,7 +92,9 @@ class TaskTestCase(unittest.TestCase):
     def test_get_playlist(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/playlists/%s" % fakeid("playlist-1")),
+                gazu.client.get_full_url(
+                    "data/playlists/%s" % fakeid("playlist-1")
+                ),
                 text=json.dumps(
                     {
                         "id": fakeid("playlist-1"),
@@ -96,13 +103,16 @@ class TaskTestCase(unittest.TestCase):
                 ),
             )
             playlist = fakeid("playlist-1")
-            self.assertEqual(gazu.playlist.get_playlist(playlist)["name"], "playlist-1")
+            self.assertEqual(
+                gazu.playlist.get_playlist(playlist)["name"], "playlist-1"
+            )
 
     def test_get_playlist_by_name(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/playlists?project_id=%s&name=playlist-1" % fakeid("project-1")
+                    "data/playlists?project_id=%s&name=playlist-1"
+                    % fakeid("project-1")
                 ),
                 text=json.dumps(
                     [
@@ -114,9 +124,9 @@ class TaskTestCase(unittest.TestCase):
                 ),
             )
             self.assertEqual(
-                gazu.playlist.get_playlist_by_name(fakeid("project-1"), "playlist-1")[
-                    "id"
-                ],
+                gazu.playlist.get_playlist_by_name(
+                    fakeid("project-1"), "playlist-1"
+                )["id"],
                 fakeid("playlist-1"),
             )
 
@@ -124,13 +134,16 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/playlists?project_id=%s&name=playlist-1" % fakeid("project-1")
+                    "data/playlists?project_id=%s&name=playlist-1"
+                    % fakeid("project-1")
                 ),
                 text=json.dumps([]),
             )
             mock.post(
                 gazu.client.get_full_url("data/playlists/"),
-                text=json.dumps({"name": "playlist-1", "id": fakeid("playlist-1")}),
+                text=json.dumps(
+                    {"name": "playlist-1", "id": fakeid("playlist-1")}
+                ),
             )
 
             playlist = gazu.playlist.new_playlist(
@@ -143,8 +156,12 @@ class TaskTestCase(unittest.TestCase):
     def test_update_playlist(self):
         with requests_mock.mock() as mock:
             mock = mock.put(
-                gazu.client.get_full_url("data/playlists/%s" % fakeid("playlist-1")),
-                text=json.dumps({"id": fakeid("playlist-1"), "name": "name_changed"}),
+                gazu.client.get_full_url(
+                    "data/playlists/%s" % fakeid("playlist-1")
+                ),
+                text=json.dumps(
+                    {"id": fakeid("playlist-1"), "name": "name_changed"}
+                ),
             )
             playlist = {"id": fakeid("playlist-1"), "name": "name_changed"}
             playlist = gazu.playlist.update_playlist(playlist)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -59,7 +59,9 @@ class ProjectTestCase(unittest.TestCase):
 
     def test_get_url(self):
         url = gazu.project.get_project_url({"id": "project-01"})
-        self.assertEqual(url, "http://gazu-server/productions/project-01/assets/")
+        self.assertEqual(
+            url, "http://gazu-server/productions/project-01/assets/"
+        )
 
     def test_all_project_status(self):
         with requests_mock.mock() as mock:
@@ -67,34 +69,53 @@ class ProjectTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/project-status"),
                 text=json.dumps(
                     [
-                        {"id": fakeid("project-status-1"), "name": "project-status-1"},
-                        {"id": fakeid("project-status-2"), "name": "project-status-2"},
+                        {
+                            "id": fakeid("project-status-1"),
+                            "name": "project-status-1",
+                        },
+                        {
+                            "id": fakeid("project-status-2"),
+                            "name": "project-status-2",
+                        },
                     ]
                 ),
             )
             project_statuses = gazu.project.all_project_status()
             self.assertEqual(len(project_statuses), 2)
-            self.assertEqual(project_statuses[0]["id"], fakeid("project-status-1"))
-            self.assertEqual(project_statuses[1]["id"], fakeid("project-status-2"))
+            self.assertEqual(
+                project_statuses[0]["id"], fakeid("project-status-1")
+            )
+            self.assertEqual(
+                project_statuses[1]["id"], fakeid("project-status-2")
+            )
 
     def test_get_project_status_by_name(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/project-status?name=project-status-1"),
+                gazu.client.get_full_url(
+                    "data/project-status?name=project-status-1"
+                ),
                 text=json.dumps(
                     [
-                        {"id": fakeid("project-status-1"), "name": "project-status-1"},
+                        {
+                            "id": fakeid("project-status-1"),
+                            "name": "project-status-1",
+                        },
                     ]
                 ),
             )
-            project_status = gazu.project.get_project_status_by_name("project-status-1")
+            project_status = gazu.project.get_project_status_by_name(
+                "project-status-1"
+            )
             self.assertEqual(project_status["id"], fakeid("project-status-1"))
 
     def test_new_project(self):
         with requests_mock.mock() as mock:
             mock.post(
                 gazu.client.get_full_url("data/projects"),
-                text=json.dumps({"id": fakeid("project-1"), "name": "project-1"}),
+                text=json.dumps(
+                    {"id": fakeid("project-1"), "name": "project-1"}
+                ),
             )
             mock.get(
                 gazu.client.get_full_url("data/projects?name=project-1"),
@@ -117,7 +138,9 @@ class ProjectTestCase(unittest.TestCase):
     def test_update_project(self):
         with requests_mock.mock() as mock:
             mock.put(
-                gazu.client.get_full_url("data/projects/%s" % fakeid("project-1")),
+                gazu.client.get_full_url(
+                    "data/projects/%s" % fakeid("project-1")
+                ),
                 text=json.dumps(
                     {
                         "id": fakeid("project-1"),
@@ -135,7 +158,9 @@ class ProjectTestCase(unittest.TestCase):
     def test_update_project_data(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/projects/%s" % fakeid("project-1")),
+                gazu.client.get_full_url(
+                    "data/projects/%s" % fakeid("project-1")
+                ),
                 text=json.dumps(
                     {
                         "id": fakeid("project-1"),
@@ -144,9 +169,15 @@ class ProjectTestCase(unittest.TestCase):
                 ),
             )
             mock.put(
-                gazu.client.get_full_url("data/projects/%s" % fakeid("project-1")),
+                gazu.client.get_full_url(
+                    "data/projects/%s" % fakeid("project-1")
+                ),
                 text=json.dumps(
-                    {"id": fakeid("project-1"), "name": "project-1", "data": {}}
+                    {
+                        "id": fakeid("project-1"),
+                        "name": "project-1",
+                        "data": {},
+                    }
                 ),
             )
             project = gazu.project.update_project_data(fakeid("project-1"))
@@ -165,7 +196,9 @@ class ProjectTestCase(unittest.TestCase):
             )
 
             mock.put(
-                gazu.client.get_full_url("data/projects/%s" % fakeid("project-1")),
+                gazu.client.get_full_url(
+                    "data/projects/%s" % fakeid("project-1")
+                ),
                 text=json.dumps(
                     {
                         "id": fakeid("project-1"),
@@ -176,4 +209,6 @@ class ProjectTestCase(unittest.TestCase):
             )
 
             project = gazu.project.close_project(fakeid("project-1"))
-            self.assertEqual(project["project_status_id"], fakeid("project-status-1"))
+            self.assertEqual(
+                project["project_status_id"], fakeid("project-status-1")
+            )

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -13,7 +13,9 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/scenes/scene-1"),
-                text=json.dumps({"name": "Scene 01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"name": "Scene 01", "project_id": "project-01"}
+                ),
             )
             scene = gazu.scene.get_scene("scene-1")
             self.assertEqual(scene["name"], "Scene 01")
@@ -24,7 +26,9 @@ class SceneTestCase(unittest.TestCase):
                 gazu.client.get_full_url(
                     "data/scenes/all?parent_id=sequence-01&name=Scene01"
                 ),
-                text=json.dumps([{"name": "Scene01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Scene01", "project_id": "project-01"}]
+                ),
             )
             sequence = {"id": "sequence-01"}
             scene = gazu.scene.get_scene_by_name(sequence, "Scene01")
@@ -34,7 +38,9 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/projects/project-01/scenes"),
-                text=json.dumps([{"name": "Scene 01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Scene 01", "project_id": "project-01"}]
+                ),
             )
             project = {"id": "project-01"}
             scenes = gazu.scene.all_scenes_for_project(project)
@@ -95,7 +101,9 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.post(
                 gazu.client.get_full_url("data/projects/project-01/scenes"),
-                text=json.dumps({"id": "scene-01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"id": "scene-01", "project_id": "project-01"}
+                ),
             )
             project = {"id": "project-01"}
             sequence = {"id": "sequence-01"}
@@ -122,7 +130,9 @@ class SceneTestCase(unittest.TestCase):
     def test_all_camera_instances_for_scene(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/scenes/scene-1/camera-instances"),
+                gazu.client.get_full_url(
+                    "data/scenes/scene-1/camera-instances"
+                ),
                 text=json.dumps(
                     [
                         {
@@ -174,7 +184,9 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             result = {"id": "asset-instance-01"}
             mock = mock.post(
-                gazu.client.get_full_url("data/scenes/scene-1/asset-instances"),
+                gazu.client.get_full_url(
+                    "data/scenes/scene-1/asset-instances"
+                ),
                 text=json.dumps(result),
             )
             scene = {"id": "scene-1"}
@@ -185,7 +197,9 @@ class SceneTestCase(unittest.TestCase):
     def test_all_asset_instances_for_scene(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/scenes/scene-1/asset-instances"),
+                gazu.client.get_full_url(
+                    "data/scenes/scene-1/asset-instances"
+                ),
                 text=json.dumps(
                     [
                         {
@@ -210,12 +224,15 @@ class SceneTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/asset-instances?" "name=instance_name&scene_id=scene-1"
+                    "data/asset-instances?"
+                    "name=instance_name&scene_id=scene-1"
                 ),
                 text=json.dumps([instance]),
             )
             scene = {"id": "scene-1"}
-            result = gazu.scene.get_asset_instance_by_name(scene, "instance_name")
+            result = gazu.scene.get_asset_instance_by_name(
+                scene, "instance_name"
+            )
             self.assertEqual(instance, result)
 
     def test_update_asset_instance_name(self):
@@ -238,7 +255,9 @@ class SceneTestCase(unittest.TestCase):
                     }
                 ),
             )
-            instance = gazu.scene.update_asset_instance_name(instance, updated_name)
+            instance = gazu.scene.update_asset_instance_name(
+                instance, updated_name
+            )
             self.assertEqual(instance["name"], updated_name)
 
     def test_update_asset_instance_data(self):
@@ -258,12 +277,16 @@ class SceneTestCase(unittest.TestCase):
             asset_instance = gazu.scene.update_asset_instance_data(
                 fakeid("asset-instance-1"), {"extra-data": "extra-data"}
             )
-            self.assertEqual(asset_instance["data"], {"extra-data": "extra-data"})
+            self.assertEqual(
+                asset_instance["data"], {"extra-data": "extra-data"}
+            )
 
     def test_get_sequence_from_scene(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/sequences/%s" % fakeid("sequence-1")),
+                gazu.client.get_full_url(
+                    "data/sequences/%s" % fakeid("sequence-1")
+                ),
                 text=json.dumps(
                     {
                         "name": "sequence-1",
@@ -272,6 +295,9 @@ class SceneTestCase(unittest.TestCase):
                     }
                 ),
             )
-            scene = {"id": fakeid("scene-1"), "parent_id": fakeid("sequence-1")}
+            scene = {
+                "id": fakeid("scene-1"),
+                "parent_id": fakeid("sequence-1"),
+            }
             sequence = gazu.scene.get_sequence_from_scene(scene)
             self.assertEqual(sequence["name"], "sequence-1")

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -14,7 +14,9 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/projects/project-01/shots"),
-                text=json.dumps([{"name": "Shot 01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Shot 01", "project_id": "project-01"}]
+                ),
             )
             project = {"id": "project-01"}
             shots = gazu.shot.all_shots_for_project(project)
@@ -123,7 +125,9 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/episodes/episode-1"),
-                text=json.dumps({"name": "Episode 01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"name": "Episode 01", "project_id": "project-01"}
+                ),
             )
             episode = gazu.shot.get_episode("episode-1")
             self.assertEqual(episode["name"], "Episode 01")
@@ -132,7 +136,9 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/episodes/episode-1"),
-                text=json.dumps({"name": "Episode 01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"name": "Episode 01", "project_id": "project-01"}
+                ),
             )
             episode = gazu.shot.get_episode_from_sequence(
                 {"id": "shot-01", "parent_id": "episode-1"}
@@ -143,7 +149,9 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/sequences/sequence-01"),
-                text=json.dumps({"name": "Sequence 01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"name": "Sequence 01", "project_id": "project-01"}
+                ),
             )
             sequence = gazu.shot.get_sequence("sequence-01")
             self.assertEqual(sequence["name"], "Sequence 01")
@@ -152,7 +160,9 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/sequences/sequence-01"),
-                text=json.dumps({"name": "Sequence 01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"name": "Sequence 01", "project_id": "project-01"}
+                ),
             )
             sequence = gazu.shot.get_sequence_from_shot(
                 {"id": "shot-01", "parent_id": "sequence-01"}
@@ -163,7 +173,9 @@ class ShotTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/shots/shot-01"),
-                text=json.dumps({"name": "Shot 01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"name": "Shot 01", "project_id": "project-01"}
+                ),
             )
             shot = gazu.shot.get_shot("shot-01")
             self.assertEqual(shot["name"], "Shot 01")
@@ -174,7 +186,9 @@ class ShotTestCase(unittest.TestCase):
                 gazu.client.get_full_url(
                     "data/shots/all?sequence_id=sequence-01&name=Shot01"
                 ),
-                text=json.dumps([{"name": "Shot01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Shot01", "project_id": "project-01"}]
+                ),
             )
             sequence = {"id": "sequence-01"}
             shot = gazu.shot.get_shot_by_name(sequence, "Shot01")
@@ -186,7 +200,9 @@ class ShotTestCase(unittest.TestCase):
                 gazu.client.get_full_url(
                     "data/sequences?project_id=project-01&name=Sequence01"
                 ),
-                text=json.dumps([{"name": "Sequence01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Sequence01", "project_id": "project-01"}]
+                ),
             )
             project = {"id": "project-01"}
             sequence = gazu.shot.get_sequence_by_name(project, "Sequence01")
@@ -202,7 +218,9 @@ class ShotTestCase(unittest.TestCase):
             )
             mock.post(
                 gazu.client.get_full_url("data/projects/project-01/episodes"),
-                text=json.dumps({"id": "episode-01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"id": "episode-01", "project_id": "project-01"}
+                ),
             )
             project = {"id": "project-01"}
             shot = gazu.shot.new_episode(project, "Episode 01")
@@ -212,7 +230,9 @@ class ShotTestCase(unittest.TestCase):
                 gazu.client.get_full_url(
                     "data/episodes?project_id=project-01&name=Episode 01"
                 ),
-                text=json.dumps([{"id": "episode-01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"id": "episode-01", "project_id": "project-01"}]
+                ),
             )
 
             shot = gazu.shot.new_episode(project, "Episode 01")
@@ -228,7 +248,9 @@ class ShotTestCase(unittest.TestCase):
             )
             mock.post(
                 gazu.client.get_full_url("data/projects/project-01/sequences"),
-                text=json.dumps({"id": "sequence-01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"id": "sequence-01", "project_id": "project-01"}
+                ),
             )
             project = {"id": "project-01"}
             episode = {"id": "episode-1"}
@@ -241,7 +263,9 @@ class ShotTestCase(unittest.TestCase):
             )
             mock.post(
                 gazu.client.get_full_url("data/projects/project-01/sequences"),
-                text=json.dumps({"id": "sequence-01", "project_id": "project-01"}),
+                text=json.dumps(
+                    {"id": "sequence-01", "project_id": "project-01"}
+                ),
             )
             project = {"id": "project-01"}
             shot = gazu.shot.new_sequence(project, "Sequence 01")
@@ -249,7 +273,9 @@ class ShotTestCase(unittest.TestCase):
 
             mock.get(
                 gazu.client.get_full_url("data/sequences?name=Sequence 01"),
-                text=json.dumps([{"id": "sequence-01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"id": "sequence-01", "project_id": "project-01"}]
+                ),
             )
 
             project = {"id": "project-01"}
@@ -271,7 +297,12 @@ class ShotTestCase(unittest.TestCase):
             project = {"id": "project-01"}
             sequence = {"id": "sequence-01"}
             shot = gazu.shot.new_shot(
-                project, sequence, "Shot 01", nb_frames=10, frame_in=10, frame_out=20
+                project,
+                sequence,
+                "Shot 01",
+                nb_frames=10,
+                frame_in=10,
+                frame_out=20,
             )
             self.assertEqual(shot["id"], "shot-01")
             sent_data = json.loads(mock.request_history[0].text)
@@ -282,11 +313,18 @@ class ShotTestCase(unittest.TestCase):
                 gazu.client.get_full_url(
                     "data/shots/all?sequence_id=sequence-01&name=Shot 01"
                 ),
-                text=json.dumps([{"id": "shot-01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"id": "shot-01", "project_id": "project-01"}]
+                ),
             )
 
             shot = gazu.shot.new_shot(
-                project, sequence, "Shot 01", nb_frames=10, frame_in=10, frame_out=20
+                project,
+                sequence,
+                "Shot 01",
+                nb_frames=10,
+                frame_in=10,
+                frame_out=20,
             )
             self.assertEqual(shot["id"], "shot-01")
 
@@ -302,7 +340,9 @@ class ShotTestCase(unittest.TestCase):
 
     def test_remove_shot(self):
         with requests_mock.mock() as mock:
-            mock.delete(gazu.client.get_full_url("data/shots/shot-01"), status_code=204)
+            mock.delete(
+                gazu.client.get_full_url("data/shots/shot-01"), status_code=204
+            )
             shot = {"id": "shot-01", "name": "S02"}
             gazu.shot.remove_shot(shot)
             mock.delete(
@@ -315,7 +355,9 @@ class ShotTestCase(unittest.TestCase):
     def test_remove_sequence(self):
         with requests_mock.mock() as mock:
             mock.delete(
-                gazu.client.get_full_url("data/sequences/sequence-01?force=true"),
+                gazu.client.get_full_url(
+                    "data/sequences/sequence-01?force=true"
+                ),
                 status_code=204,
             )
             sequence = {"id": "sequence-01", "name": "S02"}
@@ -350,7 +392,9 @@ class ShotTestCase(unittest.TestCase):
             )
             shot = {"id": "shot-01"}
             asset_instance = {"id": "asset-instance-1"}
-            asset_instance = gazu.shot.add_asset_instance_to_shot(shot, asset_instance)
+            asset_instance = gazu.shot.add_asset_instance_to_shot(
+                shot, asset_instance
+            )
             self.assertEqual(asset_instance, result)
 
     def test_remove_asset_instance(self):
@@ -392,7 +436,11 @@ class ShotTestCase(unittest.TestCase):
                 "episodes/episode-01/shots/shot-01/",
             )
 
-            shot = {"id": "shot-01", "project_id": "project-01", "episode_id": None}
+            shot = {
+                "id": "shot-01",
+                "project_id": "project-01",
+                "episode_id": None,
+            }
             project = {
                 "id": "project-01",
                 "production_type": "tvshow",
@@ -407,7 +455,8 @@ class ShotTestCase(unittest.TestCase):
             )
             url = gazu.shot.get_shot_url(fakeid("shot-01"))
             self.assertEqual(
-                url, "http://gazu-server/productions/project-01/" "shots/shot-01/"
+                url,
+                "http://gazu-server/productions/project-01/" "shots/shot-01/",
             )
 
     def test_all_sequences_for_episode(self):
@@ -446,7 +495,9 @@ class ShotTestCase(unittest.TestCase):
     def test_get_episode_url(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/episodes/%s" % fakeid("episode-1")),
+                gazu.client.get_full_url(
+                    "data/episodes/%s" % fakeid("episode-1")
+                ),
                 text=json.dumps(
                     {
                         "id": fakeid("episode-1"),
@@ -458,14 +509,19 @@ class ShotTestCase(unittest.TestCase):
             self.assertEqual(
                 url,
                 "http://gazu-server/productions/%s/"
-                "episodes/%s/shots" % (fakeid("project-1"), fakeid("episode-1")),
+                "episodes/%s/shots"
+                % (fakeid("project-1"), fakeid("episode-1")),
             )
 
     def test_update_sequence(self):
         with requests_mock.mock() as mock:
             mock.put(
-                gazu.client.get_full_url("data/entities/%s" % fakeid("sequence-1")),
-                text=json.dumps({"id": fakeid("sequence-1"), "name": "sequence-1"}),
+                gazu.client.get_full_url(
+                    "data/entities/%s" % fakeid("sequence-1")
+                ),
+                text=json.dumps(
+                    {"id": fakeid("sequence-1"), "name": "sequence-1"}
+                ),
             )
             sequence = {"id": fakeid("sequence-1"), "name": "sequence-1"}
             sequence = gazu.shot.update_sequence(sequence)
@@ -479,15 +535,27 @@ class ShotTestCase(unittest.TestCase):
                 ),
                 text=json.dumps(
                     [
-                        {"id": fakeid("asset_instance-1"), "name": "asset_instance-1"},
-                        {"id": fakeid("asset_instance-2"), "name": "asset_instance-2"},
+                        {
+                            "id": fakeid("asset_instance-1"),
+                            "name": "asset_instance-1",
+                        },
+                        {
+                            "id": fakeid("asset_instance-2"),
+                            "name": "asset_instance-2",
+                        },
                     ]
                 ),
             )
-            asset_instances = gazu.shot.get_asset_instances_for_shot(fakeid("shot-1"))
+            asset_instances = gazu.shot.get_asset_instances_for_shot(
+                fakeid("shot-1")
+            )
             self.assertEqual(len(asset_instances), 2)
-            self.assertEqual(asset_instances[0]["id"], fakeid("asset_instance-1"))
-            self.assertEqual(asset_instances[1]["id"], fakeid("asset_instance-2"))
+            self.assertEqual(
+                asset_instances[0]["id"], fakeid("asset_instance-1")
+            )
+            self.assertEqual(
+                asset_instances[1]["id"], fakeid("asset_instance-2")
+            )
 
     def test_update_shot_data(self):
         with requests_mock.mock() as mock:
@@ -496,9 +564,14 @@ class ShotTestCase(unittest.TestCase):
                 text=json.dumps({"id": fakeid("shot-1"), "data": {}}),
             )
             mock.put(
-                gazu.client.get_full_url("data/entities/%s" % fakeid("shot-1")),
+                gazu.client.get_full_url(
+                    "data/entities/%s" % fakeid("shot-1")
+                ),
                 text=json.dumps(
-                    {"id": fakeid("shot-1"), "data": {"metadata-1": "metadata-1"}}
+                    {
+                        "id": fakeid("shot-1"),
+                        "data": {"metadata-1": "metadata-1"},
+                    }
                 ),
             )
             data = {"metadata-1": "metadata-1"}
@@ -508,23 +581,34 @@ class ShotTestCase(unittest.TestCase):
     def test_update_sequence_data(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/sequences/%s" % fakeid("sequence-1")),
+                gazu.client.get_full_url(
+                    "data/sequences/%s" % fakeid("sequence-1")
+                ),
                 text=json.dumps({"id": fakeid("sequence-1"), "data": {}}),
             )
             mock.put(
-                gazu.client.get_full_url("data/entities/%s" % fakeid("sequence-1")),
+                gazu.client.get_full_url(
+                    "data/entities/%s" % fakeid("sequence-1")
+                ),
                 text=json.dumps(
-                    {"id": fakeid("sequence-1"), "data": {"metadata-1": "metadata-1"}}
+                    {
+                        "id": fakeid("sequence-1"),
+                        "data": {"metadata-1": "metadata-1"},
+                    }
                 ),
             )
             data = {"metadata-1": "metadata-1"}
-            sequence = gazu.shot.update_sequence_data(fakeid("sequence-1"), data)
+            sequence = gazu.shot.update_sequence_data(
+                fakeid("sequence-1"), data
+            )
             self.assertEqual(sequence["data"]["metadata-1"], "metadata-1")
 
     def test_update_episode(self):
         with requests_mock.mock() as mock:
             mock.put(
-                gazu.client.get_full_url("data/entities/%s" % fakeid("episode-1")),
+                gazu.client.get_full_url(
+                    "data/entities/%s" % fakeid("episode-1")
+                ),
                 text=json.dumps(
                     {"id": fakeid("episode-1"), "project_id": "project-01"}
                 ),
@@ -536,13 +620,20 @@ class ShotTestCase(unittest.TestCase):
     def test_update_episode_data(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/sequences/%s" % fakeid("episode-1")),
+                gazu.client.get_full_url(
+                    "data/sequences/%s" % fakeid("episode-1")
+                ),
                 text=json.dumps({"id": fakeid("episode-1"), "data": {}}),
             )
             mock.put(
-                gazu.client.get_full_url("data/entities/%s" % fakeid("episode-1")),
+                gazu.client.get_full_url(
+                    "data/entities/%s" % fakeid("episode-1")
+                ),
                 text=json.dumps(
-                    {"id": fakeid("episode-1"), "data": {"metadata-1": "metadata-1"}}
+                    {
+                        "id": fakeid("episode-1"),
+                        "data": {"metadata-1": "metadata-1"},
+                    }
                 ),
             )
             data = {"metadata-1": "metadata-1"}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -43,12 +43,16 @@ class SyncestCase(unittest.TestCase):
             {"id": "asset-3"},
         ]
         target_list = [{"id": "asset-2"}, {"id": "asset-4"}]
-        (missing, unexpected) = gazu.sync.get_model_list_diff(source_list, target_list)
+        (missing, unexpected) = gazu.sync.get_model_list_diff(
+            source_list, target_list
+        )
         self.assertEqual(missing, [{"id": "asset-1"}, {"id": "asset-3"}])
         self.assertEqual(unexpected, [{"id": "asset-4"}])
         source_list = []
         target_list = []
-        (missing, unexpected) = gazu.sync.get_model_list_diff(source_list, target_list)
+        (missing, unexpected) = gazu.sync.get_model_list_diff(
+            source_list, target_list
+        )
         self.assertEqual(missing, [])
         self.assertEqual(unexpected, [])
 
@@ -62,7 +66,9 @@ class SyncestCase(unittest.TestCase):
             {"entity_in_id": "shot-2", "entity_out_id": "asset-2"},
             {"entity_in_id": "shot-4", "entity_out_id": "asset-4"},
         ]
-        (missing, unexpected) = gazu.sync.get_link_list_diff(source_list, target_list)
+        (missing, unexpected) = gazu.sync.get_link_list_diff(
+            source_list, target_list
+        )
         self.assertEqual(
             missing,
             [
@@ -78,7 +84,9 @@ class SyncestCase(unittest.TestCase):
         )
         source_list = []
         target_list = []
-        (missing, unexpected) = gazu.sync.get_link_list_diff(source_list, target_list)
+        (missing, unexpected) = gazu.sync.get_link_list_diff(
+            source_list, target_list
+        )
         self.assertEqual(missing, [])
         self.assertEqual(unexpected, [])
 
@@ -106,7 +114,9 @@ class SyncestCase(unittest.TestCase):
             self.assertEqual(gazu.sync.get_last_events(), result)
             self.assertEqual(
                 gazu.sync.get_last_events(
-                    project=fakeid("project-1"), after="2021-11-06", before="2021-11-06"
+                    project=fakeid("project-1"),
+                    after="2021-11-06",
+                    before="2021-11-06",
                 ),
                 result,
             )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -13,7 +13,9 @@ class TaskTestCase(unittest.TestCase):
     def test_all_for_shot(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/shots/shot-01/tasks?relations=true"),
+                gazu.client.get_full_url(
+                    "data/shots/shot-01/tasks?relations=true"
+                ),
                 text=json.dumps(
                     [
                         {"id": 1, "name": "Master Compositing"},
@@ -49,7 +51,9 @@ class TaskTestCase(unittest.TestCase):
     def test_all_for_asset(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/assets/asset-01/tasks?relations=true"),
+                gazu.client.get_full_url(
+                    "data/assets/asset-01/tasks?relations=true"
+                ),
                 text=json.dumps(
                     [
                         {"id": "task-01", "name": "Master Modeling"},
@@ -134,7 +138,9 @@ class TaskTestCase(unittest.TestCase):
                     "data/tasks?name=Task%2001&entity_id=entity-01&"
                     "task_type_id=modeling-1"
                 ),
-                text=json.dumps([{"name": "Task 01", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "Task 01", "project_id": "project-01"}]
+                ),
             )
             test_task = gazu.task.get_task_by_name(
                 {"id": "entity-01"}, {"id": "modeling-1"}, "Task 01"
@@ -162,7 +168,9 @@ class TaskTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/tasks/from-path"),
                 text=json.dumps({"id": "task-id"}),
             )
-            task = gazu.task.get_task_by_path({"id": "project-id"}, file_path, "shot")
+            task = gazu.task.get_task_by_path(
+                {"id": "project-id"}, file_path, "shot"
+            )
             request_body_string = mock.request_history[0].body.decode("utf-8")
             request_body = json.loads(request_body_string)
             self.assertEqual(request_body["project_id"], "project-id")
@@ -195,7 +203,9 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.put(
                 gazu.client.get_full_url("actions/tasks/task-01/start"),
-                text=json.dumps({"name": "Task 01", "task_status_id": "wip-1"}),
+                text=json.dumps(
+                    {"name": "Task 01", "task_status_id": "wip-1"}
+                ),
             )
             test_task = gazu.task.start_task({"id": "task-01"})
             self.assertEqual(test_task["task_status_id"], "wip-1")
@@ -204,7 +214,9 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.put(
                 gazu.client.get_full_url("actions/tasks/task-01/to-review"),
-                text=json.dumps({"name": "Task 01", "task_status_id": "wfa-1"}),
+                text=json.dumps(
+                    {"name": "Task 01", "task_status_id": "wfa-1"}
+                ),
             )
             test_task = gazu.task.task_to_review(
                 {"id": "task-01"}, {"id": "person-01"}, "my comment"
@@ -221,16 +233,21 @@ class TaskTestCase(unittest.TestCase):
                 gazu.client.get_full_url(
                     "actions/tasks/task-01/time-spents/2017-09-23"
                 ),
-                text=json.dumps({"person1": {"duration": 3600}, "total": 3600}),
+                text=json.dumps(
+                    {"person1": {"duration": 3600}, "total": 3600}
+                ),
             )
-            time_spents = gazu.task.get_time_spent({"id": "task-01"}, "2017-09-23")
+            time_spents = gazu.task.get_time_spent(
+                {"id": "task-01"}, "2017-09-23"
+            )
             self.assertEqual(time_spents["total"], 3600)
 
     def test_set_time_spent(self):
         with requests_mock.mock() as mock:
             mock.post(
                 gazu.client.get_full_url(
-                    "actions/tasks/task-01/time-spents/2017-09-23/" "persons/person-01"
+                    "actions/tasks/task-01/time-spents/2017-09-23/"
+                    "persons/person-01"
                 ),
                 text=json.dumps({"id": "time-spent-01", "duration": 3600}),
             )
@@ -280,7 +297,9 @@ class TaskTestCase(unittest.TestCase):
             project = {"id": "project-01"}
             task_type = {"id": "task-type-01"}
             task_status = {"id": "task-status-01"}
-            tasks = gazu.task.all_tasks_for_task_status(project, task_type, task_status)
+            tasks = gazu.task.all_tasks_for_task_status(
+                project, task_type, task_status
+            )
             self.assertEqual(tasks, result)
 
     def test_all_tasks_for_person(self):
@@ -336,7 +355,9 @@ class TaskTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/task-status?name=Todo"),
                 text=json.dumps([{"id": fakeid("task-status-01")}]),
             )
-            mock.post(gazu.client.get_full_url("data/tasks"), text=json.dumps(result))
+            mock.post(
+                gazu.client.get_full_url("data/tasks"), text=json.dumps(result)
+            )
             asset = {
                 "id": fakeid("asset-01"),
                 "project_id": fakeid("project-01"),
@@ -349,10 +370,15 @@ class TaskTestCase(unittest.TestCase):
                 "id": fakeid("task-01"),
                 "data": {
                     "assigner_id": fakeid("assigner-1"),
-                    "assignees": [fakeid("assignees-1"), fakeid("assignees-2")],
+                    "assignees": [
+                        fakeid("assignees-1"),
+                        fakeid("assignees-2"),
+                    ],
                 },
             }
-            mock.post(gazu.client.get_full_url("data/tasks"), text=json.dumps(result))
+            mock.post(
+                gazu.client.get_full_url("data/tasks"), text=json.dumps(result)
+            )
 
             task = gazu.task.new_task(
                 asset,
@@ -378,7 +404,11 @@ class TaskTestCase(unittest.TestCase):
             task_status = {"id": "task-status-01"}
             comment = "New comment"
             comment = gazu.task.add_comment(
-                task, task_status, comment, person=fakeid("person-1"), created_at=date
+                task,
+                task_status,
+                comment,
+                person=fakeid("person-1"),
+                created_at=date,
             )
             self.assertEqual(comment, result)
 
@@ -410,9 +440,13 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.put(
                 gazu.client.get_full_url("actions/persons/person-01/assign"),
-                text=json.dumps([{"id": "task-01", "assignees": ["person-01"]}]),
+                text=json.dumps(
+                    [{"id": "task-01", "assignees": ["person-01"]}]
+                ),
             )
-            task = gazu.task.assign_task({"id": "task-01"}, {"id": "person-01"})[0]
+            task = gazu.task.assign_task(
+                {"id": "task-01"}, {"id": "person-01"}
+            )[0]
             self.assertIn("person-01", task["assignees"])
 
     def test_new_task_type(self):
@@ -440,7 +474,9 @@ class TaskTestCase(unittest.TestCase):
                 gazu.client.get_full_url("data/task-status"),
                 text=json.dumps(status),
             )
-            self.assertEqual(gazu.task.new_task_status(name, short_name, color), status)
+            self.assertEqual(
+                gazu.task.new_task_status(name, short_name, color), status
+            )
 
     def test_set_main_preview(self):
         with requests_mock.mock() as mock:
@@ -550,7 +586,8 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/episodes/%s/shot-tasks?relations=true" % (fakeid("episode-1"))
+                    "data/episodes/%s/shot-tasks?relations=true"
+                    % (fakeid("episode-1"))
                 ),
                 text=json.dumps(
                     [
@@ -580,7 +617,9 @@ class TaskTestCase(unittest.TestCase):
 
             entity = {"id": fakeid("entity-1")}
             task_type = {"id": fakeid("task-type-1")}
-            tasks = gazu.task.all_tasks_for_entity_and_task_type(entity, task_type)
+            tasks = gazu.task.all_tasks_for_entity_and_task_type(
+                entity, task_type
+            )
             task = tasks[0]
             self.assertEqual(task["name"], "Master Compositing")
 
@@ -631,7 +670,9 @@ class TaskTestCase(unittest.TestCase):
                     "data/tasks?name=main&entity_id=entity-01&"
                     "task_type_id=modeling-1"
                 ),
-                text=json.dumps([{"name": "main", "project_id": "project-01"}]),
+                text=json.dumps(
+                    [{"name": "main", "project_id": "project-01"}]
+                ),
             )
             test_task = gazu.task.get_task_by_entity(
                 {"id": "entity-01"}, {"id": "modeling-1"}
@@ -674,7 +715,9 @@ class TaskTestCase(unittest.TestCase):
     def test_remove_task(self):
         with requests_mock.mock() as mock:
             mock.delete(
-                gazu.client.get_full_url("data/tasks/%s?force=true" % fakeid("task-1")),
+                gazu.client.get_full_url(
+                    "data/tasks/%s?force=true" % fakeid("task-1")
+                ),
                 status_code=204,
             )
             gazu.task.remove_task(fakeid("task-1"))
@@ -692,13 +735,18 @@ class TaskTestCase(unittest.TestCase):
     def test_update_task_data(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/tasks/%s/full" % fakeid("task-1")),
+                gazu.client.get_full_url(
+                    "data/tasks/%s/full" % fakeid("task-1")
+                ),
                 text=json.dumps({"id": fakeid("task-1"), "data": {}}),
             )
             mock.put(
                 gazu.client.get_full_url("data/tasks/%s" % fakeid("task-1")),
                 text=json.dumps(
-                    {"id": fakeid("task-1"), "data": {"metadata-1": "metadata-1"}}
+                    {
+                        "id": fakeid("task-1"),
+                        "data": {"metadata-1": "metadata-1"},
+                    }
                 ),
             )
             data = {"metadata-1": "metadata-1"}
@@ -706,7 +754,9 @@ class TaskTestCase(unittest.TestCase):
             self.assertEqual(task["data"]["metadata-1"], "metadata-1")
 
             mock.get(
-                gazu.client.get_full_url("data/tasks/%s/full" % fakeid("task-1")),
+                gazu.client.get_full_url(
+                    "data/tasks/%s/full" % fakeid("task-1")
+                ),
                 text=json.dumps({"id": fakeid("task-1"), "data": None}),
             )
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -40,7 +40,8 @@ class ProjectTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "GET",
-                "data/user/projects/project-01/asset-types/asset-type-01" "/assets",
+                "data/user/projects/project-01/asset-types/asset-type-01"
+                "/assets",
                 text=[{"name": "Chair", "id": "asset-01"}],
             )
 
@@ -77,7 +78,9 @@ class ProjectTestCase(unittest.TestCase):
     def test_tasks_for_sequence(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/user/sequences/sequence-1/tasks"),
+                gazu.client.get_full_url(
+                    "data/user/sequences/sequence-1/tasks"
+                ),
                 text=json.dumps([{"name": "main", "id": "task-01"}]),
             )
             sequence = {"id": "sequence-1"}
@@ -142,7 +145,9 @@ class ProjectTestCase(unittest.TestCase):
     def test_shot_for_sequences(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/user/sequences/sequence-01/shots"),
+                gazu.client.get_full_url(
+                    "data/user/sequences/sequence-01/shots"
+                ),
                 text=json.dumps([{"name": "SEQ01", "id": "shot-01"}]),
             )
             sequence = {"id": "sequence-01"}
@@ -268,5 +273,7 @@ class ProjectTestCase(unittest.TestCase):
             )
 
             log_desktop_session_log_in = gazu.user.log_desktop_session_log_in()
-            self.assertEqual(log_desktop_session_log_in["id"], fakeid("user-1"))
+            self.assertEqual(
+                log_desktop_session_log_in["id"], fakeid("user-1")
+            )
             self.assertEqual(log_desktop_session_log_in["date"], date_str)


### PR DESCRIPTION
**Problem**
Black python code formater was previously with line-length at 89. 

**Solution**
Pass black on every python files and set the line-length at 79 in a config file.
