### PR TITLE
handle meta update when key is present but its value is None

### DIFF
--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -404,7 +404,8 @@ def update_shot_data(shot, data={}, client=default):
     """
     shot = normalize_model_parameter(shot)
     current_shot = get_shot(shot["id"], client=client)
-    updated_shot = {"id": current_shot["id"], "data": current_shot["data"]}
+    current_data = current_shot["data"] if current_shot["data"] is not None else {}
+    updated_shot = {"id": current_shot["id"], "data": current_data}
     updated_shot["data"].update(data)
     return update_shot(updated_shot, client=client)
 


### PR DESCRIPTION
**Problem**
While I try to update shot metadata, I often run into this error : 
AttributeError: 'NoneType' object has no attribute 'update'

Indeed it appears that sometimes my "current_shot" data looks like : {"id": "one_id", "data" : None }

**Solution**
Make sure that current_shot["data"] is not None before we call update()