### PR TITLE
added task context to remove comment

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -760,16 +760,18 @@ def get_comment(comment_id, client=default):
     return raw.fetch_one("comments", comment_id, client=client)
 
 
-def remove_comment(comment, client=default):
+def remove_comment(task, comment, client=default):
     """
     Remove given comment and related (previews, news, notifications) from
     database.
 
     Args:
+        task (str / dict): The task dict or the task ID.
         comment (str / dict): The comment dict or the comment ID.
     """
+    task = normalize_model_parameter(task)
     comment = normalize_model_parameter(comment)
-    return raw.delete("data/comments/%s" % comment["id"], client=client)
+    return raw.delete("data/tasks/%s/comments/%s" % (task["id"], comment["id"]), client=client)
 
 
 def create_preview(task, comment, client=default):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -415,12 +415,13 @@ class TaskTestCase(unittest.TestCase):
     def test_remove_comment(self):
         with requests_mock.mock() as mock:
             mock.delete(
-                gazu.client.get_full_url("data/comments/comment-01"),
+                gazu.client.get_full_url("data/tasks/task-01/comments/comment-01"),
                 status_code=204,
                 text="",
             )
+            task = {"id": "task-01"}
             comment = {"id": "comment-01"}
-            gazu.task.remove_comment(comment)
+            gazu.task.remove_comment(task, comment)
 
     def test_comments_for_task(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
**Problem**
calling task.remove_comment was failing with a NotAllowedException. After a little digging, I noticed the path needed the task context: 'data/tasks/%s/comments/%s' rather than 'data/comments/%s'. 

**Solution**
Updated task.remove_comment to include the task context.
I had the change the function signature to include a task parameter. 
I also updated the associated task_test 