### PR TITLE
Fix search due to missing jQuery

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
+    "sphinx_rtd_theme",
     "recommonmark",
 ]
 


### PR DESCRIPTION
**Problem**
- The search in documentation doesn't work, due to jQuery messing.

eg. https://gazu.cg-wire.com/search.html?q=test

![iScreen Shoter - 20230515115429915](https://github.com/cgwire/gazu/assets/493223/3222af2c-90ed-486e-9392-314668e6b501)

**Solution**
- fix sphinx-rtd-theme install

**jQuery** is no longer included on **Sphinx** >= 6.x, but embedded by **sphinx-rtd-theme** >= 1.2.0

Learn more:
- https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#known-issues
- https://blog.readthedocs.com/sphinx6-upgrade/