### PR TITLE
[Bugfix] Eror messages from Zou would not be returned properly

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -39,6 +39,16 @@ class FilesTestCase(unittest.TestCase):
             )
             self.assertEqual(working_file["id"], 1)
 
+            mock.post(gazu.client.get_full_url(path),
+                      text=json.dumps({"error": "The given working file already exists."}),
+                      status_code=400)
+
+            with self.assertRaises(gazu.client.ParameterException) as context:
+                gazu.files.new_working_file(
+                    task, person={"id": "person-01"}, software={"id": "software-1"})
+
+                self.assertTrue(str(context.exception) == "The given working file already exists.")
+
     def test_new_entity_output_file(self):
         entity = {"id": "asset-01"}
         output_type = {"id": "output-type-01"}


### PR DESCRIPTION
**Problem**
Zou returns json objects with the 'error' key instead of 'message'. 
As an example; See https://github.com/cgwire/zou/blob/7f217f6be8cbc6eb1b10d80ca465c823b0aede40/zou/app/blueprints/files/resources.py#L705

**Solution**
I've added a utility function that checks a given request for the presence of both 'message' and 'error' keys, so that the error message of Zou can be properly passed on.

I also updated the UnitTests to test the following scenario's: verifying that the error message raised matches the one given by Zou and properly handling the error message when attempting to create a duplicate working file.