### PR TITLE
[files] add new function gazu.files.remove_preview_file

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -147,6 +147,20 @@ def get_preview_file(preview_file_id, client=default):
     return raw.fetch_one("preview-files", preview_file_id, client=client)
 
 
+def remove_preview_file(preview_file, client=default):
+    """
+    Remove given preview file from database.
+
+    Args:
+        preview_file (str / dict): The preview_file dict or ID.
+    """
+    preview_file = normalize_model_parameter(preview_file)
+    return raw.delete(
+        "data/preview-files/%s" % preview_file["id"],
+        client=client,
+    )
+
+
 @cache
 def get_all_preview_files_for_task(task, client=default):
     """

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1067,6 +1067,16 @@ class FilesTestCase(unittest.TestCase):
             )
             self.assertEqual(preview_file["name"], "preview-file-1")
 
+    def test_remove_preview_file(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "DELETE",
+                "data/preview-files/%s" % fakeid("preview-file-1"),
+                status_code=204,
+            )
+            gazu.files.remove_preview_file(fakeid("preview-file-1"))
+
     def test_get_all_preview_files_for_task(self):
         with requests_mock.mock() as mock:
             text = [


### PR DESCRIPTION
**Problem**
- There's no function to delete a preview file. 

**Solution**
- Add new function gazu.files.remove_preview_file
