### PR TITLE
Fix Optional Edit Argument in `new_edit`

### DIFF
--- a/gazu/edit.py
+++ b/gazu/edit.py
@@ -111,10 +111,11 @@ def new_edit(
         Created edit.
     """
     project = normalize_model_parameter(project)
+    data = {"name": name, "data": data}
+
     if episode is not None:
         episode = normalize_model_parameter(episode)
-
-    data = {"name": name, "data": data, "parent_id": episode["id"]}
+        data["parent_id"] = episode["id"]
 
     if description is not None:
         data["description"] = description


### PR DESCRIPTION
**Problem**
When I try to use the `new_edit` function without passing an argument  an exception is raise. Example traceback:

```bash
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/nicka/.config/blender/5.0/extensions/.local/lib/python3.11/site-packages/gazu/edit.py", line 117, in new_edit
    data = {"name": name, "data": data, "parent_id": episode["id"]}
                                                     ~~~~~~~^^^^^^
TypeError: 'NoneType' object is not subscriptable
```


**Solution**
Only add episode ID to data if episode is not None
