### PR TITLE
[2FA] add parameters to log_in for 2FA + add send_email_otp

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -32,11 +32,28 @@ def set_host(url, client=raw.default_client):
     raw.set_host(url, client=client)
 
 
-def log_in(email, password, client=raw.default_client):
+def log_in(
+    email,
+    password,
+    totp=None,
+    email_otp=None,
+    fido_authentication_response=None,
+    recovery_code=None,
+    client=raw.default_client,
+):
     tokens = {}
     try:
         tokens = raw.post(
-            "auth/login", {"email": email, "password": password}, client=client
+            "auth/login",
+            {
+                "email": email,
+                "password": password,
+                "totp": totp,
+                "email_otp": email_otp,
+                "fido_authentication_response": fido_authentication_response,
+                "recovery_code": recovery_code,
+            },
+            client=client,
         )
     except (NotAuthenticatedException, ParameterException):
         pass
@@ -48,6 +65,10 @@ def log_in(email, password, client=raw.default_client):
     else:
         raw.set_tokens(tokens, client=client)
     return tokens
+
+
+def send_email_otp(email, client=raw.default_client):
+    return raw.get("auth/email-otp", params={"email": email}, client=client)
 
 
 def log_out(client=raw.default_client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -400,6 +400,17 @@ class BaseFuncTestCase(ClientTestCase):
             gazu.log_out()
             self.assertEqual(raw.default_client.tokens, {})
 
+    def test_init_send_email_otp(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "auth/email-otp?email=test@test.com",
+                text={"success": True},
+            )
+            success = gazu.send_email_otp("test@test.com")
+            self.assertEqual(success, {"success": True})
+
     def test_init_refresh_token(self):
         with requests_mock.mock() as mock:
             raw.default_client.tokens["refresh_token"] = "refresh_token1"


### PR DESCRIPTION
**Problem**
- There's no parameters to log_in for 2FA
- There's no function to send an otp by email
**Solution**
- Add parameters to log_in for 2FA
- Add a function to send an otp by email
