### PR TITLE
Added some exceptions for some usages

### DIFF
--- a/gazu/exception.py
+++ b/gazu/exception.py
@@ -98,12 +98,14 @@ class TaskMustBeADictException(Exception):
     Error raised when a task should be a dict.
     """
 
-class FileDoesntExist(Exception):
+
+class FileDoesntExistException(Exception):
     """
     Error raised when a file should be existed when we submit a preview.
     """
 
-class ProjectDoesntExist(Exception):
+
+class ProjectDoesntExistException(Exception):
     """
     Error raised when a project isn't available.
     """

--- a/gazu/exception.py
+++ b/gazu/exception.py
@@ -97,3 +97,13 @@ class TaskMustBeADictException(Exception):
     """
     Error raised when a task should be a dict.
     """
+
+class FileDoesntExist(Exception):
+    """
+    Error raised when a file should be existed when we submit a preview.
+    """
+
+class ProjectDoesntExist(Exception):
+    """
+    Error raised when a project isn't available.
+    """


### PR DESCRIPTION
**Problem**
Projects may not exist when we need to use `gazu.get_task_by_entity()` so we need to handle these exceptions when we raise some errors.

**Solution**
Added some exceptions to handle this when it returns None.
