### PR TITLE
fix(user.py): Use the right url path to access to scenes tasks

### DIFF
--- a/gazu/user.py
+++ b/gazu/user.py
@@ -98,7 +98,7 @@ def all_tasks_for_scene(scene, client=default):
         list: Tasks assigned to current user for given scene.
     """
     scene = normalize_model_parameter(scene)
-    path = "user/scene/%s/tasks" % scene["id"]
+    path = "user/scenes/%s/tasks" % scene["id"]
     tasks = raw.fetch_all(path, client=client)
     return sort_by_name(tasks)
 


### PR DESCRIPTION
**Problem**
The url was missing a plural.

**Solution**
Use the correct url.


[Zou blueprint](https://github.com/cgwire/zou/blob/a8e89d6381c2260664f9e4d798c96d7f91ea9546/zou/app/blueprints/user/__init__.py#L54)
