### PR TITLE
Removed type hinting to support Python 2.7

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -303,7 +303,7 @@ def delete(path, params=None, client=default_client):
     return response.text
 
 
-def get_message_from_response(response: requests.Request, default_message: str = "No additional information") -> str:
+def get_message_from_response(response: requests.Request, default_message: str = "No additional information"):
     """
     A utility function that handles Zou's inconsistent message keys.
     For a given request, checks if any error messages or regular messages were given and returns their value.


### PR DESCRIPTION
**Problem**
Previous pull request included type hinting, which is only supported with Python 3.6 onwards.

**Solution**
Removed type hinting to support Python 2.7.