### PR TITLE
[requirements] permit to have requests>=2.25.1,<=2.27.1 to not break …

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,7 @@ install_requires =
     python-socketio[client]==4.2.1; python_version == "2.7"
     python-socketio[client]==4.6.1; python_version >= "3.5"
     deprecated==1.2.13
-    requests==2.27.1; python_version != "3.5"
-    requests==2.25.1; python_version == "3.5"
+    requests>=2.25.1,<=2.27.1
 
 [options.packages.find]
 # ignore gazutest directory


### PR DESCRIPTION
…other modules dependencies

**Problem**
Pip dependency resolver can have issue with requests and other modules (like openpype) so we have to be permissive

**Solution**
Permit to have requests requests>=2.25.1,<=2.27.1
