### PR TITLE
fix: update tests to reflect real project background files endpoint.

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -548,7 +548,7 @@ class ProjectTestCase(unittest.TestCase):
     def test_preview_background_files(self):
         with requests_mock.mock() as mock:
             project_id = fakeid("project-1")
-            base_path = "data/projects/%s/preview-background-files" % project_id
+            base_path = "data/projects/%s/settings/preview-background-files" % project_id
 
             mock_route(
                 mock,


### PR DESCRIPTION
**Problem**

Hi @frankrousseau my apologies, I forgot to update the tests in my previous fix PR https://github.com/cgwire/gazu/pull/375 to reflect the real `{project}/settings/preview-background-files` endpoint as well, which resulted in them failing in CI.

**Solution**

This PR corrects the URL in the test mocks, matching the real Zou endpoint and fixing the tests.