### PR TITLE
[sync] Allow to build model map on any field

### DIFF
--- a/gazu/sync.py
+++ b/gazu/sync.py
@@ -88,7 +88,7 @@ def import_entity_links(links, client=default):
     return raw.post("import/kitsu/entity-links", links, client=client)
 
 
-def get_model_list_diff(source_list, target_list):
+def get_model_list_diff(source_list, target_list, id_field="id"):
     """
     Args:
         source_list (list): List of models to compare.
@@ -99,13 +99,15 @@ def get_model_list_diff(source_list, target_list):
         and one containing the models that should not be in the target list.
     """
     missing = []
-    source_ids = {m["id"]: True for m in source_list}
-    target_ids = {m["id"]: True for m in target_list}
-    for model in source_list:
-        if model["id"] not in target_ids:
-            missing.append(model)
+    source_ids = {m[id_field]: True for m in source_list}
+    target_ids = {m[id_field]: True for m in target_list}
+    missing = [
+        model for model in source_list
+        if not target_ids.get(model[id_field], False)
+    ]
     unexpected = [
-        model for model in target_list if model["id"] not in source_ids
+        model for model in target_list
+        if not source_ids.get(model[id_field], False)
     ]
     return (missing, unexpected)
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -38,16 +38,34 @@ class SyncestCase(unittest.TestCase):
 
     def test_get_model_list_diff(self):
         source_list = [
-            {"id": "asset-1"},
-            {"id": "asset-2"},
-            {"id": "asset-3"},
+            {"id": "asset-1", "name": "Asset 1"},
+            {"id": "asset-2", "name": "Asset 2"},
+            {"id": "asset-3", "name": "Asset 3"},
         ]
-        target_list = [{"id": "asset-2"}, {"id": "asset-4"}]
-        (missing, unexpected) = gazu.sync.get_model_list_diff(
+        target_list = [
+            {"id": "asset-2", "name": "Asset 2"},
+            {"id": "asset-4", "name": "Asset 4"}
+        ]
+        missing, unexpected = gazu.sync.get_model_list_diff(
             source_list, target_list
         )
-        self.assertEqual(missing, [{"id": "asset-1"}, {"id": "asset-3"}])
-        self.assertEqual(unexpected, [{"id": "asset-4"}])
+        self.assertEqual(missing, [
+            {"id": "asset-1", "name": "Asset 1"},
+            {"id": "asset-3", "name": "Asset 3"}
+        ])
+        self.assertEqual(unexpected, [
+            {"id": "asset-4", "name": "Asset 4"}
+        ])
+        missing, unexpected = gazu.sync.get_model_list_diff(
+            source_list, target_list, id_field="name"
+        )
+        self.assertEqual(missing, [
+            {"id": "asset-1", "name": "Asset 1"},
+            {"id": "asset-3", "name": "Asset 3"}
+        ])
+        self.assertEqual(unexpected, [
+            {"id": "asset-4", "name": "Asset 4"}
+        ])
         source_list = []
         target_list = []
         (missing, unexpected) = gazu.sync.get_model_list_diff(


### PR DESCRIPTION
**Problem**

For some sync cases, allow to build a model map based on another field than the ID (on the name in most cases).

**Solution**

Build the model map with the field given in the parameters.
