### PR TITLE
[tasks] Add for_client parameter to add_comment

### DIFF
--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -19,6 +19,7 @@ from . import edit
 from . import entity
 from . import files
 from . import project
+from . import project_template
 from . import person
 from . import shot
 from . import studio

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlencode
+
 from .helpers import normalize_model_parameter
 
 from . import client as raw
@@ -173,6 +175,64 @@ def get_asset_url(asset: str | dict, client: KitsuClient = default) -> str:
         if asset.get("episode_id"):
             episode_id = asset["episode_id"]
         return f"{host}/productions/{project_id}/episodes/{episode_id}/assets/{asset_id}/"
+
+
+@cache
+def get_all_assets_url(
+    project: str | dict, client: KitsuClient = default
+) -> str:
+    """
+    Args:
+        project (str / dict): The project dict or the project ID.
+
+    Returns:
+        url (str): Web url of the assets list page for the given project.
+        For TV shows the URL targets the "main" episode (where shared
+        assets live), mirroring the convention used by ``get_asset_url``.
+    """
+    project = normalize_model_parameter(project)
+    project = gazu_project.get_project(project["id"], client=client)
+    host = raw.get_api_url_from_host(client=client)
+    project_id = project["id"]
+    if project["production_type"] != "tvshow":
+        return f"{host}/productions/{project_id}/assets/"
+    else:
+        return f"{host}/productions/{project_id}/episodes/main/assets/"
+
+
+@cache
+def get_asset_type_url(
+    project: str | dict,
+    asset_type: str | dict,
+    client: KitsuClient = default,
+) -> str:
+    """
+    Build a URL pointing at the assets list page of the given project,
+    pre-filtered by the given asset type's name (e.g. ``Character``,
+    ``Prop``).
+
+    Args:
+        project (str / dict): The project dict or the project ID.
+        asset_type (str / dict): The asset type dict or the asset type ID.
+
+    Returns:
+        url (str): Web url of the project's assets list, with the search
+        field pre-populated with ``type=[Asset-Type-Name]``.
+    """
+    project = normalize_model_parameter(project)
+    project = gazu_project.get_project(project["id"], client=client)
+    asset_type = normalize_model_parameter(asset_type)
+    if "name" not in asset_type:
+        asset_type = get_asset_type(asset_type["id"], client=client)
+    host = raw.get_api_url_from_host(client=client)
+    project_id = project["id"]
+    query = urlencode({"search": f"type=[{asset_type['name']}]"})
+    if project["production_type"] != "tvshow":
+        return f"{host}/productions/{project_id}/assets?{query}"
+    else:
+        return (
+            f"{host}/productions/{project_id}/episodes/main/assets?{query}"
+        )
 
 
 def new_asset(

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -691,6 +691,85 @@ def get_year_day_offs(
     )
 
 
+@cache
+def get_day_off(day_off_id: str, client: KitsuClient = default) -> dict:
+    """
+    Get a day off by its ID.
+
+    Args:
+        day_off_id (str): ID of the day off.
+
+    Returns:
+        dict: Day off matching the given ID.
+    """
+    return raw.fetch_one("day-offs", day_off_id, client=client)
+
+
+def new_day_off(
+    person: str | dict,
+    date: str,
+    end_date: str,
+    description: str | None = None,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Create a new day off for the given person. The server rejects the
+    request if the period overlaps with an existing day off. Time-spent
+    entries that fall within the period are automatically removed by zou.
+
+    Args:
+        person (str / dict): The person dict or id.
+        date (str): Start date (ISO format, e.g. ``"2026-04-10"``).
+        end_date (str): End date (ISO format, inclusive).
+        description (str): Optional description.
+
+    Returns:
+        dict: Created day off.
+    """
+    person = normalize_model_parameter(person)
+    data = {
+        "person_id": person["id"],
+        "date": date,
+        "end_date": end_date,
+    }
+    if description is not None:
+        data["description"] = description
+    return raw.create("day-offs", data, client=client)
+
+
+def update_day_off(day_off: dict, client: KitsuClient = default) -> dict:
+    """
+    Update a day off.
+
+    Args:
+        day_off (dict): The day off dict to update. Must include the
+            ``id`` key. Fields that can be changed: ``date``,
+            ``end_date``, ``description``, ``person_id``.
+
+    Returns:
+        dict: Updated day off.
+    """
+    return raw.put(
+        f"data/day-offs/{day_off['id']}", day_off, client=client
+    )
+
+
+def remove_day_off(
+    day_off: str | dict, client: KitsuClient = default
+) -> str:
+    """
+    Delete a day off.
+
+    Args:
+        day_off (dict / ID): The day off dict or id.
+
+    Returns:
+        str: Empty response.
+    """
+    day_off = normalize_model_parameter(day_off)
+    return raw.delete(f"data/day-offs/{day_off['id']}", client=client)
+
+
 def add_person_to_department(
     person: str | dict, department: str | dict, client: KitsuClient = default
 ) -> dict:

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -110,6 +110,7 @@ def new_project(
     task_statuses: list | None = None,
     task_types: list | None = None,
     production_style: str = "2d3d",
+    project_template: str | dict | None = None,
     client: KitsuClient = default,
 ) -> dict:
     """
@@ -124,6 +125,9 @@ def new_project(
         task_types (list): Task types of the project.
         production_style (str): 2d, 3d, 2d3d, ar, vfx, stop-motion, motion-design,
             archviz, commercial, catalog, immersive, nft, video-game, vr.
+        project_template (dict / ID): Optional project template to apply
+            after creation. Settings explicitly provided in the call (fps,
+            ratio, etc.) take precedence over the template's defaults.
     Returns:
         dict: Created project.
     """
@@ -137,19 +141,23 @@ def new_project(
         task_types = []
     project = get_project_by_name(name, client=client)
     if project is None:
+        data = {
+            "name": name,
+            "production_type": production_type,
+            "team": normalize_list_of_models_for_links(team),
+            "asset_types": normalize_list_of_models_for_links(asset_types),
+            "task_statuses": normalize_list_of_models_for_links(
+                task_statuses
+            ),
+            "task_types": normalize_list_of_models_for_links(task_types),
+            "production_style": production_style,
+        }
+        if project_template is not None:
+            template = normalize_model_parameter(project_template)
+            data["project_template_id"] = template["id"]
         project = raw.create(
             "projects",
-            {
-                "name": name,
-                "production_type": production_type,
-                "team": normalize_list_of_models_for_links(team),
-                "asset_types": normalize_list_of_models_for_links(asset_types),
-                "task_statuses": normalize_list_of_models_for_links(
-                    task_statuses
-                ),
-                "task_types": normalize_list_of_models_for_links(task_types),
-                "production_style": production_style,
-            },
+            data,
             client=client,
         )
     return project

--- a/gazu/project_template.py
+++ b/gazu/project_template.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+from . import client as raw
+
+from .cache import cache
+from .client import KitsuClient
+from .helpers import normalize_model_parameter
+from .sorting import sort_by_name
+
+default = raw.default_client
+
+
+# ---------------------------------------------------------------------------
+# Listing & retrieval
+# ---------------------------------------------------------------------------
+
+
+@cache
+def all_project_templates(client: KitsuClient = default) -> list[dict]:
+    """
+    Returns:
+        list: All project templates stored in the database, ordered by name.
+    """
+    return sort_by_name(raw.fetch_all("project-templates", client=client))
+
+
+@cache
+def get_project_template(
+    project_template_id: str, client: KitsuClient = default
+) -> dict:
+    """
+    Args:
+        project_template_id (str): ID of the claimed project template.
+
+    Returns:
+        dict: Project template corresponding to given id.
+    """
+    return raw.fetch_one(
+        "project-templates", project_template_id, client=client
+    )
+
+
+@cache
+def get_project_template_by_name(
+    name: str, client: KitsuClient = default
+) -> dict | None:
+    """
+    Args:
+        name (str): Name of the project template.
+
+    Returns:
+        dict: Project template matching the given name, or None.
+    """
+    templates = raw.fetch_all("project-templates", client=client)
+    for template in templates:
+        if template.get("name", "").lower() == name.lower():
+            return template
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+def new_project_template(
+    name: str,
+    description: str | None = None,
+    fps: str | None = None,
+    ratio: str | None = None,
+    resolution: str | None = None,
+    production_type: str | None = None,
+    production_style: str | None = None,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Create a new empty project template.
+
+    Args:
+        name (str): Name of the template (must be unique).
+        description (str): Optional description.
+        fps (str): Default frames per second for projects created from this
+            template.
+        ratio (str): Default aspect ratio.
+        resolution (str): Default resolution.
+        production_type (str): Default production type (short, featurefilm,
+            tvshow, etc.).
+        production_style (str): Default production style (2d, 3d, 2d3d, vfx,
+            etc.).
+
+    Returns:
+        dict: Created project template.
+    """
+    data = {"name": name, "description": description}
+    for key, value in {
+        "fps": fps,
+        "ratio": ratio,
+        "resolution": resolution,
+        "production_type": production_type,
+        "production_style": production_style,
+    }.items():
+        if value is not None:
+            data[key] = value
+    return raw.post("data/project-templates", data, client=client)
+
+
+def update_project_template(
+    project_template: dict, client: KitsuClient = default
+) -> dict:
+    """
+    Save the given project template's fields back to the API.
+
+    Args:
+        project_template (dict): The project template dict to update. Must
+            include the ``id`` key.
+
+    Returns:
+        dict: Updated project template.
+    """
+    return raw.put(
+        f"data/project-templates/{project_template['id']}",
+        project_template,
+        client=client,
+    )
+
+
+def remove_project_template(
+    project_template: str | dict, client: KitsuClient = default
+) -> str:
+    """
+    Delete the given project template.
+
+    Args:
+        project_template (dict / ID): The template dict or id to remove.
+
+    Returns:
+        str: API response.
+    """
+    project_template = normalize_model_parameter(project_template)
+    return raw.delete(
+        f"data/project-templates/{project_template['id']}", client=client
+    )
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / apply
+# ---------------------------------------------------------------------------
+
+
+def new_project_template_from_project(
+    project: str | dict,
+    name: str,
+    description: str | None = None,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Create a new project template by snapshotting an existing project's
+    configuration (task types, task statuses, asset types, status
+    automations, metadata descriptors and production settings). Production
+    data (tasks, entities, team, dates) is not copied.
+
+    Args:
+        project (dict / ID): The source project.
+        name (str): Name to give to the new template.
+        description (str): Optional description.
+
+    Returns:
+        dict: Created project template.
+    """
+    project = normalize_model_parameter(project)
+    data = {"name": name, "description": description}
+    return raw.post(
+        f"data/project-templates/from-project/{project['id']}",
+        data,
+        client=client,
+    )
+
+
+def apply_project_template(
+    project: str | dict,
+    project_template: str | dict,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Apply the given template to an existing project. The strategy is
+    additive: existing links are kept and duplicates are skipped.
+
+    Args:
+        project (dict / ID): The target project.
+        project_template (dict / ID): The template to apply.
+
+    Returns:
+        dict: Updated project.
+    """
+    project = normalize_model_parameter(project)
+    project_template = normalize_model_parameter(project_template)
+    return raw.post(
+        f"data/projects/{project['id']}/apply-template/{project_template['id']}",
+        {},
+        client=client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Link management
+# ---------------------------------------------------------------------------
+
+
+@cache
+def all_task_types_for_project_template(
+    project_template: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    List the task types attached to a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    return raw.fetch_all(
+        f"project-templates/{project_template['id']}/task-types", client=client
+    )
+
+
+def add_task_type_to_project_template(
+    project_template: str | dict,
+    task_type: str | dict,
+    priority: int | None = None,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Attach a task type to a project template.
+
+    Args:
+        project_template (dict / ID): The template.
+        task_type (dict / ID): The task type to attach.
+        priority (int): Optional priority for the task type within the
+            template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    task_type = normalize_model_parameter(task_type)
+    data = {"task_type_id": task_type["id"]}
+    if priority is not None:
+        data["priority"] = priority
+    return raw.post(
+        f"data/project-templates/{project_template['id']}/task-types",
+        data,
+        client=client,
+    )
+
+
+def remove_task_type_from_project_template(
+    project_template: str | dict,
+    task_type: str | dict,
+    client: KitsuClient = default,
+) -> str:
+    """
+    Detach a task type from a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    task_type = normalize_model_parameter(task_type)
+    return raw.delete(
+        f"data/project-templates/{project_template['id']}/task-types/{task_type['id']}",
+        client=client,
+    )
+
+
+@cache
+def all_task_statuses_for_project_template(
+    project_template: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    List the task statuses attached to a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    return raw.fetch_all(
+        f"project-templates/{project_template['id']}/task-statuses",
+        client=client,
+    )
+
+
+def add_task_status_to_project_template(
+    project_template: str | dict,
+    task_status: str | dict,
+    priority: int | None = None,
+    roles_for_board: list[str] | None = None,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Attach a task status to a project template.
+
+    Args:
+        project_template (dict / ID): The template.
+        task_status (dict / ID): The task status to attach.
+        priority (int): Optional priority.
+        roles_for_board (list): Optional list of roles allowed to view this
+            status on the board.
+    """
+    project_template = normalize_model_parameter(project_template)
+    task_status = normalize_model_parameter(task_status)
+    data = {"task_status_id": task_status["id"]}
+    if priority is not None:
+        data["priority"] = priority
+    if roles_for_board is not None:
+        data["roles_for_board"] = roles_for_board
+    return raw.post(
+        f"data/project-templates/{project_template['id']}/task-statuses",
+        data,
+        client=client,
+    )
+
+
+def remove_task_status_from_project_template(
+    project_template: str | dict,
+    task_status: str | dict,
+    client: KitsuClient = default,
+) -> str:
+    """
+    Detach a task status from a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    task_status = normalize_model_parameter(task_status)
+    return raw.delete(
+        f"data/project-templates/{project_template['id']}/task-statuses/{task_status['id']}",
+        client=client,
+    )
+
+
+@cache
+def all_asset_types_for_project_template(
+    project_template: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    List the asset types attached to a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    return raw.fetch_all(
+        f"project-templates/{project_template['id']}/asset-types",
+        client=client,
+    )
+
+
+def add_asset_type_to_project_template(
+    project_template: str | dict,
+    asset_type: str | dict,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Attach an asset type to a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    asset_type = normalize_model_parameter(asset_type)
+    return raw.post(
+        f"data/project-templates/{project_template['id']}/asset-types",
+        {"asset_type_id": asset_type["id"]},
+        client=client,
+    )
+
+
+def remove_asset_type_from_project_template(
+    project_template: str | dict,
+    asset_type: str | dict,
+    client: KitsuClient = default,
+) -> str:
+    """
+    Detach an asset type from a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    asset_type = normalize_model_parameter(asset_type)
+    return raw.delete(
+        f"data/project-templates/{project_template['id']}/asset-types/{asset_type['id']}",
+        client=client,
+    )
+
+
+@cache
+def all_status_automations_for_project_template(
+    project_template: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    List the status automations attached to a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    return raw.fetch_all(
+        f"project-templates/{project_template['id']}/status-automations",
+        client=client,
+    )
+
+
+def add_status_automation_to_project_template(
+    project_template: str | dict,
+    status_automation: str | dict,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Attach a status automation to a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    status_automation = normalize_model_parameter(status_automation)
+    return raw.post(
+        f"data/project-templates/{project_template['id']}/status-automations",
+        {"status_automation_id": status_automation["id"]},
+        client=client,
+    )
+
+
+def remove_status_automation_from_project_template(
+    project_template: str | dict,
+    status_automation: str | dict,
+    client: KitsuClient = default,
+) -> str:
+    """
+    Detach a status automation from a project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    status_automation = normalize_model_parameter(status_automation)
+    return raw.delete(
+        f"data/project-templates/{project_template['id']}/status-automations/{status_automation['id']}",
+        client=client,
+    )
+
+
+def set_project_template_metadata_descriptors(
+    project_template: str | dict,
+    descriptors: list[dict],
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Replace the metadata descriptor snapshot stored on a project template.
+
+    Each descriptor is a dict with the following keys (the same shape that
+    will be materialized into MetadataDescriptor rows when the template is
+    applied to a project):
+
+        - name (str)
+        - entity_type (str): "Asset", "Shot", "Edit", ...
+        - data_type (str): "string", "number", "list", "taglist", "boolean",
+          "checklist"
+        - choices (list[str]): only used for list/taglist/checklist types
+        - for_client (bool)
+        - departments (list[str]): department IDs
+        - position (int): optional ordering hint
+
+    Args:
+        project_template (dict / ID): The template.
+        descriptors (list[dict]): The full descriptor snapshot. The previous
+            snapshot is replaced (not merged).
+
+    Returns:
+        dict: Updated project template.
+    """
+    project_template = normalize_model_parameter(project_template)
+    return raw.put(
+        f"data/project-templates/{project_template['id']}/metadata-descriptors",
+        {"metadata_descriptors": descriptors},
+        client=client,
+    )

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -300,6 +300,68 @@ def get_shot_url(shot: str | dict, client: KitsuClient = default) -> str:
         return f"{host}/productions/{project_id}/episodes/{episode_id}/shots/{shot_id}/"
 
 
+@cache
+def get_all_episodes_url(
+    project: str | dict, client: KitsuClient = default
+) -> str:
+    """
+    Args:
+        project (str / dict): The project dict or the project ID.
+
+    Returns:
+        url (str): Web url of the episodes list page for the given project.
+        Only meaningful for TV show productions; for other production types
+        the page exists in the UI but will be empty.
+    """
+    project = normalize_model_parameter(project)
+    host = raw.get_api_url_from_host(client=client)
+    return f"{host}/productions/{project['id']}/episodes/"
+
+
+@cache
+def get_all_sequences_url(
+    project: str | dict, client: KitsuClient = default
+) -> str:
+    """
+    Args:
+        project (str / dict): The project dict or the project ID.
+
+    Returns:
+        url (str): Web url of the sequences list page for the given project.
+    """
+    project = normalize_model_parameter(project)
+    host = raw.get_api_url_from_host(client=client)
+    return f"{host}/productions/{project['id']}/sequences/"
+
+
+@cache
+def get_sequence_url(
+    sequence: str | dict, client: KitsuClient = default
+) -> str:
+    """
+    Args:
+        sequence (str / dict): The sequence dict or the sequence ID.
+
+    Returns:
+        url (str): Web url associated to the given sequence. The URL shape
+        depends on whether the sequence belongs to an episode (TV show) or
+        to the project root (non-episodic).
+    """
+    sequence = normalize_model_parameter(sequence)
+    sequence = get_sequence(sequence["id"], client=client)
+    host = raw.get_api_url_from_host(client=client)
+    project_id = sequence["project_id"]
+    sequence_id = sequence["id"]
+    if sequence.get("parent_id") is None:
+        return f"{host}/productions/{project_id}/sequences/{sequence_id}/"
+    else:
+        episode_id = sequence["parent_id"]
+        return (
+            f"{host}/productions/{project_id}/episodes/{episode_id}"
+            f"/sequences/{sequence_id}/"
+        )
+
+
 def new_sequence(
     project: str | dict,
     name: str,

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -933,6 +933,7 @@ def add_comment(
     attachments: list[str] | None = None,
     created_at: str | None = None,
     links: list[str] | None = None,
+    for_client: bool = False,
     client: KitsuClient = default,
     progress_callback=None,
 ) -> dict:
@@ -950,6 +951,8 @@ def add_comment(
         attachments (list[file_path]): Attachments file paths
         created_at (str): Comment date
         links (list): List of URL links to add to the comment
+        for_client (bool): When True, make the comment visible to clients
+            (manager-only).
 
     Returns:
         dict: Created comment.
@@ -967,6 +970,7 @@ def add_comment(
         "comment": comment,
         "checklist": checklist,
         "links": links,
+        "for_client": for_client,
     }
 
     if person is not None:

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -399,6 +399,95 @@ class CastingTestCase(unittest.TestCase):
                 "assets/asset-01/",
             )
 
+    def test_get_all_assets_url(self):
+        host = gazu.client.get_api_url_from_host()
+        # Non-tvshow project: plain assets list URL
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url("data/projects/project-01"),
+                text=json.dumps(
+                    {"id": "project-01", "production_type": "short"}
+                ),
+            )
+            url = gazu.asset.get_all_assets_url({"id": "project-01"})
+            self.assertEqual(
+                url, f"{host}/productions/project-01/assets/"
+            )
+        # TV show: targets the "main" episode (mirrors get_asset_url)
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url("data/projects/project-01"),
+                text=json.dumps(
+                    {"id": "project-01", "production_type": "tvshow"}
+                ),
+            )
+            url = gazu.asset.get_all_assets_url({"id": "project-01"})
+            self.assertEqual(
+                url,
+                f"{host}/productions/project-01/episodes/main/assets/",
+            )
+
+    def test_get_asset_type_url(self):
+        host = gazu.client.get_api_url_from_host()
+        # Non-tvshow project, asset_type passed as dict (no extra fetch)
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url("data/projects/project-01"),
+                text=json.dumps(
+                    {"id": "project-01", "production_type": "short"}
+                ),
+            )
+            url = gazu.asset.get_asset_type_url(
+                {"id": "project-01"},
+                {"id": "asset-type-01", "name": "Character"},
+            )
+            self.assertEqual(
+                url,
+                f"{host}/productions/project-01/assets"
+                "?search=type%3D%5BCharacter%5D",
+            )
+        # TV show: search query lives on the episodes/main/assets URL
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url("data/projects/project-01"),
+                text=json.dumps(
+                    {"id": "project-01", "production_type": "tvshow"}
+                ),
+            )
+            url = gazu.asset.get_asset_type_url(
+                {"id": "project-01"},
+                {"id": "asset-type-01", "name": "Prop"},
+            )
+            self.assertEqual(
+                url,
+                f"{host}/productions/project-01/episodes/main/assets"
+                "?search=type%3D%5BProp%5D",
+            )
+        # Asset type passed by ID only — helper fetches the name
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url("data/projects/project-01"),
+                text=json.dumps(
+                    {"id": "project-01", "production_type": "short"}
+                ),
+            )
+            mock.get(
+                gazu.client.get_full_url(
+                    "data/asset-types/%s" % fakeid("asset-type-01")
+                ),
+                text=json.dumps(
+                    {"id": fakeid("asset-type-01"), "name": "Vehicle"}
+                ),
+            )
+            url = gazu.asset.get_asset_type_url(
+                {"id": "project-01"}, fakeid("asset-type-01")
+            )
+            self.assertEqual(
+                url,
+                f"{host}/productions/project-01/assets"
+                "?search=type%3D%5BVehicle%5D",
+            )
+
     def test_all_assets_for_open_projects(self):
         with requests_mock.mock() as mock:
             mock.get(

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -483,6 +483,105 @@ class PersonTestCase(unittest.TestCase):
             day_offs = gazu.person.get_year_day_offs(person_id, 2025)
             self.assertEqual(len(day_offs), 2)
 
+    def test_get_day_off(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/day-offs/%s" % fakeid("dayoff-1"),
+                text={
+                    "id": fakeid("dayoff-1"),
+                    "date": "2026-04-10",
+                    "end_date": "2026-04-11",
+                    "person_id": fakeid("person-1"),
+                },
+            )
+            day_off = gazu.person.get_day_off(fakeid("dayoff-1"))
+            self.assertEqual(day_off["id"], fakeid("dayoff-1"))
+            self.assertEqual(day_off["date"], "2026-04-10")
+
+    def test_new_day_off(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/day-offs",
+                text={
+                    "id": fakeid("dayoff-1"),
+                    "date": "2026-04-10",
+                    "end_date": "2026-04-11",
+                    "person_id": fakeid("person-1"),
+                    "description": "Vacances",
+                },
+                status_code=201,
+            )
+            day_off = gazu.person.new_day_off(
+                fakeid("person-1"),
+                "2026-04-10",
+                "2026-04-11",
+                description="Vacances",
+            )
+            self.assertEqual(day_off["id"], fakeid("dayoff-1"))
+            self.assertEqual(day_off["description"], "Vacances")
+            request_body = json.loads(mock.request_history[0].text)
+            self.assertEqual(request_body["person_id"], fakeid("person-1"))
+            self.assertEqual(request_body["date"], "2026-04-10")
+            self.assertEqual(request_body["end_date"], "2026-04-11")
+            self.assertEqual(request_body["description"], "Vacances")
+
+    def test_new_day_off_without_description(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/day-offs",
+                text={
+                    "id": fakeid("dayoff-1"),
+                    "date": "2026-04-10",
+                    "end_date": "2026-04-10",
+                    "person_id": fakeid("person-1"),
+                },
+                status_code=201,
+            )
+            day_off = gazu.person.new_day_off(
+                fakeid("person-1"), "2026-04-10", "2026-04-10"
+            )
+            self.assertEqual(day_off["id"], fakeid("dayoff-1"))
+            request_body = json.loads(mock.request_history[0].text)
+            self.assertNotIn("description", request_body)
+
+    def test_update_day_off(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "PUT",
+                "data/day-offs/%s" % fakeid("dayoff-1"),
+                text={
+                    "id": fakeid("dayoff-1"),
+                    "date": "2026-04-12",
+                    "end_date": "2026-04-14",
+                    "person_id": fakeid("person-1"),
+                },
+            )
+            day_off = gazu.person.update_day_off(
+                {
+                    "id": fakeid("dayoff-1"),
+                    "date": "2026-04-12",
+                    "end_date": "2026-04-14",
+                }
+            )
+            self.assertEqual(day_off["date"], "2026-04-12")
+
+    def test_remove_day_off(self):
+        with requests_mock.mock() as mock:
+            mock.delete(
+                gazu.client.get_full_url(
+                    "data/day-offs/%s" % fakeid("dayoff-1")
+                ),
+                status_code=204,
+            )
+            gazu.person.remove_day_off(fakeid("dayoff-1"))
+
     def test_add_person_to_department(self):
         with requests_mock.mock() as mock:
             person_id = fakeid("person-1")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -124,6 +124,60 @@ class ProjectTestCase(unittest.TestCase):
             self.assertEqual(project["name"], "project-1")
             self.assertEqual(project["id"], fakeid("project-1"))
 
+    def test_new_project_with_template(self):
+        with requests_mock.mock() as mock:
+            mock.post(
+                gazu.client.get_full_url("data/projects"),
+                text=json.dumps(
+                    {
+                        "id": fakeid("project-1"),
+                        "name": "project-1",
+                        "fps": "30",
+                    }
+                ),
+            )
+            mock.get(
+                gazu.client.get_full_url("data/projects?name=project-1"),
+                text=json.dumps([]),
+            )
+            project = gazu.project.new_project(
+                "project-1",
+                project_template={"id": fakeid("template-1")},
+            )
+            self.assertEqual(project["fps"], "30")
+            # Verify project_template_id was forwarded in the request body
+            request_body = json.loads(mock.request_history[-1].text)
+            self.assertEqual(
+                request_body["project_template_id"], fakeid("template-1")
+            )
+
+    def test_new_project_explicit_field_overrides_template(self):
+        with requests_mock.mock() as mock:
+            mock.post(
+                gazu.client.get_full_url("data/projects"),
+                text=json.dumps(
+                    {
+                        "id": fakeid("project-1"),
+                        "name": "project-1",
+                    }
+                ),
+            )
+            mock.get(
+                gazu.client.get_full_url("data/projects?name=project-1"),
+                text=json.dumps([]),
+            )
+            gazu.project.new_project(
+                "project-1",
+                production_type="featurefilm",
+                project_template={"id": fakeid("template-1")},
+            )
+            # gazu just forwards both — zou enforces the precedence rule
+            request_body = json.loads(mock.request_history[-1].text)
+            self.assertEqual(request_body["production_type"], "featurefilm")
+            self.assertEqual(
+                request_body["project_template_id"], fakeid("template-1")
+            )
+
     def test_remove_project(self):
         with requests_mock.mock() as mock:
             mock.delete(

--- a/tests/test_project_template.py
+++ b/tests/test_project_template.py
@@ -1,0 +1,318 @@
+import json
+import unittest
+
+import requests_mock
+
+import gazu.client
+import gazu.project_template
+
+from utils import fakeid, mock_route
+
+
+class ProjectTemplateTestCase(unittest.TestCase):
+    # ----- Listing -------------------------------------------------------
+
+    def test_all_project_templates(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/project-templates",
+                text=[
+                    {"id": fakeid("template-2"), "name": "Bravo"},
+                    {"id": fakeid("template-1"), "name": "Alpha"},
+                ],
+            )
+            templates = gazu.project_template.all_project_templates()
+            self.assertEqual(len(templates), 2)
+            # sort_by_name is applied
+            self.assertEqual(templates[0]["name"], "Alpha")
+            self.assertEqual(templates[1]["name"], "Bravo")
+
+    def test_get_project_template(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/project-templates/%s" % fakeid("template-1"),
+                text={"id": fakeid("template-1"), "name": "Alpha"},
+            )
+            template = gazu.project_template.get_project_template(
+                fakeid("template-1")
+            )
+            self.assertEqual(template["name"], "Alpha")
+
+    def test_get_project_template_by_name(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/project-templates",
+                text=[
+                    {"id": fakeid("template-1"), "name": "Series Setup"},
+                    {"id": fakeid("template-2"), "name": "Short Film"},
+                ],
+            )
+            template = gazu.project_template.get_project_template_by_name(
+                "Short Film"
+            )
+            self.assertEqual(template["id"], fakeid("template-2"))
+
+    # ----- CRUD ----------------------------------------------------------
+
+    def test_new_project_template(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/project-templates",
+                text={
+                    "id": fakeid("template-1"),
+                    "name": "Series Setup",
+                    "fps": "24",
+                },
+                status_code=201,
+            )
+            template = gazu.project_template.new_project_template(
+                name="Series Setup",
+                description="Animated series defaults",
+                fps="24",
+                production_type="tvshow",
+                production_style="3d",
+            )
+            self.assertEqual(template["name"], "Series Setup")
+            request_body = json.loads(mock.request_history[0].text)
+            self.assertEqual(request_body["name"], "Series Setup")
+            self.assertEqual(request_body["fps"], "24")
+            self.assertEqual(request_body["production_type"], "tvshow")
+
+    def test_update_project_template(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "PUT",
+                "data/project-templates/%s" % fakeid("template-1"),
+                text={
+                    "id": fakeid("template-1"),
+                    "name": "Updated",
+                    "description": "new desc",
+                },
+            )
+            updated = gazu.project_template.update_project_template(
+                {
+                    "id": fakeid("template-1"),
+                    "name": "Updated",
+                    "description": "new desc",
+                }
+            )
+            self.assertEqual(updated["description"], "new desc")
+
+    def test_remove_project_template(self):
+        with requests_mock.mock() as mock:
+            mock.delete(
+                gazu.client.get_full_url(
+                    "data/project-templates/%s" % fakeid("template-1")
+                ),
+                status_code=204,
+            )
+            gazu.project_template.remove_project_template(
+                {"id": fakeid("template-1"), "name": "Old"}
+            )
+
+    # ----- Snapshot / apply ---------------------------------------------
+
+    def test_new_project_template_from_project(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/project-templates/from-project/%s" % fakeid("project-1"),
+                text={"id": fakeid("template-1"), "name": "Snapshot"},
+                status_code=201,
+            )
+            template = (
+                gazu.project_template.new_project_template_from_project(
+                    {"id": fakeid("project-1")},
+                    name="Snapshot",
+                    description="from project",
+                )
+            )
+            self.assertEqual(template["name"], "Snapshot")
+
+    def test_apply_project_template(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/projects/%s/apply-template/%s"
+                % (fakeid("project-1"), fakeid("template-1")),
+                text={"id": fakeid("project-1"), "name": "Target"},
+            )
+            project = gazu.project_template.apply_project_template(
+                {"id": fakeid("project-1")},
+                {"id": fakeid("template-1")},
+            )
+            self.assertEqual(project["id"], fakeid("project-1"))
+
+    # ----- Link management ----------------------------------------------
+
+    def test_task_type_link_calls(self):
+        template_id = fakeid("template-1")
+        task_type_id = fakeid("task-type-1")
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/project-templates/%s/task-types" % template_id,
+                text=[{"id": task_type_id, "name": "Modeling"}],
+            )
+            mock_route(
+                mock,
+                "POST",
+                "data/project-templates/%s/task-types" % template_id,
+                text={
+                    "project_template_id": template_id,
+                    "task_type_id": task_type_id,
+                    "priority": 3,
+                },
+                status_code=201,
+            )
+            mock_route(
+                mock,
+                "DELETE",
+                "data/project-templates/%s/task-types/%s"
+                % (template_id, task_type_id),
+                status_code=204,
+            )
+
+            listed = (
+                gazu.project_template.all_task_types_for_project_template(
+                    {"id": template_id}
+                )
+            )
+            self.assertEqual(len(listed), 1)
+
+            link = gazu.project_template.add_task_type_to_project_template(
+                {"id": template_id},
+                {"id": task_type_id},
+                priority=3,
+            )
+            self.assertEqual(link["priority"], 3)
+
+            gazu.project_template.remove_task_type_from_project_template(
+                {"id": template_id}, {"id": task_type_id}
+            )
+
+    def test_task_status_link_calls(self):
+        template_id = fakeid("template-1")
+        task_status_id = fakeid("task-status-1")
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/project-templates/%s/task-statuses" % template_id,
+                text={
+                    "project_template_id": template_id,
+                    "task_status_id": task_status_id,
+                    "priority": 1,
+                    "roles_for_board": ["admin", "manager"],
+                },
+                status_code=201,
+            )
+            link = (
+                gazu.project_template.add_task_status_to_project_template(
+                    {"id": template_id},
+                    {"id": task_status_id},
+                    priority=1,
+                    roles_for_board=["admin", "manager"],
+                )
+            )
+            self.assertEqual(link["priority"], 1)
+            request_body = json.loads(mock.request_history[0].text)
+            self.assertEqual(
+                request_body["roles_for_board"], ["admin", "manager"]
+            )
+
+    def test_asset_type_link_calls(self):
+        template_id = fakeid("template-1")
+        asset_type_id = fakeid("asset-type-1")
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/project-templates/%s/asset-types" % template_id,
+                text={"id": asset_type_id, "name": "Props"},
+                status_code=201,
+            )
+            mock_route(
+                mock,
+                "DELETE",
+                "data/project-templates/%s/asset-types/%s"
+                % (template_id, asset_type_id),
+                status_code=204,
+            )
+
+            gazu.project_template.add_asset_type_to_project_template(
+                {"id": template_id}, {"id": asset_type_id}
+            )
+            gazu.project_template.remove_asset_type_from_project_template(
+                {"id": template_id}, {"id": asset_type_id}
+            )
+
+    def test_status_automation_link_calls(self):
+        template_id = fakeid("template-1")
+        automation_id = fakeid("automation-1")
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                "data/project-templates/%s/status-automations" % template_id,
+                text={"id": automation_id},
+                status_code=201,
+            )
+            mock_route(
+                mock,
+                "DELETE",
+                "data/project-templates/%s/status-automations/%s"
+                % (template_id, automation_id),
+                status_code=204,
+            )
+
+            gazu.project_template.add_status_automation_to_project_template(
+                {"id": template_id}, {"id": automation_id}
+            )
+            gazu.project_template.remove_status_automation_from_project_template(
+                {"id": template_id}, {"id": automation_id}
+            )
+
+    def test_set_project_template_metadata_descriptors(self):
+        template_id = fakeid("template-1")
+        descriptors = [
+            {
+                "name": "Difficulty",
+                "entity_type": "Asset",
+                "data_type": "list",
+                "choices": ["easy", "medium", "hard"],
+                "for_client": False,
+                "departments": [fakeid("department-1")],
+            }
+        ]
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "PUT",
+                "data/project-templates/%s/metadata-descriptors"
+                % template_id,
+                text={
+                    "id": template_id,
+                    "metadata_descriptors": descriptors,
+                },
+            )
+            updated = gazu.project_template.set_project_template_metadata_descriptors(
+                {"id": template_id}, descriptors
+            )
+            self.assertEqual(len(updated["metadata_descriptors"]), 1)
+            request_body = json.loads(mock.request_history[0].text)
+            self.assertEqual(
+                request_body["metadata_descriptors"][0]["name"], "Difficulty"
+            )

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -548,6 +548,65 @@ class ShotTestCase(unittest.TestCase):
                 % (fakeid("project-1"), fakeid("episode-1")),
             )
 
+    def test_get_all_episodes_url(self):
+        host = gazu.client.get_api_url_from_host()
+        url = gazu.shot.get_all_episodes_url({"id": fakeid("project-1")})
+        self.assertEqual(
+            url, f"{host}/productions/{fakeid('project-1')}/episodes/"
+        )
+
+    def test_get_all_sequences_url(self):
+        host = gazu.client.get_api_url_from_host()
+        url = gazu.shot.get_all_sequences_url({"id": fakeid("project-1")})
+        self.assertEqual(
+            url, f"{host}/productions/{fakeid('project-1')}/sequences/"
+        )
+
+    def test_get_sequence_url_non_episodic(self):
+        host = gazu.client.get_api_url_from_host()
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url(
+                    "data/sequences/%s" % fakeid("sequence-1")
+                ),
+                text=json.dumps(
+                    {
+                        "id": fakeid("sequence-1"),
+                        "project_id": fakeid("project-1"),
+                        "parent_id": None,
+                    }
+                ),
+            )
+            url = gazu.shot.get_sequence_url(fakeid("sequence-1"))
+            self.assertEqual(
+                url,
+                f"{host}/productions/{fakeid('project-1')}"
+                f"/sequences/{fakeid('sequence-1')}/",
+            )
+
+    def test_get_sequence_url_episodic(self):
+        host = gazu.client.get_api_url_from_host()
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url(
+                    "data/sequences/%s" % fakeid("sequence-1")
+                ),
+                text=json.dumps(
+                    {
+                        "id": fakeid("sequence-1"),
+                        "project_id": fakeid("project-1"),
+                        "parent_id": fakeid("episode-1"),
+                    }
+                ),
+            )
+            url = gazu.shot.get_sequence_url(fakeid("sequence-1"))
+            self.assertEqual(
+                url,
+                f"{host}/productions/{fakeid('project-1')}"
+                f"/episodes/{fakeid('episode-1')}"
+                f"/sequences/{fakeid('sequence-1')}/",
+            )
+
     def test_update_sequence(self):
         with requests_mock.mock() as mock:
             mock.put(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -468,6 +468,28 @@ class TaskTestCase(unittest.TestCase):
                 created_at=date,
             )
             self.assertEqual(comment, result)
+            self.assertEqual(mock.last_request.json()["for_client"], False)
+
+    def test_add_comment_for_client(self):
+        with requests_mock.mock() as mock:
+            result = {
+                "id": "comment-1",
+                "for_client": True,
+            }
+            mock_route(
+                mock,
+                "POST",
+                "actions/tasks/%s/comment" % fakeid("task-1"),
+                text=result,
+            )
+            comment = gazu.task.add_comment(
+                fakeid("task-1"),
+                fakeid("task-status-01"),
+                "Visible to client",
+                for_client=True,
+            )
+            self.assertEqual(comment, result)
+            self.assertEqual(mock.last_request.json()["for_client"], True)
 
     def test_remove_comment(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
## Problems

- No way to post a task comment flagged as visible to clients through the gazu client, even though Kitsu now exposes the new \`Comment.for_client\` column.

## Solutions

- Add an optional \`for_client=False\` parameter to \`task.add_comment()\` that is forwarded in the POST body. \`update_comment\` already accepts arbitrary dict keys so no other helper change is needed.