### PR TITLE
Proposal to fixed the "gazu.files.get_all_preview_files_for_task(task)" issue (#206)

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -161,7 +161,7 @@ def get_all_preview_files_for_task(task, client=default):
     task = normalize_model_parameter(task)
     comments = tsk.all_comments_for_task(task)
     return list(chain.from_iterable(
-        [comment['previews'] for comment in comments if comment['previews']]
+        comment['previews'] for comment in comments if comment['previews']
     ))
 
 

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -1,4 +1,5 @@
 from . import client as raw
+from . import task as tsk
 
 from .cache import cache
 from .helpers import normalize_model_parameter
@@ -156,9 +157,8 @@ def get_all_preview_files_for_task(task, client=default):
         task (str, id): Target task
     """
     task = normalize_model_parameter(task)
-    return raw.fetch_all(
-        "preview-files", {"task_id": task["id"]}, client=client
-    )
+    comments = tsk.all_comments_for_task(task)
+    return [comment['previews'][0] for comment in comments if comment['previews']]
 
 
 def all_output_files_for_entity(

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 from . import client as raw
 from . import task as tsk
 
@@ -158,7 +160,9 @@ def get_all_preview_files_for_task(task, client=default):
     """
     task = normalize_model_parameter(task)
     comments = tsk.all_comments_for_task(task)
-    return [comment['previews'][0] for comment in comments if comment['previews']]
+    return list(chain.from_iterable(
+        [comment['previews'] for comment in comments if comment['previews']]
+    ))
 
 
 def all_output_files_for_entity(


### PR DESCRIPTION
**Problem**
gazu.files.get_all_preview_files_for_task(task) gives all the Kitsu instance previews instead of giving the previews linked to the task we give in parameter.

**Solution**
Instead of sending a request to Zou API to get the previews, we get them from the task comment data. For a given task we get all the associated comments. For each comment we get all the linked previews and add them to the returned list.

Linked issue #206
