### PR TITLE
[bot] add new function set_token

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -110,3 +110,18 @@ def get_event_host(client=raw.default_client):
 
 def set_event_host(url, client=raw.default_client):
     raw.set_event_host(url, client=client)
+
+
+def set_token(token, client=raw.default_client):
+    """
+    Store authentication token to reuse them for all requests.
+
+    Args:
+        new_tokens (dict): Tokens to use for authentication.
+    """
+    tokens = {}
+    if isinstance(token, dict):
+        tokens["access_token"] = token["access_token"]
+    else:
+        tokens["access_token"] = token
+    return raw.set_tokens(tokens, client=client)

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -181,6 +181,8 @@ def new_person(
     desktop_login="",
     departments=[],
     password=None,
+    is_bot=False,
+    expiration_date=None,
     client=default,
 ):
     """
@@ -196,6 +198,9 @@ def new_person(
                     and studio manager)
         desktop_login (str): The login the users uses to log on its computer.
         departments (list): The departments for the person.
+        password (str): The password for the person.
+        is_bot (bool): Whether the person is a bot or not.
+        expiration_date (str): The expiration date for the person.
     Returns:
         dict: Created person.
     """
@@ -212,6 +217,8 @@ def new_person(
                 "desktop_login": desktop_login,
                 "departments": normalize_list_of_models_for_links(departments),
                 "password": password,
+                "is_bot": is_bot,
+                "expiration_date": expiration_date,
             },
             client=client,
         )


### PR DESCRIPTION
**Problem**
- There's no way to use tokens for bots in Gazu.

**Solution**
- Add new function gazu.set_token to use these tokens for bots.
