### PR TITLE
[playlists] Share-link wrappers + metadata entity_type filter

### DIFF
--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -483,3 +483,73 @@ def notify_clients_playlist_ready(
     return raw.post(
         f"data/playlists/{playlist['id']}/notify-clients", {}, client=client
     )
+
+
+def create_share_link(
+    playlist: str | dict,
+    expiration_date: str | None = None,
+    can_comment: bool = True,
+    password: str | None = None,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Generate a share link for a playlist. Only managers and above can
+    call this.
+
+    Args:
+        playlist (str / dict): The playlist dict or ID.
+        expiration_date (str): Optional ISO date for link expiry.
+        can_comment (bool): Whether guests can comment (default True).
+        password (str): Optional password protection.
+
+    Returns:
+        dict: Created share link with token.
+    """
+    playlist = normalize_model_parameter(playlist)
+    data = {"can_comment": can_comment}
+    if expiration_date:
+        data["expiration_date"] = expiration_date
+    if password:
+        data["password"] = password
+    return raw.post(
+        f"data/playlists/{playlist['id']}/share", data, client=client
+    )
+
+
+def get_share_links(
+    playlist: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    List all active share links for a playlist.
+
+    Args:
+        playlist (str / dict): The playlist dict or ID.
+
+    Returns:
+        list: Active share links.
+    """
+    playlist = normalize_model_parameter(playlist)
+    return raw.fetch_all(
+        f"playlists/{playlist['id']}/share", client=client
+    )
+
+
+def revoke_share_link(
+    playlist: str | dict,
+    token: str,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Revoke (deactivate) a share link.
+
+    Args:
+        playlist (str / dict): The playlist dict or ID.
+        token (str): The share link token to revoke.
+
+    Returns:
+        dict: Revoked share link.
+    """
+    playlist = normalize_model_parameter(playlist)
+    return raw.delete(
+        f"data/playlists/{playlist['id']}/share/{token}", client=client
+    )

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -485,7 +485,7 @@ def notify_clients_playlist_ready(
     )
 
 
-def create_share_link(
+def new_share_link(
     playlist: str | dict,
     expiration_date: str | None = None,
     can_comment: bool = True,
@@ -516,7 +516,7 @@ def create_share_link(
     )
 
 
-def get_share_links(
+def all_share_links_for_playlist(
     playlist: str | dict, client: KitsuClient = default
 ) -> list[dict]:
     """
@@ -534,11 +534,11 @@ def get_share_links(
     )
 
 
-def revoke_share_link(
+def remove_share_link(
     playlist: str | dict,
     token: str,
     client: KitsuClient = default,
-) -> dict:
+) -> str:
     """
     Revoke (deactivate) a share link.
 
@@ -547,7 +547,7 @@ def revoke_share_link(
         token (str): The share link token to revoke.
 
     Returns:
-        dict: Revoked share link.
+        str: API response.
     """
     playlist = normalize_model_parameter(playlist)
     return raw.delete(

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -435,22 +435,33 @@ def get_metadata_descriptor_by_field_name(
 
 
 def all_metadata_descriptors(
-    project: str | dict, client: KitsuClient = default
+    project: str | dict,
+    client: KitsuClient = default,
+    *,
+    entity_type: str | None = None,
 ) -> list[dict]:
     """
-    Get all the metadata descriptors.
+    Get all the metadata descriptors for a project.
 
     Args:
         project (dict / ID): The project dict or id.
+        entity_type (str, optional): If set, only descriptors for this
+            model are returned. Values match the API (e.g. "Asset",
+            "Shot", "Project"); casing is significant. Must be passed as a
+            keyword argument so a custom ``client`` can still be the second
+            positional parameter.
 
     Returns:
         list: The metadata descriptors.
     """
     project = normalize_model_parameter(project)
-    return raw.fetch_all(
+    descriptors = raw.fetch_all(
         f"projects/{project['id']}/metadata-descriptors",
         client=client,
     )
+    if entity_type is None:
+        return descriptors
+    return [d for d in descriptors if d.get("entity_type") == entity_type]
 
 
 def update_metadata_descriptor(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "pytest",
     "pytest-cov",
     "requests_mock",
-    "multipart; python_version >= '3.13'",
+    "multipart; python_version >= '3.8'",
 ]
 lint = [
     "autoflake==2.3.1; python_version >= '3.8'",

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -426,3 +426,49 @@ class TaskTestCase(unittest.TestCase):
                 fakeid("playlist-1")
             )
             self.assertEqual(response["status"], "notified")
+
+    def test_create_share_link(self):
+        with requests_mock.mock() as mock:
+            result = {
+                "id": fakeid("share-1"),
+                "token": "abc-123",
+                "can_comment": True,
+            }
+            mock.post(
+                gazu.client.get_full_url(
+                    f"data/playlists/{fakeid('playlist-1')}/share"
+                ),
+                text=json.dumps(result),
+            )
+            response = gazu.playlist.create_share_link(
+                fakeid("playlist-1"), can_comment=True
+            )
+            self.assertEqual(response["token"], "abc-123")
+
+    def test_get_share_links(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url(
+                    f"data/playlists/{fakeid('playlist-1')}/share"
+                ),
+                text=json.dumps(
+                    [{"id": fakeid("share-1"), "token": "abc-123"}]
+                ),
+            )
+            response = gazu.playlist.get_share_links(
+                fakeid("playlist-1")
+            )
+            self.assertEqual(len(response), 1)
+
+    def test_revoke_share_link(self):
+        with requests_mock.mock() as mock:
+            mock.delete(
+                gazu.client.get_full_url(
+                    f"data/playlists/{fakeid('playlist-1')}/share/abc-123"
+                ),
+                status_code=200,
+                text="",
+            )
+            gazu.playlist.revoke_share_link(
+                fakeid("playlist-1"), "abc-123"
+            )

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -427,7 +427,7 @@ class TaskTestCase(unittest.TestCase):
             )
             self.assertEqual(response["status"], "notified")
 
-    def test_create_share_link(self):
+    def test_new_share_link(self):
         with requests_mock.mock() as mock:
             result = {
                 "id": fakeid("share-1"),
@@ -440,12 +440,38 @@ class TaskTestCase(unittest.TestCase):
                 ),
                 text=json.dumps(result),
             )
-            response = gazu.playlist.create_share_link(
+            response = gazu.playlist.new_share_link(
                 fakeid("playlist-1"), can_comment=True
             )
             self.assertEqual(response["token"], "abc-123")
+            self.assertEqual(
+                mock.last_request.json(), {"can_comment": True}
+            )
 
-    def test_get_share_links(self):
+    def test_new_share_link_with_expiration_and_password(self):
+        with requests_mock.mock() as mock:
+            mock.post(
+                gazu.client.get_full_url(
+                    f"data/playlists/{fakeid('playlist-1')}/share"
+                ),
+                text=json.dumps({"id": fakeid("share-1"), "token": "x"}),
+            )
+            gazu.playlist.new_share_link(
+                fakeid("playlist-1"),
+                expiration_date="2026-12-31",
+                can_comment=False,
+                password="s3cret",
+            )
+            self.assertEqual(
+                mock.last_request.json(),
+                {
+                    "can_comment": False,
+                    "expiration_date": "2026-12-31",
+                    "password": "s3cret",
+                },
+            )
+
+    def test_all_share_links_for_playlist(self):
         with requests_mock.mock() as mock:
             mock.get(
                 gazu.client.get_full_url(
@@ -455,12 +481,12 @@ class TaskTestCase(unittest.TestCase):
                     [{"id": fakeid("share-1"), "token": "abc-123"}]
                 ),
             )
-            response = gazu.playlist.get_share_links(
+            response = gazu.playlist.all_share_links_for_playlist(
                 fakeid("playlist-1")
             )
             self.assertEqual(len(response), 1)
 
-    def test_revoke_share_link(self):
+    def test_remove_share_link(self):
         with requests_mock.mock() as mock:
             mock.delete(
                 gazu.client.get_full_url(
@@ -469,6 +495,6 @@ class TaskTestCase(unittest.TestCase):
                 status_code=200,
                 text="",
             )
-            gazu.playlist.revoke_share_link(
+            gazu.playlist.remove_share_link(
                 fakeid("playlist-1"), "abc-123"
             )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -358,6 +358,40 @@ class ProjectTestCase(unittest.TestCase):
                 metadata_descriptors[1]["id"], fakeid("metadata-descriptor-2")
             )
 
+    def test_all_metadata_descriptors_filter_entity_type(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                f"data/projects/{fakeid('project-1')}/metadata-descriptors",
+                text=[
+                    {
+                        "id": fakeid("metadata-descriptor-1"),
+                        "entity_type": "Project",
+                    },
+                    {
+                        "id": fakeid("metadata-descriptor-2"),
+                        "entity_type": "Asset",
+                    },
+                ],
+            )
+            all_desc = gazu.project.all_metadata_descriptors(
+                fakeid("project-1")
+            )
+            self.assertEqual(len(all_desc), 2)
+            project_desc = gazu.project.all_metadata_descriptors(
+                fakeid("project-1"), entity_type="Project"
+            )
+            self.assertEqual(len(project_desc), 1)
+            self.assertEqual(
+                project_desc[0]["id"], fakeid("metadata-descriptor-1")
+            )
+            self.assertEqual(project_desc[0]["entity_type"], "Project")
+            other_filter = gazu.project.all_metadata_descriptors(
+                fakeid("project-1"), entity_type="Sequence"
+            )
+            self.assertEqual(len(other_filter), 0)
+
     def test_update_metadata_descriptor(self):
         with requests_mock.mock() as mock:
             mock_route(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,7 +38,7 @@ def add_verify_file_callback(mock, dict_assert={}, url=None):
         if url is None or url == request.url:
             body_file = io.BytesIO(request.body)
 
-            if sys.version_info >= (3, 13):
+            if sys.version_info >= (3, 8):
                 import multipart
 
                 p = multipart.MultipartParser(
@@ -56,10 +56,7 @@ def add_verify_file_callback(mock, dict_assert={}, url=None):
                 import cgi
 
                 _, pdict = cgi.parse_header(request.headers["Content-Type"])
-                if sys.version_info[0] == 3:
-                    pdict["boundary"] = bytes(pdict["boundary"], "utf-8")
-                else:
-                    pdict["boundary"] = bytes(pdict["boundary"])
+                pdict["boundary"] = bytes(pdict["boundary"], "utf-8")
                 parsed = cgi.parse_multipart(fp=body_file, pdict=pdict)
             for key in dict_assert.keys():
                 assert key in parsed.keys()


### PR DESCRIPTION
## Problems

- gazu has no wrappers for the new playlist share-link routes added in cgwire/zou#1060, so pipeline scripts cannot create or revoke share links programmatically
- `all_metadata_descriptors` returns every descriptor for a project; callers cannot ask for the descriptors of a specific entity type and have to filter client-side
- Tests rely on the `cgi` module, which is removed in Python 3.13

## Solutions

- Add share-link management wrappers in `gazu/playlist.py` (`all_*`, `get_*`, `new_*`, `remove_*`) following the gazu naming conventions, with `requests_mock` tests
- Accept an optional `entity_type` argument on `all_metadata_descriptors` in `gazu/project.py` to filter server-side, with a matching test
- Replace the deprecated `cgi.parse_multipart` call in `tests/utils.py` with the `multipart` package for Python >= 3.8 compatibility