### PR TITLE
various commits

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -16,7 +16,11 @@ from . import task
 from . import user
 from . import playlist
 
-from .exception import AuthFailedException, ParameterException
+from .exception import (
+    AuthFailedException,
+    ParameterException,
+    NotAuthenticatedException,
+)
 from .__version__ import __version__
 
 
@@ -34,7 +38,7 @@ def log_in(email, password, client=raw.default_client):
         tokens = raw.post(
             "auth/login", {"email": email, "password": password}, client=client
         )
-    except ParameterException:
+    except (NotAuthenticatedException, ParameterException):
         pass
 
     if not tokens or (

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -74,9 +74,9 @@ def host_is_valid(client=default_client):
     if not host_is_up(client):
         return False
     try:
-        post("auth/login", {"email": "", "password": ""})
+        post("auth/login", {"email": ""})
     except Exception as exc:
-        return type(exc) == ParameterException
+        return isinstance(exc, NotAuthenticatedException)
 
 
 def get_host(client=default_client):

--- a/gazu/entity.py
+++ b/gazu/entity.py
@@ -29,36 +29,39 @@ def all_entity_types(client=default):
 def get_entity(entity_id, client=default):
     """
     Args:
-        id (str, client=default): ID of claimed entity.
+        entity_id (str): ID of claimed entity.
 
     Returns:
-        dict: Retrieve entity matching given ID (It can be an entity of any
+        dict: Retrieve entity matching given ID (it can be an entity of any
         kind: asset, shot, sequence or episode).
     """
     return raw.fetch_one("entities", entity_id, client=client)
 
 
 @cache
-def get_entity_by_name(entity_name, client=default):
+def get_entity_by_name(entity_name, project=None, client=default):
     """
     Args:
-        name (str, client=default): The name of the claimed entity.
-
+        name (str): The name of the claimed entity.
+        project (str, dict): Project ID or dict.
     Returns:
-        Retrieve entity matching given name.
+        Retrieve entity matching given name (and project if given).
     """
-    return raw.fetch_first("entities", {"name": entity_name}, client=client)
+    params = {"name": entity_name}
+    if project is not None:
+        project = normalize_model_parameter(project)
+        params["project_id"] = project["id"]
+    return raw.fetch_first("entities", params, client=client)
 
 
 @cache
 def get_entity_type(entity_type_id, client=default):
     """
-        Args:
-            id (str, client=default): ID of claimed entity type.
-    , client=client
-        Returns:
-            Retrieve entity type matching given ID (It can be an entity type of any
-            kind).
+    Args:
+        entity_type_id (str): ID of claimed entity type.
+    Returns:
+        Retrieve entity type matching given ID (It can be an entity type of any
+        kind).
     """
     return raw.fetch_one("entity-types", entity_type_id, client=client)
 

--- a/gazu/exception.py
+++ b/gazu/exception.py
@@ -94,4 +94,6 @@ class DownloadFileException(Exception):
 
 
 class TaskMustBeADictException(Exception):
-    """ """
+    """
+    Error raised when a task should be a dict.
+    """

--- a/gazu/exception.py
+++ b/gazu/exception.py
@@ -79,7 +79,7 @@ class TooBigFileException(Exception):
     pass
 
 
-class TaskStatusNotFound(Exception):
+class TaskStatusNotFoundException(Exception):
     """
     Error raised when a task status is not found.
     """
@@ -91,3 +91,7 @@ class DownloadFileException(Exception):
     """
     Error raised when a file can't be downloaded.
     """
+
+
+class TaskMustBeADictException(Exception):
+    """ """

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -1,7 +1,10 @@
 import string
 import json
 
-from gazu.exception import TaskStatusNotFound
+from gazu.exception import (
+    TaskStatusNotFoundException,
+    TaskMustBeADictException,
+)
 
 from . import client as raw
 from .sorting import sort_by_name
@@ -589,7 +592,7 @@ def start_task(task, started_task_status=None, client=default):
             "wip", client=client
         )
         if started_task_status is None:
