### PR TITLE
[events] Fix namespace error

### DIFF
--- a/gazu/events.py
+++ b/gazu/events.py
@@ -60,7 +60,7 @@ def init(
     params.update(kwargs)
     event_client = socketio.Client(**params)
     event_client.on("connect_error", connect_error)
-    event_client.register_namespace(EventsNamespace("/events"))
+    event_client.register_namespace(EventsNamespace("/"))
     event_client.connect(get_event_host(client), make_auth_header())
     return event_client
 


### PR DESCRIPTION
**Problem**

The event listener is blocked due to a namespace error.

**Solution**

Set an empty namespace as default namespace.
