### PR TITLE
various commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 21.12b0
     hooks:
     -   id: black

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -44,6 +44,19 @@ def all_task_types_for_project(project, client=default):
 
 
 @cache
+def all_task_statuses_for_project(project, client=default):
+    """
+    Returns:
+        list: Task status stored in database.
+    """
+    project = normalize_model_parameter(project)
+    task_statuses = raw.fetch_all(
+        "projects/%s/settings/task-status" % project["id"], client=client
+    )
+    return sort_by_name(task_statuses)
+
+
+@cache
 def all_tasks_for_shot(shot, relations=False, client=default):
     """
     Args:

--- a/gazu/user.py
+++ b/gazu/user.py
@@ -238,6 +238,15 @@ def all_tasks_to_do(client=default):
     return raw.fetch_all("user/tasks", client=client)
 
 
+@cache
+def all_tasks_done(client=default):
+    """
+    Returns:
+        list: Tasks assigned to current user which are done.
+    """
+    return raw.fetch_all("user/done-tasks", client=client)
+
+
 def log_desktop_session_log_in(client=default):
     """
     Add a log entry to mention that the user logged in his computer.

--- a/gazu/user.py
+++ b/gazu/user.py
@@ -239,7 +239,7 @@ def all_tasks_to_do(client=default):
 
 
 @cache
-def all_tasks_done(client=default):
+def all_done_tasks(client=default):
     """
     Returns:
         list: Tasks assigned to current user which are done.

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,5 +48,5 @@ test =
     pytest==4.6.11; python_version == "2.7"
     pytest-cov==2.12.1
     requests_mock==1.9.3
-    pre-commit==2.15.0; python_version >= "3.6"
-    pre-commit==1.21.0; python_version == "2.7" or python_version == "3.5"
+    black==21.12b0; python_version >= "3.6"
+    pre-commit==2.17.0; python_version >= "3.6"

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ with open(convert_path("gazu/__version__.py")) as ver_file:
 
 setup(
     version=main_ns["__version__"],
-    python_requires=">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
 )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -545,6 +545,33 @@ class TaskTestCase(unittest.TestCase):
             self.assertEqual(tasks[0]["name"], "task-type-1")
             self.assertEqual(tasks[1]["name"], "task-type-2")
 
+    def test_all_task_statuses_for_project(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url(
+                    "data/projects/%s/settings/task-status"
+                    % (fakeid("project-1"))
+                ),
+                text=json.dumps(
+                    [
+                        {
+                            "name": "task-status-1",
+                            "id": fakeid("task-status-1"),
+                        },
+                        {
+                            "name": "task-status-2",
+                            "id": fakeid("task-status-2"),
+                        },
+                    ]
+                ),
+            )
+            tasks = gazu.task.all_task_statuses_for_project(
+                fakeid("project-1")
+            )
+
+            self.assertEqual(tasks[0]["name"], "task-status-1")
+            self.assertEqual(tasks[1]["name"], "task-status-2")
+
     def test_all_tasks_for_scene(self):
         with requests_mock.mock() as mock:
             mock.get(

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -262,6 +262,22 @@ class ProjectTestCase(unittest.TestCase):
             self.assertEqual(tasks[0]["name"], "task-1")
             self.assertEqual(tasks[1]["name"], "task-2")
 
+    def test_all_tasks_done(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url("data/user/done-tasks"),
+                text=json.dumps(
+                    [
+                        {"id": fakeid("task-1"), "name": "task-1"},
+                        {"id": fakeid("task-2"), "name": "task-2"},
+                    ]
+                ),
+            )
+            tasks = gazu.user.all_tasks_done()
+            self.assertEqual(len(tasks), 2)
+            self.assertEqual(tasks[0]["name"], "task-1")
+            self.assertEqual(tasks[1]["name"], "task-2")
+
     def test_log_desktop_session_log_in(self):
         with requests_mock.mock() as mock:
             date_str = datetime.datetime.now().isoformat()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -262,7 +262,7 @@ class ProjectTestCase(unittest.TestCase):
             self.assertEqual(tasks[0]["name"], "task-1")
             self.assertEqual(tasks[1]["name"], "task-2")
 
-    def test_all_tasks_done(self):
+    def test_all_done_tasks(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url("data/user/done-tasks"),
@@ -273,7 +273,7 @@ class ProjectTestCase(unittest.TestCase):
                     ]
                 ),
             )
-            tasks = gazu.user.all_tasks_done()
+            tasks = gazu.user.all_done_tasks()
             self.assertEqual(len(tasks), 2)
             self.assertEqual(tasks[0]["name"], "task-1")
             self.assertEqual(tasks[1]["name"], "task-2")


### PR DESCRIPTION
**Problem**

- in setup.py python_requires needs to accept python2.7 
- pre-commit and black don't work
- we need a function for user to get all done tasks 
- we need a function to get all tasks statuses for a project 

**Solution**

- fix setup.py to accept python>=2.7
- fix and update pre-commit and black
- add new function gazu.user.all_tasks_done + tests (https://github.com/cgwire/gazu/issues/224)
- add new function gazu.task.all_task_statuses_for_project  + tests (https://github.com/cgwire/gazu/issues/217)
