### PR TITLE
fix bug: use revision in dict

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -868,7 +868,7 @@ def create_preview(task, comment, revision=None, client=default):
     data = {}
     if revision is not None:
         data["revision"] = revision
-    return raw.post(path, revision, client=client)
+    return raw.post(path, data, client=client)
 
 
 def upload_preview_file(


### PR DESCRIPTION
**Problem**
The revision number was sent to the tracker while a dict was expected, causing an not iterable error.

**Solution**
I updated the line to use data instead revision variable.
