### PR TITLE
fix: correct endpoint for project preview background file functionality.

### DIFF
--- a/gazu/project.py
+++ b/gazu/project.py
@@ -551,6 +551,9 @@ def add_preview_background_file(project, background_file, client=default):
     """
     Add a preview background file to a project.
 
+    The background_file payload must be a dict in the form:
+        {"preview_background_file_id": <background file id>}
+
     Args:
         project (dict / ID): The project dict or id.
         background_file (dict): A dict with a key of "preview_background_file_id"


### PR DESCRIPTION
**Problem**

Ran into this issue when working on adding type annotations to the codebase.

The current methods for altering preview background files on a project all fail with an error about not being able to find the right endpoint:
```
gazu.exception.RouteNotFoundException: data/projects/6c08617b-ec37-47ff-a90f-0058fea9b9cf/preview-background-files
```
Looking at the [API Docs](https://api-docs.kitsu.cloud/operation/operation-delete-data-projects-parameter-settings-preview-background-files-parameter) it seems that the route under the project resource is `settings/preview-background-files` rather than `preview-background-files`. 

**Solution**

Adding the `/settings` route prefix to each of the methods seems to have them back up and running again. 

I also added a bit of information to the `add_preview_background_file()` method explaining the format of the payload to pass through, as it wasn't immediately clear to me and I had to go to the REST API docs to figure it out
