### PR TITLE
Various commits

### DIFF
--- a/gazu/person.py
+++ b/gazu/person.py
@@ -130,6 +130,7 @@ def new_person(
     phone="",
     role="user",
     desktop_login="",
+    departments=[],
     client=default,
 ):
     """
@@ -148,6 +149,15 @@ def new_person(
     Returns:
         dict: Created person.
     """
+
+    if not isinstance(departments, list):
+        departments = [departments]
+
+    departments_ids = [
+        department["id"] if isinstance(department, dict) else department
+        for department in departments
+    ]
+
     person = get_person_by_email(email)
     if person is None:
         person = raw.post(
@@ -159,10 +169,29 @@ def new_person(
                 "phone": phone,
                 "role": role,
                 "desktop_login": desktop_login,
+                "departments": departments_ids,
             },
             client=client,
         )
     return person
+
+
+def update_person(person, client=default):
+    """
+    Update a person.
+
+    Args:
+        person (dict): The person dict that needs to be upgraded.
+
+    Returns:
+        dict: The updated person.
+    """
+    person = normalize_model_parameter(person)
+    return raw.put(
+        "data/persons/%s" % (person["id"]),
+        person,
+        client=client,
+    )
 
 
 def set_avatar(person, file_path, client=default):

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -213,7 +213,13 @@ def add_task_status(project, task_status, client=default):
 
 
 def add_metadata_descriptor(
-    project, name, entity_type, choices=[], for_client=False, client=default
+    project,
+    name,
+    entity_type,
+    choices=[],
+    for_client=False,
+    departments=[],
+    client=default,
 ):
     """
     Create a new metadata descriptor for a project.
@@ -224,16 +230,27 @@ def add_metadata_descriptor(
         entity_type (str): asset, shot or scene.
         choices (list): A list of possible values, empty list for free values.
         for_client (bool) : Wheter it should be displayed in Kitsu or not.
+        departments (list): A list of departments dict or id.
 
     Returns:
         dict: Created metadata descriptor.
     """
