### PR TITLE
[comment] restore the route "/api/data/comments/<comment_id>" for del…

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -760,18 +760,16 @@ def get_comment(comment_id, client=default):
     return raw.fetch_one("comments", comment_id, client=client)
 
 
-def remove_comment(task, comment, client=default):
+def remove_comment(comment, client=default):
     """
     Remove given comment and related (previews, news, notifications) from
     database.
 
     Args:
-        task (str / dict): The task dict or the task ID.
         comment (str / dict): The comment dict or the comment ID.
     """
-    task = normalize_model_parameter(task)
     comment = normalize_model_parameter(comment)
-    return raw.delete("data/tasks/%s/comments/%s" % (task["id"], comment["id"]), client=client)
+    return raw.delete("data/comments/%s" % (comment["id"]), client=client)
 
 
 def create_preview(task, comment, client=default):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -414,14 +414,14 @@ class TaskTestCase(unittest.TestCase):
 
     def test_remove_comment(self):
         with requests_mock.mock() as mock:
-            mock.delete(
-                gazu.client.get_full_url("data/tasks/task-01/comments/comment-01"),
+            mock_route(
+                mock,
+                "DELETE",
+                "data/comments/%s" % fakeid("comment-1"),
                 status_code=204,
                 text="",
             )
-            task = {"id": "task-01"}
-            comment = {"id": "comment-01"}
-            gazu.task.remove_comment(task, comment)
+            gazu.task.remove_comment(fakeid("comment-1"))
 
     def test_comments_for_task(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
…eting a comment because the rights have changed in Zou

**Problem**
- we use "/api/data/task/<task_id>/comments/<comment_id>" for deleting a comment we should use "/api/data/comments/<comment_id>" because the rights in Zou are more permissive now

**Solution**
- use "/api/data/comments/<comment_id>" to delete a comment
