### PR TITLE
various commits

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -107,7 +107,7 @@ def get_output_file(output_file_id, client=default):
 def get_output_file_by_path(path, client=default):
     """
     Args:
-        output_file_id (str, client=default): Path of claimed output file.
+        path (str): Path of claimed output file.
 
     Returns:
         dict: Output file matching given path.

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -171,7 +171,7 @@ def get_all_attachment_files_for_task(task, client=default):
     """
     task = normalize_model_parameter(task)
     return raw.fetch_all(
-        "attachment-files", {"task_id": task["id"]}, client=client
+        "tasks/%s/attachment-files" % task["id"], client=client
     )
 
 

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -161,6 +161,20 @@ def get_all_preview_files_for_task(task, client=default):
     )
 
 
+@cache
+def get_all_attachment_files_for_task(task, client=default):
+    """
+    Retrieves all the attachment files for a given task.
+
+    Args:
+        task (str, id): Target task
+    """
+    task = normalize_model_parameter(task)
+    return raw.fetch_all(
+        "attachment-files", {"task_id": task["id"]}, client=client
+    )
+
+
 def all_output_files_for_entity(
     entity,
     output_type=None,

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -210,3 +210,113 @@ def add_task_status(project, task_status, client=default):
         data,
         client=client,
     )
+
+
+def add_metadata_descriptor(
+    project, name, entity_type, choices=[], for_client=False, client=default
+):
+    """
+    Create a new metadata descriptor for a project.
+
+    Args:
+        project (dict / ID): The project dict or id.
+        name (str): The name of the metadata descriptor
+        entity_type (str): asset, shot or scene.
+        choices (list): A list of possible values, empty list for free values.
+        for_client (bool) : Wheter it should be displayed in Kitsu or not.
+
+    Returns:
+        dict: Created metadata descriptor.
+    """
+    project = normalize_model_parameter(project)
+    data = {
+        "name": name,
+        "choices": choices,
+        "for_client": for_client,
+        "entity_type": entity_type,
+    }
+    return raw.post(
+        "data/projects/%s/metadata-descriptors" % project["id"],
+        data,
+        client=client,
+    )
+
+
+def get_metadata_descriptor(project, metadata_descriptor_id, client=default):
+    """
+    Get a metadata descriptor matchind it's ID.
+
+    Args:
+        project (dict / ID): The project dict or id.
+        metadata_descriptor_id (dict / ID): The metadata descriptor dict or id.
+
+    Returns:
+        dict: The metadata descriptor matchind the ID.
+    """
+    project = normalize_model_parameter(project)
+    metadata_descriptor = normalize_model_parameter(metadata_descriptor_id)
+    return raw.fetch_one(
+        "projects/%s/metadata-descriptors" % project["id"],
+        metadata_descriptor["id"],
+        client=client,
+    )
+
+
+def get_metadata_descriptors(project, client=default):
+    """
+    Get all the metadata descriptors.
+
+    Args:
+        project (dict / ID): The project dict or id.
+
+    Returns:
+        list: The metadata descriptors.
+    """
+    project = normalize_model_parameter(project)
+    return raw.fetch_all(
+        "projects/%s/metadata-descriptors" % project["id"],
+        client=client,
+    )
+
+
+def update_metadata_descriptor(project, metadata_descriptor, client=default):
+    """
+    Update a metadata descriptor.
+
+    Args:
+        project (dict / ID): The project dict or id.
+        metadata_descriptor (dict): The metadata descriptor that needs to be updated.
+
+    Returns:
+        dict: The updated metadata descriptor.
+    """
+    project = normalize_model_parameter(project)
+    return raw.put(
+        "data/projects/%s/metadata-descriptors/%s"
+        % (project["id"], metadata_descriptor["id"]),
+        metadata_descriptor,
+        client=client,
+    )
+
+
+def delete_metadata_descriptor(
+    project, metadata_descriptor_id, force=False, client=default
+):
+    """
+    Delete a metadata descriptor.
+
+    Args:
+        project (dict / ID): The project dict or id.
+        metadata_descriptor_id (dict / ID): The metadata descriptor dict or id.
+    """
+    project = normalize_model_parameter(project)
+    metadata_descriptor = normalize_model_parameter(metadata_descriptor_id)
+    params = {}
+    if force:
+        params = {"force": "true"}
+    return raw.delete(
+        "data/projects/%s/metadata-descriptors/%s"
+        % (project["id"], metadata_descriptor["id"]),
+        params,
+        client=client,
+    )

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -183,7 +183,7 @@ def add_asset_type(project, asset_type, client=default):
     project = normalize_model_parameter(project)
     asset_type = normalize_model_parameter(asset_type)
     data = {"asset_type_id": asset_type["id"]}
