### PR TITLE
various improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 24.2.0
     hooks:
       - id: black

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -123,14 +123,13 @@ def get_person_by_email(email, client=default):
 
 @cache
 def get_person_by_full_name(
-    full_name,
-    first_name=None,
-    last_name=None,
-    client=default
+    full_name, first_name=None, last_name=None, client=default
 ):
     """
     Args:
         full_name (str): User's full name
+        first_name (str): User's first name
+        last_name (str): User's last name
 
     Returns:
         dict: Person corresponding to given name.
@@ -142,19 +141,11 @@ def get_person_by_full_name(
             client=client,
         )
     else:
-        if " " in full_name:
-            first_name, last_name = full_name.lower().split(" ")
-        else:
-            first_name, last_name = full_name.lower().strip(), ""
-        for person in all_persons():
-            is_right_first_name = (
-                first_name == person["first_name"].lower().strip()
-            )
-            is_right_last_name = (
-                len(last_name) == 0 or last_name == person["last_name"].lower()
-            )
-            if is_right_first_name and is_right_last_name:
-                return person
+        return raw.fetch_first(
+            "persons",
+            {"full_name": full_name},
+            client=client,
+        )
     return None
 
 

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -367,10 +367,10 @@ def update_metadata_descriptor(project, metadata_descriptor, client=default):
         dict: The updated metadata descriptor.
     """
     if "departments" in metadata_descriptor:
-        metadata_descriptor[
-            "departments"
-        ] = normalize_list_of_models_for_links(
-            metadata_descriptor["departments"]
+        metadata_descriptor["departments"] = (
+            normalize_list_of_models_for_links(
+                metadata_descriptor["departments"]
+            )
         )
 
     project = normalize_model_parameter(project)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,5 +48,5 @@ test =
     requests_mock
 
 lint =
-    black==24.1.1; python_version >= '3.8'
-    pre-commit==3.6.1; python_version >= '3.9'
+    black==24.2.0; python_version >= '3.8'
+    pre-commit==3.6.2; python_version >= '3.9'

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -22,23 +22,13 @@ class PersonTestCase(unittest.TestCase):
     def test_get_person_by_full_name(self):
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/persons"),
+                gazu.client.get_full_url("data/persons?full_name=John Doe"),
                 text=json.dumps(
                     [
                         {
                             "first_name": "John",
                             "last_name": "Doe",
                             "id": "person-1",
-                        },
-                        {
-                            "first_name": "Alex",
-                            "last_name": "Doe",
-                            "id": "person-2",
-                        },
-                        {
-                            "first_name": "Ema",
-                            "last_name": "Doe",
-                            "id": "person-3",
                         },
                     ]
                 ),
@@ -47,32 +37,21 @@ class PersonTestCase(unittest.TestCase):
             self.assertEqual(person["id"], "person-1")
         with requests_mock.mock() as mock:
             mock.get(
-                gazu.client.get_full_url("data/persons"),
+                gazu.client.get_full_url(
+                    "data/persons?first_name=John&last_name=Doe"
+                ),
                 text=json.dumps(
                     [
                         {
                             "first_name": "John",
                             "last_name": "Doe",
-                            "id": "person-01",
-                        },
-                        {
-                            "first_name": "JohnDid",
-                            "last_name": "",
-                            "id": "person-2",
-                        },
-                        {
-                            "first_name": "Ema",
-                            "last_name": "Doe",
-                            "id": "person-3",
+                            "id": "person-1",
                         },
                     ]
                 ),
             )
-            person = gazu.person.get_person_by_full_name("JohnDid")
-            self.assertEqual(person["id"], "person-2")
-            self.assertEqual(
-                gazu.person.get_person_by_full_name("Unknown"), None
-            )
+            person = gazu.person.get_person_by_full_name("", "John", "Doe")
+            self.assertEqual(person["id"], "person-1")
 
     def test_get_person_by_desktop_login(self):
         with requests_mock.mock() as mock:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 """
 Contains utility routines to be used in gazu tests
 """
+
 import sys
 import binascii
 import json


### PR DESCRIPTION
**Problem**
- some requirements are outdated: pre-commit and black
- for gazu.person.get_person_by_full_name we can use the query parameter full_name directly now (instead of trying to split the first and last name). (https://github.com/cgwire/gazu/issues/267)

**Solution**
- Upgrade outdated requirements: pre-commit and black
- for gazu.person.get_person_by_full_name use the query parameter full_name directly now.