### PR TITLE
various improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         run: >-
           python3 -m
           build
-          --wheel
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.4.0
     hooks:
       - id: black

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ test =
     requests_mock
 
 lint =
-    black==24.3.0; python_version >= '3.8'
+    black==24.4.0; python_version >= '3.8'
     pre-commit==3.7.0; python_version >= '3.9'
 
 [bdist_wheel]


### PR DESCRIPTION
**Problem**
- In release GitHub workflow the source distributions are not builded.
- Black requirement is outdated.

**Solution**
- In release GitHub workflow also build the source distributions.
- Upgrade Black requirement.
