### PR TITLE
SocketIO + python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
-install: 
-  - "python setup.py install"
+install:
   - "pip install -r requirements.txt"
 script: py.test
 branches:

--- a/gazu/events.py
+++ b/gazu/events.py
@@ -2,6 +2,7 @@ from .exception import AuthFailedException
 from .client import default_client, get_event_host
 from gazu.client import make_auth_header
 import socketio
+import sys
 
 
 class EventsNamespace(socketio.ClientNamespace):
@@ -22,8 +23,8 @@ def init(client=default_client, ssl_verify=False):
     Returns:
         Event client that will be able to set listeners.
     """
-
-    event_client = socketio.Client(reconnection=False, ssl_verify=ssl_verify)
+    params = {"ssl_verify": ssl_verify} if sys.version_info[0] > 3 else {}
+    event_client = socketio.Client(**params)
     event_client.on("connect_error", connect_error)
     event_client.register_namespace(EventsNamespace("/events"))
     event_client.connect(get_event_host(client), make_auth_header())

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,11 @@ classifiers =
 zip_safe = False
 packages = find:
 install_requires =
-    python-socketio[client]==4.6.1; python_version == "2.7"
-    python-socketio[client]==5.3.0; python_version == "3.5"
-    python-socketio[client]==5.4.0; python_version > "3.5"
-    websocket-client==0.59.0; python_version == "2.7"
-    python-engineio==3.13.2; python_version == "2.7"
+    python-socketio[client]==4.2.1; python_version == "2.7"
+    python-socketio[client]==4.6.1; python_version >= "3.5"
     deprecated==1.2.13
-    requests==2.26.0
+    requests==2.26.0; python_version != "3.5"
+    requests==2.25.1; python_version == "3.5"
 
 [options.packages.find]
 # ignore gazutest directory
@@ -43,9 +41,10 @@ dev =
     wheel
 
 test =
-    pytest==6.2.5; python_version>='3.6'
-    pytest==4.6.11; python_version=='2.7'
+    pytest==6.2.5; python_version >= "3.6"
+    pytest==6.1.2; python_version == "3.5"
+    pytest==4.6.11; python_version == "2.7"
     pytest-cov==2.12.1
     requests_mock==1.9.3
-    pre-commit==2.15.0; python_version>='3.6'
-    pre-commit==1.21.0; python_version=='2.7'
+    pre-commit==2.15.0; python_version >= "3.6"
+    pre-commit==1.21.0; python_version == "2.7" or python_version == "3.5"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,11 @@ classifiers =
     Intended Audience :: Developers
     Natural Language :: English
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ from distutils.util import convert_path
 # Get version without sourcing gazu module
 # (to avoid importing dependencies yet to be installed)
 main_ns = {}
-with open(convert_path('gazu/__version__.py')) as ver_file:
+with open(convert_path("gazu/__version__.py")) as ver_file:
     exec(ver_file.read(), main_ns)
 
-setup(version=main_ns['__version__'])
+setup(
+    version=main_ns["__version__"],
+    python_requires=">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+)


### PR DESCRIPTION
**Problem**
The previous version of socketIO is not working with python 2.7
Gazu isn't working with python 3.4

**Solution**
Use a correct version of python-socketio to work with python 2.7 and Zou : [documentation](https://python-socketio.readthedocs.io/en/latest/intro.html)
Drop support for python 3.4