-    raw.post(
+    return raw.post(
         "data/projects/%s/settings/asset-types" % project["id"],
         data,
         client=client,
@@ -194,7 +194,7 @@ def add_task_type(project, task_type, priority, client=default):
     project = normalize_model_parameter(project)
     task_type = normalize_model_parameter(task_type)
     data = {"task_type_id": task_type["id"], "priority": priority}
-    raw.post(
+    return raw.post(
         "data/projects/%s/settings/task-types" % project["id"],
         data,
         client=client,
@@ -205,7 +205,7 @@ def add_task_status(project, task_status, client=default):
     project = normalize_model_parameter(project)
     task_status = normalize_model_parameter(task_status)
     data = {"task_status_id": task_status["id"]}
-    raw.post(
+    return raw.post(
         "data/projects/%s/settings/task-status" % project["id"],
         data,
         client=client,

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -262,7 +262,7 @@ def get_metadata_descriptor(project, metadata_descriptor_id, client=default):
     )
 
 
-def get_metadata_descriptors(project, client=default):
+def all_metadata_descriptors(project, client=default):
     """
     Get all the metadata descriptors.
 
@@ -299,11 +299,11 @@ def update_metadata_descriptor(project, metadata_descriptor, client=default):
     )
 
 
-def delete_metadata_descriptor(
+def remove_metadata_descriptor(
     project, metadata_descriptor_id, force=False, client=default
 ):
     """
-    Delete a metadata descriptor.
+    Remove a metadata descriptor.
 
     Args:
         project (dict / ID): The project dict or id.

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -708,8 +708,8 @@ def add_attachment_to_comment(task, comment, attachments=[], client=default):
     Add attachments to a given command.
 
     Args:
-        task (str / dict): The task dict or the task ID.
-        comment (str / dict): The comment dict or the comment ID.
+        task (dict / ID): The task dict or the task ID.
+        comment (dict / ID): The comment dict or the comment ID.
         attachments (list / str) : A list of path for attachments or directly the path.
 
     Returns:
@@ -731,22 +731,17 @@ def add_attachment_to_comment(task, comment, attachments=[], client=default):
     )
 
 
-def get_comment(task, comment, client=default):
+def get_comment(comment_id, client=default):
     """
     Get comment instance
 
     Args:
-        task (str / dict): The task dict or the task ID.
-        comment (str / dict): The comment dict or the comment ID.
+        comment_id (ID): The comment ID.
 
     Returns:
         dict: Given comment instance.
     """
-    task = normalize_model_parameter(task)
-    comment = normalize_model_parameter(comment)
-    return raw.fetch_one(
-        "tasks/%s/comments" % task["id"], comment["id"], client=client
-    )
+    return raw.fetch_one("comments", comment_id, client=client)
 
 
 def remove_comment(comment, client=default):

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -703,6 +703,34 @@ def add_comment(
         )
 
 
+def add_attachment_to_comment(task, comment, attachments=[], client=default):
+    """
+    Add attachments to a given command.
+
+    Args:
+        task (str / dict): The task dict or the task ID.
+        comment (str / dict): The comment dict or the comment ID.
+        attachments (list / str) : A list of path for attachments or directly the path.
+
+    Returns:
+        dict: Added attachment files.
+    """
+    if isinstance(attachments, str):
+        attachments = [attachments]
+    if len(attachments) == 0:
+        raise ValueError("The attachments list is empty")
+    task = normalize_model_parameter(task)
+    comment = normalize_model_parameter(comment)
+    attachment = attachments.pop()
+    return raw.upload(
+        "actions/tasks/%s/comments/%s/add-attachment"
+        % (task["id"], comment["id"]),
+        attachment,
+        extra_files=attachments,
+        client=client,
+    )
+
+
 def remove_comment(comment, client=default):
     """
     Remove given comment and related (previews, news, notifications) from

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -731,6 +731,22 @@ def add_attachment_to_comment(task, comment, attachments=[], client=default):
     )
 
 
+def get_comment(task, comment, client=default):
+    """
+    Get comment instance
+
+    Args:
+        task (str / dict): The task dict or the task ID.
+        comment (str / dict): The comment dict or the comment ID.
+
+    Returns:
+        dict: Given comment instance.
+    """
+    task = normalize_model_parameter(task)
+    comment = normalize_model_parameter(comment)
+    return raw.fetch_one("tasks/%s/comments" % task["id"], comment["id"])
+
+
 def remove_comment(comment, client=default):
     """
     Remove given comment and related (previews, news, notifications) from

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -744,7 +744,9 @@ def get_comment(task, comment, client=default):
     """
     task = normalize_model_parameter(task)
     comment = normalize_model_parameter(comment)
-    return raw.fetch_one("tasks/%s/comments" % task["id"], comment["id"])
+    return raw.fetch_one(
+        "tasks/%s/comments" % task["id"], comment["id"], client=client
+    )
 
 
 def remove_comment(comment, client=default):

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -170,6 +170,20 @@ def all_shot_tasks_for_episode(episode, relations=False, client=default):
 
 
 @cache
+def all_assets_tasks_for_episode(episode, relations=False, client=default):
+    """
+    Retrieve all tasks directly linked to all assets of given episode.
+    """
+    episode = normalize_model_parameter(episode)
+    params = {}
+    if relations:
+        params = {"relations": "true"}
+    path = "episodes/%s/asset-tasks" % episode["id"]
+    tasks = raw.fetch_all(path, params, client=client)
+    return sort_by_name(tasks)
+
+
+@cache
 def all_tasks_for_task_status(project, task_type, task_status, client=default):
     """
     Args:

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -717,9 +717,11 @@ def add_comment(
         )
 
 
-def add_attachment_to_comment(task, comment, attachments=[], client=default):
+def add_attachment_files_to_comment(
+    task, comment, attachments=[], client=default
+):
     """
-    Add attachments to a given command.
+    Add attachments files to a given comment.
 
     Args:
         task (dict / ID): The task dict or the task ID.

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -7,7 +7,7 @@ import unittest
 import gazu.client
 import gazu.files
 
-from utils import fakeid
+from utils import fakeid, mock_route
 
 
 class FilesTestCase(unittest.TestCase):
@@ -1115,3 +1115,13 @@ class FilesTestCase(unittest.TestCase):
             )
             self.assertEqual(preview_file["id"], fakeid("preview-file-1"))
             self.assertEqual(preview_file["name"], "test-name")
+
+    def test_get_output_file_by_path(self):
+        with requests_mock.mock() as mock:
+            text = [{"id": fakeid("output-file-1"), "path": "testpath"}]
+            mock_route(
+                mock, "GET", "/data/output-files?path=testpath", text=text
+            )
+            self.assertEqual(
+                gazu.files.get_output_file_by_path("testpath"), text[0]
+            )

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1054,29 +1054,49 @@ class FilesTestCase(unittest.TestCase):
 
     def test_get_all_preview_files_for_task(self):
         with requests_mock.mock() as mock:
-            mock.get(
-                gazu.client.get_full_url(
-                    "data/preview-files?task_id=%s" % fakeid("task-1")
-                ),
-                text=json.dumps(
-                    [
-                        {
-                            "id": fakeid("preview-file-1"),
-                            "name": "preview-file-1",
-                        },
-                        {
-                            "id": fakeid("preview-file-2"),
-                            "name": "preview-file-2",
-                        },
-                    ]
-                ),
+            text = [
+                {
+                    "id": fakeid("preview-file-1"),
+                    "name": "preview-file-1",
+                },
+                {
+                    "id": fakeid("preview-file-2"),
+                    "name": "preview-file-2",
+                },
+            ]
+            mock_route(
+                mock,
+                "GET",
+                "data/preview-files?task_id=%s" % fakeid("task-1"),
+                text=text,
             )
             preview_files = gazu.files.get_all_preview_files_for_task(
                 fakeid("task-1")
             )
-            self.assertEqual(len(preview_files), 2)
-            self.assertEqual(preview_files[0]["name"], "preview-file-1")
-            self.assertEqual(preview_files[1]["name"], "preview-file-2")
+            self.assertEqual(preview_files, text)
+
+    def test_get_all_attachment_files_for_task(self):
+        with requests_mock.mock() as mock:
+            text = [
+                {
+                    "id": fakeid("attachment-file-1"),
+                    "name": "attachment-file-1",
+                },
+                {
+                    "id": fakeid("attachment-file-2"),
+                    "name": "attachment-file-2",
+                },
+            ]
+            mock_route(
+                mock,
+                "GET",
+                "data/attachment-files?task_id=%s" % fakeid("task-1"),
+                text=text,
+            )
+            attachment_files = gazu.files.get_all_attachment_files_for_task(
+                fakeid("task-1")
+            )
+            self.assertEqual(attachment_files, text)
 
     def test_update_output_file(self):
         with requests_mock.mock() as mock:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1090,7 +1090,7 @@ class FilesTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "GET",
-                "data/attachment-files?task_id=%s" % fakeid("task-1"),
+                "data/tasks/%s/attachment-files" % fakeid("task-1"),
                 text=text,
             )
             attachment_files = gazu.files.get_all_attachment_files_for_task(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -212,3 +212,106 @@ class ProjectTestCase(unittest.TestCase):
             self.assertEqual(
                 project["project_status_id"], fakeid("project-status-1")
             )
+
+    def test_add_metadata_descriptor(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/projects/%s/metadata-descriptors" % fakeid("project-1"),
+                text={
+                    "id": fakeid("metadata-descriptor-1"),
+                    "name": "metadata-descriptor-1",
+                },
+            ),
+            metadata_descriptor = gazu.project.add_metadata_descriptor(
+                fakeid("project-1"), "metadata-descriptor-1", "Asset"
+            )
+            self.assertEqual(
+                metadata_descriptor["name"], "metadata-descriptor-1"
+            )
+            self.assertEqual(
+                metadata_descriptor["id"], fakeid("metadata-descriptor-1")
+            )
+
+    def test_get_metadata_descriptor(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/projects/%s/metadata-descriptors/%s"
+                % (fakeid("project-1"), fakeid("metadata-descriptor-1")),
+                text={
+                    "id": fakeid("metadata-descriptor-1"),
+                    "name": "metadata-descriptor-1",
+                },
+            ),
+            metadata_descriptor = gazu.project.get_metadata_descriptor(
+                fakeid("project-1"), {"id": fakeid("metadata-descriptor-1")}
+            )
+            self.assertEqual(
+                metadata_descriptor["name"], "metadata-descriptor-1"
+            )
+            self.assertEqual(
+                metadata_descriptor["id"], fakeid("metadata-descriptor-1")
+            )
+
+    def test_all_metadata_descriptors(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/projects/%s/metadata-descriptors" % fakeid("project-1"),
+                text=[
+                    {
+                        "id": fakeid("metadata-descriptor-1"),
+                    },
+                    {
+                        "id": fakeid("metadata-descriptor-2"),
+                    },
+                ],
+            ),
+            metadata_descriptors = gazu.project.all_metadata_descriptors(
+                fakeid("project-1")
+            )
+            self.assertEqual(len(metadata_descriptors), 2)
+            self.assertEqual(
+                metadata_descriptors[0]["id"], fakeid("metadata-descriptor-1")
+            )
+            self.assertEqual(
+                metadata_descriptors[1]["id"], fakeid("metadata-descriptor-2")
+            )
+
+    def test_update_metadata_descriptor(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "PUT",
+                "data/projects/%s/metadata-descriptors/%s"
+                % (fakeid("project-1"), fakeid("metadata-descriptor-1")),
+                text={
+                    "id": fakeid("metadata-descriptor-1"),
+                },
+            ),
+            metadata_descriptor = gazu.project.update_metadata_descriptor(
+                fakeid("project-1"), {"id": fakeid("metadata-descriptor-1")}
+            )
+            self.assertEqual(
+                metadata_descriptor["id"], fakeid("metadata-descriptor-1")
+            )
+
+    def test_remove_metadata_descriptor(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "DELETE",
+                "data/projects/%s/metadata-descriptors/%s"
+                % (fakeid("project-1"), fakeid("metadata-descriptor-1")),
+                text="",
+            ),
+            response = gazu.project.remove_metadata_descriptor(
+                {"id": fakeid("project-1")},
+                {"id": fakeid("metadata-descriptor-1")},
+                force=True,
+            )
+            self.assertEqual(response, "")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -315,3 +315,87 @@ class ProjectTestCase(unittest.TestCase):
                 force=True,
             )
             self.assertEqual(response, "")
+
+    def test_add_task_status(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/projects/%s/settings/task-status" % fakeid("project-1"),
+                text={
+                    "name": "task-status-1",
+                    "id": fakeid("task-status-1"),
+                },
+            )
+            task_status = gazu.project.add_task_status(
+                fakeid("project-1"),
+                {
+                    "name": "task-status-1",
+                    "id": fakeid("task-status-1"),
+                },
+            )
+
+            self.assertEqual(
+                task_status,
+                {
+                    "name": "task-status-1",
+                    "id": fakeid("task-status-1"),
+                },
+            )
+
+    def test_add_task_type(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/projects/%s/settings/task-types" % fakeid("project-1"),
+                text={
+                    "name": "task-types-1",
+                    "id": fakeid("task-types-1"),
+                    "priority": None,
+                },
+            )
+            task_types = gazu.project.add_task_type(
+                fakeid("project-1"),
+                {
+                    "name": "task-types-1",
+                    "id": fakeid("task-types-1"),
+                },
+                priority=None,
+            )
+
+            self.assertEqual(
+                task_types,
+                {
+                    "name": "task-types-1",
+                    "id": fakeid("task-types-1"),
+                    "priority": None,
+                },
+            )
+
+    def test_add_asset_type(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/projects/%s/settings/asset-types" % fakeid("project-1"),
+                text={
+                    "name": "asset-types-1",
+                    "id": fakeid("asset-types-1"),
+                },
+            )
+            asset_type = gazu.project.add_asset_type(
+                fakeid("project-1"),
+                {
+                    "name": "asset-types-1",
+                    "id": fakeid("asset-types-1"),
+                },
+            )
+
+            self.assertEqual(
+                asset_type,
+                {
+                    "name": "asset-types-1",
+                    "id": fakeid("asset-types-1"),
+                },
+            )

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -1,5 +1,3 @@
-from pydoc import text
-from typing import Sequence
 import unittest
 import json
 import requests_mock

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -1,3 +1,4 @@
+from pydoc import text
 from typing import Sequence
 import unittest
 import json
@@ -639,3 +640,11 @@ class ShotTestCase(unittest.TestCase):
             data = {"metadata-1": "metadata-1"}
             episode = gazu.shot.update_episode_data(fakeid("episode-1"), data)
             self.assertEqual(episode["data"]["metadata-1"], "metadata-1")
+
+    def test_restore_shot(self):
+        with requests_mock.mock() as mock:
+            text = {"id": fakeid("shot-1"), "canceled": False}
+            mock_route(
+                mock, "PUT", "data/shots/%s" % fakeid("shot-1"), text=text
+            )
+            self.assertEqual(gazu.shot.restore_shot(fakeid("shot-1")), text)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -608,22 +608,39 @@ class TaskTestCase(unittest.TestCase):
 
     def test_all_shot_tasks_for_episode(self):
         with requests_mock.mock() as mock:
-            mock.get(
-                gazu.client.get_full_url(
-                    "data/episodes/%s/shot-tasks?relations=true"
-                    % (fakeid("episode-1"))
-                ),
-                text=json.dumps(
-                    [
-                        {"id": "shot_task-01", "name": "Master Compositing"},
-                    ]
-                ),
+            text = [
+                {"id": "shot_task-01", "name": "Master Compositing"},
+            ]
+            mock_route(
+                mock,
+                "GET",
+                "data/episodes/%s/shot-tasks?relations=true"
+                % fakeid("episode-1"),
+                text=text,
             )
 
-            episode = {"id": fakeid("episode-1")}
-            shot_tasks = gazu.task.all_shot_tasks_for_episode(episode, True)
-            shot_task = shot_tasks[0]
-            self.assertEqual(shot_task["name"], "Master Compositing")
+            shot_tasks = gazu.task.all_shot_tasks_for_episode(
+                fakeid("episode-1"), True
+            )
+            self.assertEqual(shot_tasks, text)
+
+    def test_all_assets_tasks_for_episode(self):
+        with requests_mock.mock() as mock:
+            text = [
+                {"id": "asset_task-01", "name": "asset_task-1"},
+            ]
+            mock_route(
+                mock,
+                "GET",
+                "data/episodes/%s/asset-tasks?relations=true"
+                % fakeid("episode-1"),
+                text=text,
+            )
+
+            asset_tasks = gazu.task.all_assets_tasks_for_episode(
+                fakeid("episode-1"), True
+            )
+            self.assertEqual(asset_tasks, text)
 
     def test_all_tasks_for_entity_and_task_type(self):
         with requests_mock.mock() as mock:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -934,13 +934,10 @@ class TaskTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "GET",
-                "data/tasks/%s/comments/%s"
-                % (fakeid("task-1"), fakeid("comment-1")),
+                "data/comments/%s" % fakeid("comment-1"),
                 text={"id": fakeid("comment-1")},
             )
             self.assertEqual(
-                gazu.task.get_comment(fakeid("task-1"), fakeid("comment-1"))[
-                    "id"
-                ],
+                gazu.task.get_comment(fakeid("comment-1"))["id"],
                 fakeid("comment-1"),
             )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -547,23 +547,20 @@ class TaskTestCase(unittest.TestCase):
 
     def test_all_task_statuses_for_project(self):
         with requests_mock.mock() as mock:
-            mock.get(
-                gazu.client.get_full_url(
-                    "data/projects/%s/settings/task-status"
-                    % (fakeid("project-1"))
-                ),
-                text=json.dumps(
-                    [
-                        {
-                            "name": "task-status-1",
-                            "id": fakeid("task-status-1"),
-                        },
-                        {
-                            "name": "task-status-2",
-                            "id": fakeid("task-status-2"),
-                        },
-                    ]
-                ),
+            mock_route(
+                mock,
+                "GET",
+                "data/projects/%s/settings/task-status" % fakeid("project-1"),
+                text=[
+                    {
+                        "name": "task-status-1",
+                        "id": fakeid("task-status-1"),
+                    },
+                    {
+                        "name": "task-status-2",
+                        "id": fakeid("task-status-2"),
+                    },
+                ],
             )
             tasks = gazu.task.all_task_statuses_for_project(
                 fakeid("project-1")

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -895,3 +895,36 @@ class TaskTestCase(unittest.TestCase):
                     ),
                     {"id": fakeid("preview-1")},
                 )
+
+    def test_add_attachment_to_comment(self):
+        with open("./tests/fixtures/v1.png", "rb") as test_file:
+            with requests_mock.Mocker() as mock:
+                text = {"id": fakeid("attachment-1")}
+                mock_route(
+                    mock,
+                    "POST",
+                    "actions/tasks/%s/comments/%s/add-attachment"
+                    % (fakeid("task-1"), fakeid("comment-1")),
+                    text=text,
+                )
+
+                add_verify_file_callback(
+                    mock,
+                    {"file": test_file.read()},
+                    "actions/tasks/%s/comments/%s/add-attachment"
+                    % (fakeid("task-1"), fakeid("comment-1")),
+                )
+
+                self.assertEqual(
+                    gazu.task.add_attachment_to_comment(
+                        fakeid("task-1"),
+                        fakeid("comment-1"),
+                        "./tests/fixtures/v1.png",
+                    ),
+                    text,
+                )
+
+            with self.assertRaises(ValueError):
+                gazu.task.add_attachment_to_comment(
+                    fakeid("task-1"), fakeid("comment-1")
+                )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -928,3 +928,19 @@ class TaskTestCase(unittest.TestCase):
                 gazu.task.add_attachment_to_comment(
                     fakeid("task-1"), fakeid("comment-1")
                 )
+
+    def test_get_comment(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/tasks/%s/comments/%s"
+                % (fakeid("task-1"), fakeid("comment-1")),
+                text={"id": fakeid("comment-1")},
+            )
+            self.assertEqual(
+                gazu.task.get_comment(fakeid("task-1"), fakeid("comment-1"))[
+                    "id"
+                ],
+                fakeid("comment-1"),
+            )


### PR DESCRIPTION
**Problem**

- functions relative to metadata descriptor are missing (https://github.com/cgwire/gazu/issues/221)
- there's no function to add attachment to a comment (https://github.com/cgwire/gazu/issues/186)
- there's no function to get a comment by its ID (https://github.com/cgwire/gazu/issues/187)
- there's no function to get all attachments files for a specific task (https://github.com/cgwire/gazu/issues/188)
- there's no function to get all assets tasks for a specific episode (https://github.com/cgwire/gazu/issues/203)
- some tests are missing

**Solution**

- add functions relative to metadata descriptor : gazu.project : add_metadata_descriptor, get_metadata_descriptor, all_metadata_descriptors, update_metadata_descriptor, remove_metadata_descriptor
- there's no function to add attachment to a comment : gazu.task.add_attachment_to_comment
- add a function to get a comment by its ID : gazu.task.get_comment
- add a function to get all attachments files for a specific task : gazu.files.get_all_attachment_files_for_task
- add a function to get all assets tasks for a specific episode : gazu.task.all_assets_tasks_for_episode
- add some missing tests
