### PR TITLE
fix: correct URL for playlist client notification.

### DIFF
--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -417,5 +417,5 @@ def notify_clients_playlist_ready(playlist, client=default):
     """
     playlist = normalize_model_parameter(playlist)
     return raw.post(
-        "data/playlists/%s/notify" % playlist["id"], {}, client=client
+        "data/playlists/%s/notify-clients" % playlist["id"], {}, client=client
     )

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -382,7 +382,7 @@ class TaskTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             mock.post(
                 gazu.client.get_full_url(
-                    "data/playlists/%s/notify" % fakeid("playlist-1")
+                    "data/playlists/%s/notify-clients" % fakeid("playlist-1")
                 ),
                 text=json.dumps({"status": "notified"}),
             )


### PR DESCRIPTION
**Problem**

Currently the `gazu.playlist.notify_clients_playlist_ready(...)` method fails as it makes it's POST request to the wrong URL, it should be `/notify-clients` instead of `/notify` (see the route definition [here](https://github.com/cgwire/zou/blob/ec4f326db20df8c13b11e5e64ffb0328ae9d59f8/zou/app/blueprints/playlists/__init__.py#L48))

**Solution**

Points this method to the correct endpoint. 

(Also - Merry Chrismas if you celebrate!)