### PR TITLE
[qa] add downloads count on pip badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ tools!
 It is made to be used with the `Zou API <https://zou.cg-wire.com>`__. It
 requires an up and running instance of Zou to run properly.
 
-|Build status| |Discord|
+|Build status| |Discord| |Downloads|
 
 Quickstart
 ----------
@@ -123,3 +123,5 @@ Visit `cg-wire.com <https://cg-wire.com>`__ for more information.
    :target: https://discord.com/invite/VbCxtKN
 .. |CGWire Logo| image:: https://zou.cg-wire.com/cgwire.png
    :target: https://cg-wire.com
+.. |Downloads| image:: https://static.pepy.tech/personalized-badge/gazu?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads
+ :target: https://pepy.tech/project/gazu


### PR DESCRIPTION
**Problem**
No downloads count for pip badge in the readme.rst

**Solution**
Add a download badge
