### PR TITLE
various improvements

### DIFF
--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -60,7 +60,10 @@ def update_episode_casting(project, episode, casting, client=default):
     """
     episode = normalize_model_parameter(episode)
     project = normalize_model_parameter(project)
-    path = "data/projects/%s/entities/%s/casting" % (project["id"], episode["id"])
+    path = "data/projects/%s/entities/%s/casting" % (
+        project["id"],
+        episode["id"],
+    )
     return raw.put(path, casting, client=client)
 
 

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -166,16 +166,12 @@ def get_entity_preview_files(entity, client=default):
     entity = normalize_model_parameter(entity)
     return raw.get(
         "data/playlists/entities/%s/preview-files" % entity["id"],
-        client=client
+        client=client,
     )
 
 
 def add_entity_to_playlist(
-    playlist,
-    entity,
-    preview_file=None,
-    persist=True,
-    client=default
+    playlist, entity, preview_file=None, persist=True, client=default
 ):
     """
     Add an entity to the playlist, use the last uploaded preview as revision
@@ -197,25 +193,23 @@ def add_entity_to_playlist(
         for task_type_id in preview_files.keys():
             task_type_files = preview_files[task_type_id]
             first_file = task_type_files[0]
-            if preview_file is None or \
-               preview_file["created_at"] < first_file["created_at"]:
+            if (
+                preview_file is None
+                or preview_file["created_at"] < first_file["created_at"]
+            ):
                 preview_file = first_file
 
     preview_file = normalize_model_parameter(preview_file)
-    playlist["shots"].append({
-        "entity_id": entity["id"],
-        "preview_file_id": preview_file["id"]
-    })
+    playlist["shots"].append(
+        {"entity_id": entity["id"], "preview_file_id": preview_file["id"]}
+    )
     if persist:
         update_playlist(playlist, client=client)
     return playlist
 
 
 def remove_entity_from_playlist(
-    playlist,
-    entity,
-    persist=True,
-    client=default
+    playlist, entity, persist=True, client=default
 ):
     """
     Remove all occurences of a given entity from a playlist.
@@ -239,11 +233,7 @@ def remove_entity_from_playlist(
 
 
 def update_entity_preview(
-    playlist,
-    entity,
-    preview_file,
-    persist=True,
-    client=default
+    playlist, entity, preview_file, persist=True, client=default
 ):
     """
     Remove all occurences of a given entity from a playlist.

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -257,12 +257,7 @@ def all_tasks_for_task_status(project, task_type, task_status, client=default):
 
 
 @cache
-def all_tasks_for_task_type(
-    project,
-    task_type,
-    episode=None,
-    client=default
-):
+def all_tasks_for_task_type(project, task_type, episode=None, client=default):
     """
     Args:
         project (str / dict): The project dict or the project ID.
@@ -533,18 +528,6 @@ def get_task_status_by_name(name, client=default):
 
 
 @cache
-def get_default_task_status(client=default):
-    """
-    Args:
-        name (str / dict): The name of claimed task status.
-
-    Returns:
-        dict: Task status matching given name.
-    """
-    return raw.fetch_first("task-status", {"is_default": True}, client=client)
-
-
-@cache
 def get_task_status_by_short_name(task_status_short_name, client=default):
     """
     Args:
@@ -661,7 +644,7 @@ def new_task(
     entity = normalize_model_parameter(entity)
     task_type = normalize_model_parameter(task_type)
     if task_status is None:
-        task_status = get_default_task_status()
+        task_status = get_default_task_status(client=client)
 
     data = {
         "project_id": entity["project_id"],
@@ -1267,10 +1250,7 @@ def get_task_url(task, client=default):
 
 
 def all_tasks_for_project(
-    project,
-    task_type=None,
-    episode=None,
-    client=default
+    project, task_type=None, episode=None, client=default
 ):
     """
     Args:

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ test =
 lint =
     autoflake==2.3.1; python_version >= '3.8'
     black==24.10.0; python_version >= '3.9'
-    pre-commit==4.0.0; python_version >= '3.9'
+    pre-commit==4.0.1; python_version >= '3.9'
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,8 @@ test =
 
 lint =
     autoflake==2.3.1; python_version >= '3.8'
-    black==24.8.0; python_version >= '3.8'
-    pre-commit==3.8.0; python_version >= '3.9'
+    black==24.10.0; python_version >= '3.9'
+    pre-commit==4.0.0; python_version >= '3.9'
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -47,7 +47,9 @@ class CastingTestCase(unittest.TestCase):
             mock.put(gazu.client.get_full_url(path), text=json.dumps(casting))
             episode = {"id": fakeid("episode-01")}
             project = {"id": fakeid("project-01")}
-            casting = gazu.casting.update_episode_casting(project, episode, casting)
+            casting = gazu.casting.update_episode_casting(
+                project, episode, casting
+            )
             self.assertEqual(casting[0]["asset_id"], fakeid("asset-1"))
 
     def test_get_asset_type_casting(self):

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -179,7 +179,8 @@ class TaskTestCase(unittest.TestCase):
             )
             mock.get(
                 gazu.client.get_full_url(
-                    "data/playlists/entities/%s/preview-files" % fakeid("shot-1")
+                    "data/playlists/entities/%s/preview-files"
+                    % fakeid("shot-1")
                 ),
                 text=json.dumps(
                     {fakeid("task-type-1"): [{"id": fakeid("preview-1")}]}
@@ -188,26 +189,33 @@ class TaskTestCase(unittest.TestCase):
             playlist = {
                 "id": fakeid("playlist-1"),
                 "name": "name_changed",
-                "shots": []
+                "shots": [],
             }
-            shot = {
-                "id": fakeid("shot-1"),
-                "name": "SH01"
-            }
+            shot = {"id": fakeid("shot-1"), "name": "SH01"}
             playlist = gazu.playlist.add_entity_to_playlist(playlist, shot)
             self.assertEqual(playlist["id"], fakeid("playlist-1"))
-            self.assertEqual(playlist["shots"], [{
-                "entity_id": fakeid("shot-1"),
-                "preview_file_id": fakeid("preview-1")
-            }])
-            playlist = gazu.playlist.update_entity_preview(
-                playlist,
-                shot,
-                fakeid("preview-2")
+            self.assertEqual(
+                playlist["shots"],
+                [
+                    {
+                        "entity_id": fakeid("shot-1"),
+                        "preview_file_id": fakeid("preview-1"),
+                    }
+                ],
             )
-            self.assertEqual(playlist["shots"], [{
-                "entity_id": fakeid("shot-1"),
-                "preview_file_id": fakeid("preview-2")
-            }])
-            playlist = gazu.playlist.remove_entity_from_playlist(playlist, shot)
+            playlist = gazu.playlist.update_entity_preview(
+                playlist, shot, fakeid("preview-2")
+            )
+            self.assertEqual(
+                playlist["shots"],
+                [
+                    {
+                        "entity_id": fakeid("shot-1"),
+                        "preview_file_id": fakeid("preview-2"),
+                    }
+                ],
+            )
+            playlist = gazu.playlist.remove_entity_from_playlist(
+                playlist, shot
+            )
             self.assertEqual(playlist["shots"], [])


### PR DESCRIPTION
**Problem**
- Some requirements are outdated. 
- Black formatter.
- When using gazu.task.new_task the custom client is not passed as an argument to gazu.task.get_default_task_status.
- gazu.task.get_default_task_status is declared twice.

**Solution**
- Upgrade outdated requirements.
- Black formatted.
- When using gazu.task.new_task pass client argument to gazu.task.get_default_task_status.
- Remove one gazu.task.get_default_task_status implementation.
