### PR TITLE
various commits

### DIFF
--- a/gazu/exception.py
+++ b/gazu/exception.py
@@ -77,3 +77,11 @@ class TooBigFileException(Exception):
     """
 
     pass
+
+
+class TaskStatusNotFound(Exception):
+    """
+    Error raised when a task status is not found.
+    """
+
+    pass

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -573,19 +573,22 @@ def remove_task(task, client=default):
     raw.delete("data/tasks/%s" % task["id"], {"force": "true"}, client=client)
 
 
-def start_task(task, client=default):
+def start_task(task, started_task_status=None, client=default):
     """
-    Change a task status to WIP and set its real start date to now.
+    Create a comment to change task status to started_task_status (by default WIP) and set its real start date to now.
 
     Args:
         task (str / dict): The task dict or the task ID.
 
     Returns:
-        dict: Modified task.
+        dict: Created comment.
     """
-    task = normalize_model_parameter(task)
-    path = "actions/tasks/%s/start" % task["id"]
-    return raw.put(path, {}, client=client)
+    if started_task_status is None:
+        started_task_status = get_task_status_by_short_name(
+            "wip", client=client
+        )
+
+    return add_comment(task, started_task_status, client=client)
 
 
 def task_to_review(
@@ -731,7 +734,6 @@ def add_comment(
         return raw.post(
             "actions/tasks/%s/comment" % task["id"], data, client=client
         )
-
     else:
         attachment = attachments.pop()
         data["checklist"] = json.dumps(checklist)

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -442,6 +442,18 @@ def get_task_status_by_name(name, client=default):
 
 
 @cache
+def get_default_task_status(client=default):
+    """
+    Args:
+        name (str / dict): The name of claimed task status.
+
+    Returns:
+        dict: Task status matching given name.
+    """
+    return raw.fetch_first("task-status", {"is_default": True}, client=client)
+
+
+@cache
 def get_task_status_by_short_name(task_status_short_name, client=default):
     """
     Args:
