### PR TITLE
[task] add new function task.get_task_type_by_short_name

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -472,6 +472,27 @@ def get_task_type_by_name(
 
 
 @cache
+def get_task_type_by_short_name(
+    task_type_short_name, for_entity=None, department=None, client=default
+):
+    """
+    Args:
+        task_type_short_name (str): Short name of claimed task type.
+        for_entity (str): The entity type for which the task type is created.
+        department (str): The department for which the task type is created.
+
+    Returns:
+        dict: Task type object for given name.
+    """
+    params = {"short_name": task_type_short_name}
+    if for_entity is not None:
+        params["for_entity"] = for_entity
+    if department is not None:
+        params["department_id"] = normalize_model_parameter(department)["id"]
+    return raw.fetch_first("task-types", params, client=client)
+
+
+@cache
 def get_task_by_path(project, file_path, entity_type="shot", client=default):
     """
     Args:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -180,16 +180,30 @@ class TaskTestCase(unittest.TestCase):
 
     def test_get_task_type_by_name(self):
         with requests_mock.mock() as mock:
-            mock.get(
-                gazu.client.get_full_url("data/task-types"),
-                text=json.dumps(
-                    [
-                        {"name": "FX", "id": "task-type-fx"},
-                        {"name": "Modeling", "id": "task-type-modeling"},
-                    ]
-                ),
+            mock_route(
+                mock,
+                "GET",
+                "data/task-types",
+                text=[
+                    {"name": "FX", "id": "task-type-fx"},
+                    {"name": "Modeling", "id": "task-type-modeling"},
+                ],
             )
             task_type = gazu.task.get_task_type_by_name("FX")
+            self.assertEqual(task_type["name"], "FX")
+
+    def test_get_task_type_by_short_name(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/task-types",
+                text=[
+                    {"name": "FX", "id": "task-type-fx"},
+                    {"name": "Modeling", "id": "task-type-modeling"},
+                ],
+            )
+            task_type = gazu.task.get_task_type_by_short_name("FX")
             self.assertEqual(task_type["name"], "FX")
 
     def test_get_task_by_path(self):


### PR DESCRIPTION
**Problem**
- No method for getting task type by short name. 

**Solution**
- Add new function task.get_task_type_by_short_name.
