### PR TITLE
feat: add relations parameter to gazu.person.get_person

### DIFF
--- a/gazu/person.py
+++ b/gazu/person.py
@@ -38,15 +38,20 @@ def all_persons(client=default):
 
 
 @cache
-def get_person(id, client=default):
+def get_person(id, relations=False, client=default):
     """
     Args:
         id (str): An uuid identifying a person.
+        relations (bool): Whether to get the relations for the given person.
 
     Returns:
         dict: Person corresponding to given id.
     """
-    return raw.fetch_one("persons", id, client=client)
+    params = {"id": id}
+    if relations:
+        params["relations"] = "true"
+
+    return raw.fetch_first("persons", params=params, client=client)
 
 
 @cache

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -180,9 +180,13 @@ class PersonTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
-                    "data/persons/%s" % (fakeid("John Doe"))
+                    "data/persons?id=%s" % (fakeid("John Doe"))
                 ),
-                text=json.dumps(result),
+                text=json.dumps(
+                    [
+                        result,
+                    ]
+                ),
             )
             self.assertEqual(
                 gazu.person.get_person(fakeid("John Doe")), result


### PR DESCRIPTION
**Problem**
We needed to get the full person information.

**Solution**
Add an optional `relations` parameter to `gazu.person.get_person`.

This PR follows [this one](https://github.com/cgwire/zou/pull/584).
