### PR TITLE
various fixes

### DIFF
--- a/gazu/project.py
+++ b/gazu/project.py
@@ -375,3 +375,14 @@ def remove_metadata_descriptor(
         params,
         client=client,
     )
+
+
+def get_team(project, client=default):
+    """
+    Get team for project.
+
+    Args:
+        project (dict / ID): The project dict or id.
+    """
+    project = normalize_model_parameter(project)
+    return raw.fetch_all("projects/%s/team" % project["id"], client=client)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -94,20 +94,19 @@ class CastingTestCase(unittest.TestCase):
 
     def test_all_asset_types_for_project(self):
         with requests_mock.mock() as mock:
-            random_uuid = "beda37a9-c257-41ea-9337-d9cf0d746898"
+            project_id = fakeid("project-1")
             mock_route(
                 mock,
                 "GET",
-                "data/projects/%s/asset-types" % random_uuid,
+                "data/projects/%/asset-types" % project_id,
                 text=[{"name": "Asset Type 01"}],
             )
-            project = {"id": random_uuid}
-            asset_types = gazu.asset.all_asset_types_for_project(project)
+            asset_types = gazu.asset.all_asset_types_for_project(project_id)
             asset_type = asset_types[0]
             self.assertEqual(asset_type["name"], "Asset Type 01")
 
             # Test that the function accepts both an ID and dict
-            asset_types = gazu.asset.all_asset_types_for_project(random_uuid)
+            asset_types = gazu.asset.all_asset_types_for_project(project_id)
             other_asset_type = asset_types[0]
             self.assertEqual(asset_type["name"], other_asset_type["name"])
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -404,3 +404,23 @@ class ProjectTestCase(unittest.TestCase):
                     "id": fakeid("asset-types-1"),
                 },
             )
+
+    def test_get_team(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/projects/%s/team" % fakeid("project-1"),
+                text=[
+                    {
+                        "id": fakeid("person-1"),
+                    },
+                    {
+                        "id": fakeid("person-2"),
+                    },
+                ],
+            ),
+            team = gazu.project.get_team(fakeid("project-1"))
+            self.assertEqual(len(team), 2)
+            self.assertEqual(team[0]["id"], fakeid("person-1"))
+            self.assertEqual(team[1]["id"], fakeid("person-2"))


### PR DESCRIPTION
**Problem**
- python 3.10 badge not shown in Pypi
- tests/test_asset.py needs to be refactored
- missing function to get team of a project

**Solution**
- show python 3.10 badge in python
- tests/test_asset.py is refactored
- add new function gazu.project.get_team
