### PR TITLE
Fix requirements after socketio client refactoring.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.6"
 install: 
   - "pip install -r requirements.txt"
-  - "pip install -r requirements_test.txt"
   - "python setup.py install"
 script: py.test
 branches:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-python-socketio[client]==5.2.1; python_version == "2.7"
-python-socketio[client]==5.3.0; python_version == "3.5"
-python-socketio[client]==5.4.0; python_version > "3.5"
-requests==2.26.0
-deprecated==1.2.13
+-e .[dev,test]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,9 @@ dev =
     wheel
 
 test =
-    pytest==4.6.11
-    pytest-cov==2.10.0
-    requests_mock==1.5.2
+    pytest==6.2.5; python_version>='3.6'
+    pytest==4.6.11; python_version=='2.7'
+    pytest-cov==2.12.1
+    requests_mock==1.9.3
+    pre-commit==2.15.0; python_version>='3.6'
+    pre-commit==1.21.0; python_version=='2.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 name = gazu
 description = Gazu is a client for Zou, the API to store the data of your CG production.
 long_description = file: README.rst
-version = attr: gazu.__version__.__version__
 keywords = cg, production, asset manager, asset, shot, tasks, tracking
 license = GNU Library or Lesser General Public License (LGPL)
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,11 @@ classifiers =
 zip_safe = False
 packages = find:
 install_requires =
-    socketio-client==0.7.2
-    deprecated==1.1.0
-    requests==2.24.0
+    python-socketio[client]==5.2.1; python_version == "2.7"
+    python-socketio[client]==5.3.0; python_version == "3.5"
+    python-socketio[client]==5.4.0; python_version > "3.5"
+    deprecated==1.2.13
+    requests==2.26.0
 
 [options.packages.find]
 # ignore gazutest directory

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,4 @@ versionpath = os.path.join(os.path.dirname(__file__), "gazu/__version__.py")
 with open(versionpath, "r") as file:
     __version__ = ast.literal_eval(re.search('__version__ *= *(\S+)', file.read()).group(1))
 
-setup()
+setup(version=__version__)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python
+import ast
+import re
+import os
+
 from setuptools import setup
 
-from gazu.__version__ import __version__
+
+# We hack our way into getting the version from gazu without imports :
+# running gazu/__init__.py would cause errors due to the import of dependencies yet to be installed
+versionpath = os.path.join(os.path.dirname(__file__), "gazu/__version__.py")
+with open(versionpath, "r") as file:
+    __version__ = ast.literal_eval(re.search('__version__ *= *(\S+)', file.read()).group(1))
 
 setup()

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python
-import ast
-import re
-import os
-
 from setuptools import setup
+from distutils.util import convert_path
 
+# Get version without sourcing gazu module
+# (to avoid importing dependencies yet to be installed)
+main_ns = {}
+with open(convert_path('gazu/__version__.py')) as ver_file:
+    exec(ver_file.read(), main_ns)
 
-# We hack our way into getting the version from gazu without imports :
-# running gazu/__init__.py would cause errors due to the import of dependencies yet to be installed
-versionpath = os.path.join(os.path.dirname(__file__), "gazu/__version__.py")
-with open(versionpath, "r") as file:
-    __version__ = ast.literal_eval(re.search('__version__ *= *(\S+)', file.read()).group(1))
-
-setup(version=__version__)
+setup(version=main_ns['__version__'])


### PR DESCRIPTION
**Problem**
After installing gazu in a clean environment through *pip*, we get an import error (see #198)

```(venv) C:\Users\aboellinger>python -c "import gazu"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\aboellinger\venv\lib\site-packages\gazu\__init__.py", line 4, in <module>
    from . import events
  File "C:\Users\aboellinger\venv\lib\site-packages\gazu\events.py", line 4, in <module>
    import socketio
ModuleNotFoundError: No module named 'socketio'
```

**Solution**
- Having a single source of truth regarding dependencies (`setup.cfg`, with requirements.txt "referencing it" with `-e .`)
- Changes also introduced to `setup.py` to avoid importing gazu dependencies before we install them. 