### PR TITLE
[runtime][netlify] set python 3.12 for netlify as runtime

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  environment = { PYTHON_VERSION = "3.12" }


### PR DESCRIPTION
**Problem**
- We can set python runtime for building doc in netlify. 

**Solution**
- Set python 3.12
