### PR TITLE
[events] fix wrong name of event for task:status-change : it's task:s…

### DIFF
--- a/docs/source/events.md
+++ b/docs/source/events.md
@@ -57,7 +57,7 @@ events emitted that way:
 * shot:casting-update
 * task:unassign
 * task:assign
-* task:status-change
+* task:status-changed
 
 ## Event table
 


### PR DESCRIPTION
**Problem**
Wrong name of event in documentation : task:status-change it's task:status-changed

**Solution**
Change the name
