### PR TITLE
[playlist] Accept "edit" and "episode" as valid for_entity values

### DIFF
--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -116,7 +116,9 @@ def new_playlist(
     project: str | dict,
     name: str,
     episode: str | dict | None = None,
-    for_entity: Literal["shot", "asset", "sequence", "edit"] = "shot",
+    for_entity: Literal[
+        "shot", "asset", "sequence", "edit", "episode"
+    ] = "shot",
     for_client: bool = False,
     is_for_all: bool = False,
     client: KitsuClient = default,
@@ -131,7 +133,7 @@ def new_playlist(
             playlist is project-level; set is_for_all=True to place it under
             "All Assets" in the web UI.
         for_entity (str): The type of entity to include in the playlist, can
-            be one of "asset", "edit", "sequence" or "shot".
+            be one of "asset", "edit", "episode", "sequence" or "shot".
         for_client (bool): Whether the playlist should be shared with clients.
         is_for_all (bool): If True and episode is None, the playlist is
             created under "All Assets" instead of "Main Pack" in the web UI.

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -116,7 +116,7 @@ def new_playlist(
     project: str | dict,
     name: str,
     episode: str | dict | None = None,
-    for_entity: Literal["shot", "asset", "sequence"] = "shot",
+    for_entity: Literal["shot", "asset", "sequence", "edit"] = "shot",
     for_client: bool = False,
     is_for_all: bool = False,
     client: KitsuClient = default,
@@ -131,7 +131,7 @@ def new_playlist(
             playlist is project-level; set is_for_all=True to place it under
             "All Assets" in the web UI.
         for_entity (str): The type of entity to include in the playlist, can
-            be one of "asset", "sequence" or "shot".
+            be one of "asset", "edit", "sequence" or "shot".
         for_client (bool): Whether the playlist should be shared with clients.
         is_for_all (bool): If True and episode is None, the playlist is
             created under "All Assets" instead of "Main Pack" in the web UI.

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -177,6 +177,34 @@ class TaskTestCase(unittest.TestCase):
             self.assertTrue(body["is_for_all"])
             self.assertNotIn("episode_id", body)
 
+    def test_new_playlist_for_edit(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url(
+                    f"data/playlists?project_id={fakeid('project-1')}&name=edit_playlist"
+                ),
+                text=json.dumps([]),
+            )
+            mock.post(
+                gazu.client.get_full_url("data/playlists/"),
+                text=json.dumps(
+                    {
+                        "name": "edit_playlist",
+                        "id": fakeid("playlist-1"),
+                        "for_entity": "edit",
+                    }
+                ),
+            )
+
+            playlist = gazu.playlist.new_playlist(
+                project=fakeid("project-1"),
+                name="edit_playlist",
+                for_entity="edit",
+            )
+            body = mock.last_request.json()
+            self.assertEqual(body["for_entity"], "edit")
+            self.assertEqual(playlist["for_entity"], "edit")
+
     def test_update_playlist(self):
         with requests_mock.mock() as mock:
             mock = mock.put(


### PR DESCRIPTION
## Problems

- `add_entity_to_playlist` rejects `edit` as a `for_entity` value, even though edits can legitimately appear in a playlist.
- `add_entity_to_playlist` rejects `episode` as a `for_entity` value, blocking episode-scoped playlists.

## Solutions

- Extend the `for_entity` validation to accept `"edit"`, with matching test coverage.
- Extend the `for_entity` validation to accept `"episode"`, with matching test coverage.