### PR TITLE
various commits

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -76,7 +76,7 @@ def host_is_valid(client=default_client):
     try:
         post("auth/login", {"email": ""})
     except Exception as exc:
-        return isinstance(exc, NotAuthenticatedException)
+        return isinstance(exc, (NotAuthenticatedException, ParameterException))
 
 
 def get_host(client=default_client):

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -636,9 +636,9 @@ def task_to_review(
 
 
 @cache
-def get_time_spent(task, date, client=default):
+def get_time_spent(task, date=None, client=default):
     """
-    Get the time spent by CG artists on a task at a given date. A field contains
+    Get the time spent by CG artists on a task at a given date if given. A field contains
     the total time spent.  Durations are given in seconds. Date format is
     YYYY-MM-DD.
 
@@ -650,7 +650,9 @@ def get_time_spent(task, date, client=default):
         dict: A dict with person ID as key and time spent object as value.
     """
     task = normalize_model_parameter(task)
-    path = "actions/tasks/%s/time-spents/%s" % (task["id"], date)
+    path = "actions/tasks/%s/time-spents" % (task["id"])
+    if date is not None:
+        path += "/%s" % (date)
     return raw.get(path, client=client)
 
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -253,17 +253,23 @@ class TaskTestCase(unittest.TestCase):
 
     def test_get_time_spent(self):
         with requests_mock.mock() as mock:
-            mock.get(
-                gazu.client.get_full_url(
-                    "actions/tasks/task-01/time-spents/2017-09-23"
-                ),
-                text=json.dumps(
-                    {"person1": {"duration": 3600}, "total": 3600}
-                ),
+            mock_route(
+                mock,
+                "GET",
+                "actions/tasks/task-01/time-spents/2017-09-23",
+                text={"person1": {"duration": 3600}, "total": 3600},
             )
             time_spents = gazu.task.get_time_spent(
                 {"id": "task-01"}, "2017-09-23"
             )
+            self.assertEqual(time_spents["total"], 3600)
+            mock_route(
+                mock,
+                "GET",
+                "actions/tasks/task-01/time-spents",
+                text={"person1": {"duration": 3600}, "total": 3600},
+            )
+            time_spents = gazu.task.get_time_spent({"id": "task-01"})
             self.assertEqual(time_spents["total"], 3600)
 
     def test_set_time_spent(self):


### PR DESCRIPTION
**Problem**
- for gazu.client.host_is_valid we need to re add ParameterException for retro compatibility. 
- we can now have get_time_spent of a task without the date

**Solution**
- In gazu.client.host_is_valid re add ParameterException for retro compatibility. 
- set date parameter of gazu.task.get_time_spent to None by default to allow to get all the time-spents of a date
