### PR TITLE
fix return value of gazu.task.add_preview with updated info from raw.upload()

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -755,13 +755,12 @@ def add_preview(
         dict: Created preview file model.
     """
     preview_file = create_preview(task, comment, client=client)
-    upload_preview_file(
+    return upload_preview_file(
         preview_file,
         preview_file_path,
         normalize_movie=normalize_movie,
         client=client,
     )
-    return preview_file
 
 
 def set_main_preview(preview_file, client=default):


### PR DESCRIPTION
**Problem**
Right now the returned dict from `gazu.task.add_preview` is missing the `original name` value, because the returned dict is the one from `gazu.task.create_preview` and not `gazu.task.upload_preview_file`.

**Solution**
directly return the result from `upload_preview_file`