@@ -524,7 +536,7 @@ def new_task(
     entity = normalize_model_parameter(entity)
     task_type = normalize_model_parameter(task_type)
     if task_status is None:
-        task_status = get_task_status_by_name("Todo", client=client)
+        task_status = get_default_task_status()
 
     data = {
         "project_id": entity["project_id"],

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -1,6 +1,8 @@
 import string
 import json
 
+from gazu.exception import TaskStatusNotFound
+
 from . import client as raw
 from .sorting import sort_by_name
 from .helpers import normalize_model_parameter
@@ -575,7 +577,8 @@ def remove_task(task, client=default):
 
 def start_task(task, started_task_status=None, client=default):
     """
-    Create a comment to change task status to started_task_status (by default WIP) and set its real start date to now.
+    Create a comment to change task status to started_task_status
+    (by default WIP) and set its real start date to now.
 
     Args:
         task (str / dict): The task dict or the task ID.
@@ -587,6 +590,15 @@ def start_task(task, started_task_status=None, client=default):
         started_task_status = get_task_status_by_short_name(
             "wip", client=client
         )
+        if started_task_status is None:
+            raise TaskStatusNotFound(
+                (
+                    "started_task_status is None : 'wip' task status is "
+                    "non-existent. You have to create it or to set an other "
+                    "task status for started_task_status in the parameters "
+                    "of the function."
+                )
+            )
 
     return add_comment(task, started_task_status, client=client)
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -352,7 +352,7 @@ class TaskTestCase(unittest.TestCase):
                 text=json.dumps([]),
             )
             mock.get(
-                gazu.client.get_full_url("data/task-status?name=Todo"),
+                gazu.client.get_full_url("data/task-status?is_default=True"),
                 text=json.dumps([{"id": fakeid("task-status-01")}]),
             )
             mock.post(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -3,6 +3,7 @@ import unittest
 import json
 import requests_mock
 import gazu.client
+from gazu.exception import TaskStatusNotFound
 import gazu.task
 import datetime
 
@@ -201,12 +202,6 @@ class TaskTestCase(unittest.TestCase):
 
     def test_start_task(self):
         with requests_mock.mock() as mock:
-            mock_route(
-                mock,
-                "GET",
-                "data/task-status?short_name=wip",
-                text=[{"id": fakeid("task-status-1")}],
-            )
             result = {
                 "id": "comment-1",
                 "task_status_id": fakeid("task-status-1"),
@@ -216,6 +211,21 @@ class TaskTestCase(unittest.TestCase):
                 "POST",
                 "actions/tasks/%s/comment" % fakeid("task-1"),
                 text=result,
+            )
+            mock_route(
+                mock,
+                "GET",
+                "data/task-status?short_name=wip",
+                text=[],
+            )
+            self.assertRaises(
+                TaskStatusNotFound, gazu.task.start_task, fakeid("task-1")
+            )
+            mock_route(
+                mock,
+                "GET",
+                "data/task-status?short_name=wip",
+                text=[{"id": fakeid("task-status-1")}],
             )
             self.assertEqual(gazu.task.start_task(fakeid("task-1")), result)
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -201,14 +201,23 @@ class TaskTestCase(unittest.TestCase):
 
     def test_start_task(self):
         with requests_mock.mock() as mock:
-            mock.put(
-                gazu.client.get_full_url("actions/tasks/task-01/start"),
-                text=json.dumps(
-                    {"name": "Task 01", "task_status_id": "wip-1"}
-                ),
+            mock_route(
+                mock,
+                "GET",
+                "data/task-status?short_name=wip",
+                text=[{"id": fakeid("task-status-1")}],
             )
-            test_task = gazu.task.start_task({"id": "task-01"})
-            self.assertEqual(test_task["task_status_id"], "wip-1")
+            result = {
+                "id": "comment-1",
+                "task_status_id": fakeid("task-status-1"),
+            }
+            mock_route(
+                mock,
+                "POST",
+                "actions/tasks/%s/comment" % fakeid("task-1"),
+                text=result,
+            )
+            self.assertEqual(gazu.task.start_task(fakeid("task-1")), result)
 
     def test_to_review(self):
         with requests_mock.mock() as mock:
@@ -396,17 +405,16 @@ class TaskTestCase(unittest.TestCase):
                 "person_id": fakeid("person-1"),
                 "created_at": date,
             }
-            mock.post(
-                gazu.client.get_full_url("actions/tasks/task-01/comment"),
-                text=json.dumps(result),
+            mock_route(
+                mock,
+                "POST",
+                "actions/tasks/%s/comment" % fakeid("task-1"),
+                text=result,
             )
-            task = {"id": "task-01"}
-            task_status = {"id": "task-status-01"}
-            comment = "New comment"
             comment = gazu.task.add_comment(
-                task,
-                task_status,
-                comment,
+                fakeid("task-1"),
+                fakeid("task-status-01"),
+                "New comment",
                 person=fakeid("person-1"),
                 created_at=date,
             )
@@ -733,11 +741,11 @@ class TaskTestCase(unittest.TestCase):
 
     def test_get_task_status_by_short_name(self):
         with requests_mock.mock() as mock:
-            mock.get(
-                gazu.client.get_full_url(
-                    "data/task-status?short_name=task_status_shortname"
-                ),
-                text=json.dumps([{"id": fakeid("task-status-1")}]),
+            mock_route(
+                mock,
+                "GET",
+                "data/task-status?short_name=task_status_shortname",
+                text=[{"id": fakeid("task-status-1")}],
             )
             task_status = gazu.task.get_task_status_by_short_name(
                 "task_status_shortname"


### PR DESCRIPTION
**Problem**
- since todo task status name can be changed we can't get it by it's name
- since actions/tasks/<task_id>/start route is deleted we need to start a task by another way

**Solution**
- get default task status by is_default=True
- start task by add_comment (by default task_status is "wip")

This PR from Zou is needed : https://github.com/cgwire/zou/pull/460
