### PR TITLE
[edit] Add functions to retireve edit tasks & preview files

### DIFF
--- a/gazu/edit.py
+++ b/gazu/edit.py
@@ -2,6 +2,7 @@ from . import client as raw
 
 from .cache import cache
 from .helpers import normalize_model_parameter
+from gazu.sorting import sort_by_name
 
 default = raw.default_client
 
@@ -58,6 +59,19 @@ def get_edit_url(edit, client=default):
         edit_id=edit["id"],
         episode_id=edit["episode_id"],
     )
+
+
+@cache
+def get_all_edits_with_tasks(relations=False, client=default):
+    """
+    Retrieve all edit entries.
+    """
+    params = {}
+    if relations:
+        params = {"relations": "true"}
+    path = "edits/with-tasks"
+    edits_with_tasks = raw.fetch_all(path, params, client=client)
+    return sort_by_name(edits_with_tasks)
 
 
 def new_edit(

--- a/gazu/edit.py
+++ b/gazu/edit.py
@@ -74,6 +74,20 @@ def get_all_edits_with_tasks(relations=False, client=default):
     return sort_by_name(edits_with_tasks)
 
 
+@cache
+def all_tasks_for_edit(edit, relations=False, client=default):
+    """
+    Retrieve all tasks directly linked to given edit.
+    """
+    edit = normalize_model_parameter(edit)
+    params = {}
+    if relations:
+        params = {"relations": "true"}
+    path = "edits/%s/tasks" % edit["id"]
+    tasks = raw.fetch_all(path, params, client=client)
+    return sort_by_name(tasks)
+
+
 def new_edit(
     project,
     name,

--- a/gazu/edit.py
+++ b/gazu/edit.py
@@ -88,6 +88,23 @@ def all_tasks_for_edit(edit, relations=False, client=default):
     return sort_by_name(tasks)
 
 
+@cache
+def get_all_previews_for_edit(edit, client=default):
+    """
+    Args:
+        episode (str / dict): The episode dict or the episode ID.
+
+    Returns:
+        list: Shots which are children of given episode.
+    """
+    edit = normalize_model_parameter(edit)
+    edit_previews = raw.fetch_all(
+        f"edits/{edit['id']}/preview-files", client=client
+    )
+    for key in [key for key in enumerate(edit_previews.keys())]:
+        return edit_previews[key[1]]
+
+
 def new_edit(
     project,
     name,


### PR DESCRIPTION
**Problem**
- Cannot access edit tasks from gazu API
- Cannot check how many preview files already exist for a given edit

**Solution**
- Add a Function to Retrieve All Edits that Include Tasks
- Add Function to Retrieve all Tasks for a Given Edit
- Add Function to get all previews for an edit (useful for checking how many preview file revisions exist)
