### PR TITLE
[files] add functions to upload avatar for projects and persons

### DIFF
--- a/gazu/files.py
+++ b/gazu/files.py
@@ -1109,8 +1109,7 @@ def upload_working_file(working_file, file_path, client=default):
     """
     working_file = normalize_model_parameter(working_file)
     url_path = "/data/working-files/%s/file" % working_file["id"]
-    raw.upload(url_path, file_path, client=client)
-    return working_file
+    return raw.upload(url_path, file_path, client=client)
 
 
 def download_working_file(working_file, file_path=None, client=default):
@@ -1243,6 +1242,21 @@ def download_person_avatar(person, file_path, client=default):
     )
 
 
+def upload_person_avatar(person, file_path, client=default):
+    """
+    Upload given file as person avatar.
+
+    Args:
+        person (str / dict): The person dict or the person ID.
+        file_path (str): Path of the file to upload as avatar.
+    """
+    path = (
+        "/pictures/thumbnails/persons/%s"
+        % normalize_model_parameter(person)["id"]
+    )
+    return raw.upload(path, file_path, client=client)
+
+
 def download_project_avatar(project, file_path, client=default):
     """
     Download given project's avatar and save it at given location.
@@ -1256,6 +1270,21 @@ def download_project_avatar(project, file_path, client=default):
         file_path,
         client=client,
     )
+
+
+def upload_project_avatar(project, file_path, client=default):
+    """
+    Upload given file as project avatar.
+
+    Args:
+        project (str / dict): The project dict or the project ID.
+        file_path (str): Path of the file to upload as avatar.
+    """
+    path = (
+        "/pictures/thumbnails/projects/%s"
+        % normalize_model_parameter(project)["id"]
+    )
+    return raw.upload(path, file_path, client=client)
 
 
 def update_preview(preview_file, data, client=default):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -7,7 +7,7 @@ import unittest
 import gazu.client
 import gazu.files
 
-from utils import fakeid, mock_route
+from utils import fakeid, mock_route, add_verify_file_callback
 
 
 class FilesTestCase(unittest.TestCase):
@@ -1170,3 +1170,43 @@ class FilesTestCase(unittest.TestCase):
             self.assertEqual(
                 gazu.files.get_output_file_by_path("testpath"), text[0]
             )
+
+    def test_upload_person_avatar(self):
+        with open("./tests/fixtures/v1.png", "rb") as test_file:
+            with requests_mock.Mocker() as mock:
+                mock_route(
+                    mock,
+                    "POST",
+                    "pictures/thumbnails/persons/%s" % fakeid("person-1"),
+                    text={"id": fakeid("person-1")},
+                )
+
+                add_verify_file_callback(mock, {"file": test_file.read()})
+
+                self.assertEqual(
+                    gazu.files.upload_person_avatar(
+                        fakeid("person-1"),
+                        "./tests/fixtures/v1.png",
+                    ),
+                    {"id": fakeid("person-1")},
+                )
+
+    def test_upload_project_avatar(self):
+        with open("./tests/fixtures/v1.png", "rb") as test_file:
+            with requests_mock.Mocker() as mock:
+                mock_route(
+                    mock,
+                    "POST",
+                    "pictures/thumbnails/projects/%s" % fakeid("project-1"),
+                    text={"id": fakeid("project-1")},
+                )
+
+                add_verify_file_callback(mock, {"file": test_file.read()})
+
+                self.assertEqual(
+                    gazu.files.upload_project_avatar(
+                        fakeid("project-1"),
+                        "./tests/fixtures/v1.png",
+                    ),
+                    {"id": fakeid("project-1")},
+                )


### PR DESCRIPTION
**Problem**
There's no functions to upload avatars/thumbnails for projects and persons.

**Solution**
Add two functions:
- gazu.files.upload_project_avatar
- gazu.files.upload_person_avatar
