### PR TITLE
Added pagination to fetch_all method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm settings
+.idea


### PR DESCRIPTION
**Problem**
Zou has the ability to provide pagination, but Gazu ignores this functionality at the moment.

I used the get_preview_files_for_project method exposed at the /data/preview-files webhook to fetch all preview files, it becomes impossible to fetch these records. Zou yields a 502 Gateway Error. I am aware that this is an absurd query, but it's a good benchmark.

Pagination is available in Zou: https://github.com/cgwire/zou/blob/8be5dfd1744115ec08eb0c5668db62e1854ebbed/zou/app/services/files_service.py#L902

**Solution**
I added the "pagination" parameter to "fetch_all", which will cause the method to handle the query in slices of 100.
`gazu.client.fetch_all('preview-files',` params=project_id, paginated=True)`

This solution also works for Persons, Tasks and other resources that inherit from the ArgsMixin in Zou.

All tests ran green. I think it would be interesting to make this option the default at some point, but will leave it for TD's that need the functionality (and know what they're doing) for now.

Note: Also adding .idea to the .gitignore to support PyCharm (if you'd like to have the run config for the unit tests, let me know.)