+
+    if not isinstance(departments, list):
+        departments = [departments]
+
+    departments_ids = [
+        department["id"] if isinstance(department, dict) else department
+        for department in departments
+    ]
+
     project = normalize_model_parameter(project)
     data = {
         "name": name,
         "choices": choices,
         "for_client": for_client,
         "entity_type": entity_type,
+        "departments": departments_ids,
     }
     return raw.post(
         "data/projects/%s/metadata-descriptors" % project["id"],

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -307,6 +307,19 @@ def update_metadata_descriptor(project, metadata_descriptor, client=default):
     Returns:
         dict: The updated metadata descriptor.
     """
+    if "departments" in metadata_descriptor:
+        if not isinstance(metadata_descriptor["departments"], list):
+            metadata_descriptor["departments"] = [
+                metadata_descriptor["departments"]
+            ]
+
+        departments_ids = [
+            department["id"] if isinstance(department, dict) else department
+            for department in metadata_descriptor["departments"]
+        ]
+
+        metadata_descriptor["departments"] = departments_ids
+
     project = normalize_model_parameter(project)
     return raw.put(
         "data/projects/%s/metadata-descriptors/%s"

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -3,7 +3,7 @@ import json
 
 from . import client as raw
 from .sorting import sort_by_name
-from .helpers import normalize_model_parameter, validate_date_format
+from .helpers import normalize_model_parameter
 
 from .cache import cache
 
@@ -452,6 +452,21 @@ def get_task_status_by_short_name(task_status_short_name, client=default):
     """
     return raw.fetch_first(
         "task-status", {"short_name": task_status_short_name}, client=client
+    )
+
+
+def remove_task_type(task_type, client=default):
+    """
+    Remove given task type from database.
+
+    Args:
+        task_type (str / dict): The task type dict or ID.
+    """
+    task_type = normalize_model_parameter(task_type)
+    return raw.delete(
+        "data/task-types/%s" % task_type["id"],
+        {"force": "true"},
+        client=client,
     )
 
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -443,26 +443,23 @@ class CastingTestCase(unittest.TestCase):
             self.assertEqual(assets[0]["name"], "asset-1")
 
     def test_update_asset(self):
+        result = {
+            "id": fakeid("asset-1"),
+            "episode_id": fakeid("episode_1"),
+            "source_id": fakeid("episode_1"),
+        }
         with requests_mock.mock() as mock:
-            mock = mock.put(
-                gazu.client.get_full_url(
-                    "data/entities/%s" % fakeid("asset-1")
-                ),
-                text=json.dumps(
-                    {
-                        "id": fakeid("asset-1"),
-                        "episode_id": fakeid("episode_1"),
-                        "source_id": fakeid("episode_1"),
-                    }
-                ),
+            mock_route(
+                mock,
+                "PUT",
+                "data/entities/%s" % fakeid("asset-1"),
+                text=result,
             )
             asset = {
                 "id": fakeid("asset-1"),
                 "episode_id": fakeid("episode_1"),
             }
-            asset = gazu.asset.update_asset(asset)
-            self.assertEqual(asset["id"], fakeid("asset-1"))
-            self.assertEqual(asset["source_id"], fakeid("episode_1"))
+            self.assertEqual(gazu.asset.update_asset(asset), result)
 
     def test_update_asset_data(self):
         with requests_mock.mock() as mock:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -293,10 +293,15 @@ class ProjectTestCase(unittest.TestCase):
                 % (fakeid("project-1"), fakeid("metadata-descriptor-1")),
                 text={
                     "id": fakeid("metadata-descriptor-1"),
+                    "departments": [fakeid("department-1")],
                 },
             ),
             metadata_descriptor = gazu.project.update_metadata_descriptor(
-                fakeid("project-1"), {"id": fakeid("metadata-descriptor-1")}
+                fakeid("project-1"),
+                {
+                    "id": fakeid("metadata-descriptor-1"),
+                    "departments": fakeid("department-1"),
+                },
             )
             self.assertEqual(
                 metadata_descriptor["id"], fakeid("metadata-descriptor-1")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -214,24 +214,26 @@ class ProjectTestCase(unittest.TestCase):
             )
 
     def test_add_metadata_descriptor(self):
+        result = {
+            "id": fakeid("metadata-descriptor-1"),
+            "name": "metadata-descriptor-1",
+            "departments": [fakeid("department-1")],
+        }
         with requests_mock.mock() as mock:
             mock_route(
                 mock,
                 "POST",
                 "data/projects/%s/metadata-descriptors" % fakeid("project-1"),
-                text={
-                    "id": fakeid("metadata-descriptor-1"),
-                    "name": "metadata-descriptor-1",
-                },
+                text=result,
             ),
-            metadata_descriptor = gazu.project.add_metadata_descriptor(
-                fakeid("project-1"), "metadata-descriptor-1", "Asset"
-            )
             self.assertEqual(
-                metadata_descriptor["name"], "metadata-descriptor-1"
-            )
-            self.assertEqual(
-                metadata_descriptor["id"], fakeid("metadata-descriptor-1")
+                gazu.project.add_metadata_descriptor(
+                    fakeid("project-1"),
+                    "metadata-descriptor-1",
+                    "Asset",
+                    departments=fakeid("department-1"),
+                ),
+                result,
             )
 
     def test_get_metadata_descriptor(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -746,23 +746,33 @@ class TaskTestCase(unittest.TestCase):
 
     def test_remove_task_status(self):
         with requests_mock.mock() as mock:
-            mock.delete(
-                gazu.client.get_full_url(
-                    "data/task-status/%s?force=true" % fakeid("task-status-1")
-                ),
+            mock_route(
+                mock,
+                "DELETE",
+                "data/task-status/%s?force=true" % fakeid("task-status-1"),
                 status_code=204,
             )
             gazu.task.remove_task_status(fakeid("task-status-1"))
 
     def test_remove_task(self):
         with requests_mock.mock() as mock:
-            mock.delete(
-                gazu.client.get_full_url(
-                    "data/tasks/%s?force=true" % fakeid("task-1")
-                ),
+            mock_route(
+                mock,
+                "DELETE",
+                "data/tasks/%s?force=true" % fakeid("task-1"),
                 status_code=204,
             )
             gazu.task.remove_task(fakeid("task-1"))
+
+    def test_remove_task_type(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "DELETE",
+                "data/task-types/%s?force=true" % fakeid("task-type-1"),
+                status_code=204,
+            )
+            gazu.task.remove_task_type(fakeid("task-type-1"))
 
     def test_update_task(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
**Problem**
- gazu.person.new_person : we can't link departments directly to a new person
- gazu.person.update_person : non-existent function
- due to this PR (https://github.com/cgwire/zou/pull/447) metadata-descriptors can now be linked with departments : so it's needed to upgrade functions related to them to add the possibility to link a metadata-descriptors to departments
- gazu.task.remove_task_type : non-existent function
- some tests are missing

**Solution**
- gazu.person.new_person : we can now link departments directly to a new person
- new function gazu.person.update_person
- upgrade functions related to metadata-descriptors : it's now possible to link a metadata-descriptors to departments
- new function gazu.task.remove_task_type 
