### PR TITLE
[events][windows] add signal handler on windows platform to properly …

### DIFF
--- a/gazu/events.py
+++ b/gazu/events.py
@@ -7,7 +7,25 @@ if sys.version_info[0] == 2:
 from .exception import AuthFailedException
 from .client import default_client, get_event_host
 from gazu.client import make_auth_header
+from engineio.base_client import signal_handler
 import socketio
+import os
+import inspect
+import signal
+import socketio
+
+if os.name == "nt":
+    from win32api import SetConsoleCtrlHandler
+
+    def WindowsSignalHandler(event):
+        if event == 0:
+            try:
+                signal_handler(signal.SIGINT, inspect.currentframe())
+            except:
+                # SetConsoleCtrlHandler handle cannot raise exceptions
+                pass
+
+    SetConsoleCtrlHandler(WindowsSignalHandler, 1)
 
 
 class EventsNamespace(socketio.ClientNamespace):

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     python-socketio[client]>=5.11.0,<6; python_version != '2.7'
     requests>=2.25.1
     Deprecated==1.2.14
+    pywin32>=308; sys_platform == 'win32' and python_version != '2.7'
 
 [options.packages.find]
 # ignore gazutest directory


### PR DESCRIPTION
…shutdown the event loop

**Problem**
- We can't CTRL+C to exit the event loop on Windows (https://github.com/cgwire/gazu/issues/338).

**Solution**
- Add a custom signal handler specifically for Windows to properly exit the event loop when doing a CTRL+C (fix https://github.com/cgwire/gazu/issues/338). 
