### PR TITLE
add a callback when an exception NotAuthenticatedException is raised + allow automatic refresh of access_token with refresh_token

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,29 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Python: Current File",
-            "type": "python",
-            "request": "launch",
-            "program": "${file}",
-            "console": "integratedTerminal",
-            "cwd": "${fileDirname}",
-            "env": {"PYTHONPATH": "${workspaceFolder}${pathSeparator}${env:PYTHONPATH}"},
-            "justMyCode": false
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "cwd": "${fileDirname}",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}${pathSeparator}${env:PYTHONPATH}"
+      },
+      "justMyCode": false
+    },
+    {
+      "name": "Python: Test current File",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["${file}"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}${pathSeparator}${env:PYTHONPATH}"
+      },
+      "justMyCode": false
+    }
+  ]
 }

--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -120,9 +120,8 @@ def set_token(token, client=raw.default_client):
     Args:
         new_tokens (dict): Tokens to use for authentication.
     """
-    tokens = {}
+
     if isinstance(token, dict):
-        tokens["access_token"] = token["access_token"]
+        return raw.set_tokens(token, client=client)
     else:
-        tokens["access_token"] = token
-    return raw.set_tokens(tokens, client=client)
+        return raw.set_tokens({"access_token": token}, client=client)

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -356,7 +356,7 @@ def check_status(request, path, client=None):
                 retry = client.callback_not_authenticated(client, path)
                 if retry:
                     return status_code, True
-                raise
+            raise
     elif status_code in [500, 502]:
         try:
             stacktrace = request.json().get(


### PR DESCRIPTION
**Problem**
- When using gazu.set_token it's not possible to set a dict with access and refresh token. 
- For KitsuClient class, it's impossible to set a parameter to allow automatic refresh of access_token with refresh_token. 
- There's no callback when an exception NotAuthenticatedException is raised. 
- There's no launcher in vscode for debugging test files. 

**Solution**
- When using gazu.set_token allows to set a dict with access and refresh token. 
- For KitsuClient class, add a parameter allowing automatic refresh of access_token with refresh_token : automatic_refresh_token. 
- For KitsuClient class, add a parameter allowing to set a callback when an exception NotAuthenticatedException : callback_not_authenticated

