### PR TITLE
Fix misconception in casting doc

### DIFF
--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -128,12 +128,12 @@ def get_asset_casting(asset, client=default):
 
 def get_asset_cast_in(asset, client=default):
     """
-    Return shot list where given asset is casted.
+    Return entity list where given asset is casted.
     Args:
         asset (dict): The asset dict
 
     Returns:
-        dict: Shot list where given asset is casted.
+        dict: Entity list where given asset is casted.
     """
     asset = normalize_model_parameter(asset)
     path = "/data/assets/%s/cast-in" % asset["id"]


### PR DESCRIPTION
**Problem**
There is a slight misconception in a gazu function which retrieves all the entities where an asset is cast in. The function says thoses entities are only shots when it can be shots and assets

**Solution**
Changed the doc 
