### PR TITLE
Travis not passing

### DIFF
--- a/gazu/helpers.py
+++ b/gazu/helpers.py
@@ -39,11 +39,8 @@ def validate_date_format(date_text):
         try:
             datetime.datetime.strptime(date_text, "%Y-%m-%d")
         except ValueError:
-            try:
-                datetime.datetime.fromisoformat(date_text)
-            except:
-                raise ValueError(
-                    "Incorrect date format for %s, should be YYYY-mm-dd or YYYY-mm-ddTHH:MM:SS"
-                    % date_text
-                )
+            raise ValueError(
+                "Incorrect date format for %s, should be YYYY-mm-dd or YYYY-mm-ddTHH:MM:SS"
+                % date_text
+            )
     return date_text

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
-pytest==6.2.5
+pytest==6.2.5; python_version>=3.6
+pytest==4.6.11; python_version==2.7
 pytest-cov==2.12.1 
 requests_mock==1.9.3
 pre-commit==2.15.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
-pytest==6.2.5; python_version>=3.6
-pytest==4.6.11; python_version==2.7
+pytest==6.2.5; python_version>='3.6'
+pytest==4.6.11; python_version=='2.7'
 pytest-cov==2.12.1 
 requests_mock==1.9.3
-pre-commit==2.15.0; python_version>=3.6
-pre-commit==1.21.0; python_version==2.7
+pre-commit==2.15.0; python_version>='3.6'
+pre-commit==1.21.0; python_version=='2.7'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,5 @@ pytest==6.2.5; python_version>=3.6
 pytest==4.6.11; python_version==2.7
 pytest-cov==2.12.1 
 requests_mock==1.9.3
-pre-commit==2.15.0
+pre-commit==2.15.0; python_version>=3.6
+pre-commit==1.21.0; python_version==2.7

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,7 +31,6 @@ class TestCase(unittest.TestCase):
     def test_validate_date_format(self):
         helpers.validate_date_format("2021-11-06")
         helpers.validate_date_format("2021-11-06T11:25:59")
-        helpers.validate_date_format(datetime.datetime.now().isoformat())
         try:
             helpers.validate_date_format("")
         except Exception as e:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -390,7 +390,7 @@ class TaskTestCase(unittest.TestCase):
 
     def test_add_comment(self):
         with requests_mock.mock() as mock:
-            date = datetime.datetime.now().isoformat()
+            date = "2021-03-13T18:47:15"
             result = {
                 "id": "comment-1",
                 "person_id": fakeid("person-1"),


### PR DESCRIPTION
**Problem**
Problem with the requirements_tests.txt for python2.7 and datetime.datetime has no attribute 'fromisoformat' in python < 3.7

**Solution**
Conditionnal requirements for python 2.7.
Remove the part with fromisoformat, it's useless because Zou doesn't use this for parsing date.