-            raise TaskStatusNotFound(
+            raise TaskStatusNotFoundException(
                 (
                     "started_task_status is None : 'wip' task status is "
                     "non-existent. You have to create it or to set an other "
@@ -1018,12 +1021,13 @@ def update_task_data(task, data={}, client=default):
 def get_task_url(task, client=default):
     """
     Args:
-        task (str / dict): The task dict or the task ID.
+        task (dict): The task dict.
 
     Returns:
         url (str): Web url associated to the given task
     """
-    task = normalize_model_parameter(task)
+    if not isinstance(task, dict):
+        raise TaskMustBeADictException
     path = "{host}/productions/{project_id}/shots/tasks/{task_id}/"
     return path.format(
         host=raw.get_api_url_from_host(client=client),

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -98,7 +98,7 @@ class CastingTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "GET",
-                "data/projects/%/asset-types" % project_id,
+                "data/projects/%s/asset-types" % project_id,
                 text=[{"name": "Asset Type 01"}],
             )
             asset_types = gazu.asset.all_asset_types_for_project(project_id)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,7 +45,7 @@ class BaseFuncTestCase(ClientTestCase):
                 "POST",
                 "auth/login",
                 text={},
-                status_code=400,
+                status_code=401,
             )
             self.assertTrue(raw.host_is_valid())
 
@@ -432,7 +432,7 @@ class BaseFuncTestCase(ClientTestCase):
                 "POST",
                 "auth/login",
                 text={},
-                status_code=400,
+                status_code=401,
             )
             with self.assertRaises(AuthFailedException):
                 gazu.log_in("", "")

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -4,7 +4,7 @@ import requests_mock
 
 import gazu.client
 
-from utils import fakeid
+from utils import fakeid, mock_route
 
 
 class AssetTestCase(unittest.TestCase):
@@ -82,13 +82,24 @@ class AssetTestCase(unittest.TestCase):
 
     def test_get_entity_by_name(self):
         with requests_mock.mock() as mock:
-            mock.get(
-                gazu.client.get_full_url("data/entities?name=entity-1"),
-                text=json.dumps(
-                    [{"id": fakeid("entity-1"), "name": "entity-1"}]
-                ),
+            mock_route(
+                mock,
+                "GET",
+                "data/entities?name=entity-1",
+                text=[{"id": fakeid("entity-1"), "name": "entity-1"}],
             )
             entity = gazu.entity.get_entity_by_name("entity-1")
+            self.assertEqual(entity["id"], fakeid("entity-1"))
+            mock_route(
+                mock,
+                "GET",
+                "data/entities?name=entity-1&project_id=%s"
+                % fakeid("project-1"),
+                text=[{"id": fakeid("entity-1"), "name": "entity-1"}],
+            )
+            entity = gazu.entity.get_entity_by_name(
+                "entity-1", fakeid("project-1")
+            )
             self.assertEqual(entity["id"], fakeid("entity-1"))
 
     def test_get_entity_type_by_name(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -859,7 +859,7 @@ class TaskTestCase(unittest.TestCase):
         )
         task = "test"
         self.assertRaises(
-            gazu.task.get_task_url(task), TaskMustBeADictException
+            TaskMustBeADictException, gazu.task.get_task_url, task
         )
 
     def test_upload_preview_file(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -3,7 +3,10 @@ import unittest
 import json
 import requests_mock
 import gazu.client
-from gazu.exception import TaskStatusNotFound
+from gazu.exception import (
+    TaskStatusNotFoundException,
+    TaskMustBeADictException,
+)
 import gazu.task
 import datetime
 
@@ -219,7 +222,9 @@ class TaskTestCase(unittest.TestCase):
                 text=[],
             )
             self.assertRaises(
-                TaskStatusNotFound, gazu.task.start_task, fakeid("task-1")
+                TaskStatusNotFoundException,
+                gazu.task.start_task,
+                fakeid("task-1"),
             )
             mock_route(
                 mock,
@@ -851,6 +856,10 @@ class TaskTestCase(unittest.TestCase):
             gazu.task.get_task_url(task),
             "http://gazu-server/productions/%s/"
             "shots/tasks/%s/" % (fakeid("project-1"), fakeid("task-1")),
+        )
+        task = "test"
+        self.assertRaises(
+            gazu.task.get_task_url(task), TaskMustBeADictException
         )
 
     def test_upload_preview_file(self):


### PR DESCRIPTION
**Problem**
- Tests are broken
- Arg for gazu.task.get_task_url must be a dict : https://github.com/cgwire/gazu/issues/253
- There's no arg to filter by project for gazu.entity.get_entity_by_name
- Due to this future PR : https://github.com/cgwire/zou/pull/533 when log in have 401 as status code, so it's needed to change that for gazu.client.host_is_valid and gazu.log_in.

**Solution**
- Fix tests
- Raise an exception if task arg for get_task_url is not a dict
- Add an arg to filter by project for gazu.entity.get_entity_by_name
- Change gazu.client.host_is_valid and gazu.log_in to receive 401 as status code when log in failed due to wrong user/password
