### PR TITLE
various improvements 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         if: matrix.version != '2.7'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install pypa/build

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -117,8 +117,8 @@ def get_person(id, relations=False, client=default):
         dict: Person corresponding to given id.
     """
     params = {"id": id}
-    if not relations:
-        params["relations"] = False
+    if relations:
+        params["relations"] = True
 
     return raw.fetch_first("persons", params=params, client=client)
 

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -76,7 +76,7 @@ def get_project_url(project, section="assets", client=default):
     project = normalize_model_parameter(project)
     path = "{host}/productions/{project_id}/{section}/"
     return path.format(
-        host=raw.get_api_url_from_host(),
+        host=raw.get_api_url_from_host(client=client),
         project_id=project["id"],
         section=section,
     )

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -740,7 +740,7 @@ def task_to_review(
 def get_time_spent(task, date=None, client=default):
     """
     Get the time spent by CG artists on a task at a given date if given. A field contains
-    the total time spent.  Durations are given in seconds. Date format is
+    the total time spent.  Durations are given in minutes. Date format is
     YYYY-MM-DD.
 
     Args:
@@ -759,14 +759,13 @@ def get_time_spent(task, date=None, client=default):
 
 def set_time_spent(task, person, date, duration, client=default):
     """
-    Set the time spent by a CG artist on a given task at a given date. Durations
-    must be set in seconds. Date format is YYYY-MM-DD.
+    Set the time spent by a CG artist on a given task at a given date.
 
     Args:
         task (str / dict): The task dict or the task ID.
         person (str / dict): The person who spent the time on given task.
-        date (str): The date for which time spent must be set.
-        duration (int): The duration of the time spent on given task.
+        date (str): The date ("YYYY-MM-DD") for which time spent must be set.
+        duration (int): The duration (in minutes) of the time spent on given task.
 
     Returns:
         dict: Created time spent entry.
@@ -784,14 +783,13 @@ def set_time_spent(task, person, date, duration, client=default):
 def add_time_spent(task, person, date, duration, client=default):
     """
     Add given duration to the already logged duration for given task and person
-    at a given date. Durations must be set in seconds. Date format is
-    YYYY-MM-DD.
+    at a given date.
 
     Args:
         task (str / dict): The task dict or the task ID.
         person (str / dict): The person who spent the time on given task.
-        date (str): The date for which time spent must be added.
-        duration (int): The duration to add on the time spent on given task.
+        date (str): The date ("YYYY-MM-DD") for which time spent must be set.
+        duration (int): The duration (in minutes) of the time spent on given task.
 
     Returns:
         dict: Updated time spent entry.

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -244,11 +244,11 @@ class PersonTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "GET",
-                "data/persons?id=%s&relations=False" % (fakeid("John Doe")),
+                "data/persons?id=%s&relations=True" % (fakeid("John Doe")),
                 text=result,
             )
             self.assertEqual(
-                gazu.person.get_person(fakeid("John Doe"), relations=False),
+                gazu.person.get_person(fakeid("John Doe"), relations=True),
                 result[0],
             )
 


### PR DESCRIPTION
**Problem**
- For time_spent docs duration is in seconds meanwhile it's in minutes. 
- Some github actions are outdated. 
- gazu.project.get_project_url doesn't use the client.
- for gazu.person.get_person relations param needs to be set to true (it's by default to false on api side). 

**Solution**
- For time_spent docs duration is in minutes now. 
- Update some github actions. 
- gazu.project.get_project_url now use the client.
- for gazu.person.get_person set param "relations" to True. 
