### PR TITLE
[person] allow to set password for gazu.person.new_person + allow to …

### DIFF
--- a/gazu/person.py
+++ b/gazu/person.py
@@ -180,6 +180,7 @@ def new_person(
     role="user",
     desktop_login="",
     departments=[],
+    password=None,
     client=default,
 ):
     """
@@ -210,6 +211,7 @@ def new_person(
                 "role": role,
                 "desktop_login": desktop_login,
                 "departments": normalize_list_of_models_for_links(departments),
+                "password": password,
             },
             client=client,
         )
@@ -268,3 +270,21 @@ def get_presence_log(year, month, client=default):
     """
     path = "data/persons/presence-logs/%s-%s" % (year, str(month).zfill(2))
     return raw.get(path, json_response=False, client=client)
+
+
+def change_password_for_person(person, password, client=default):
+    """
+    Change the password for given person.
+
+    Args:
+        person (str / dict): The person dict or the person ID.
+        password (str): The new password.
+    Returns:
+        dict: success or not.
+    """
+    person = normalize_model_parameter(person)
+    return raw.post(
+        "actions/persons/%s/change-password" % (person["id"]),
+        {"password": password, "password_2": password},
+        client=client,
+    )

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -237,3 +237,17 @@ class PersonTestCase(unittest.TestCase):
             )
 
             self.assertEqual(person_id["id"], fakeid("person-1"))
+
+    def test_change_password_for_person(self):
+        with requests_mock.mock() as mock:
+            person_id = fakeid("person-1")
+            mock_route(
+                mock,
+                "POST",
+                "actions/persons/%s/change-password" % person_id,
+                text={"success": True},
+            )
+            self.assertEqual(
+                gazu.person.change_password_for_person(person_id, "password"),
+                {"success": True},
+            )


### PR DESCRIPTION
…change password for a person using gazu.person.change_password_for_person

**Problem**
- It's not possible to set password for gazu.person.new_person.
- There's no function to change password of a person.

**Solution**
- Allow to set password directly for gazu.person.new_person.
- Add new function to change password of a person : gazu.person.change_password_for_person. 
