### PR TITLE
[tasks] Add move_comment_to_task wrapper

### DIFF
--- a/gazu/task.py
+++ b/gazu/task.py
@@ -1927,6 +1927,38 @@ def remove_preview_from_comment(
     )
 
 
+def move_comment_to_task(
+    task: str | dict,
+    comment: str | dict,
+    target_task: str | dict,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Move a comment from its current task to another task that belongs to the
+    same entity. Reserved to production managers and studio admins. The
+    original creation date, text, attachments, mentions and status change
+    carried by the comment are preserved. Notifications and news are rebuilt
+    against the target task as if a new comment was posted.
+
+    Args:
+        task (str / dict): The task dict or id currently holding the comment.
+        comment (str / dict): The comment dict or id to move.
+        target_task (str / dict): The destination task dict or id. Must
+            belong to the same entity as the current task.
+
+    Returns:
+        dict: Updated comment whose object_id is now the target task id.
+    """
+    task = normalize_model_parameter(task)
+    comment = normalize_model_parameter(comment)
+    target_task = normalize_model_parameter(target_task)
+    return raw.post(
+        f"actions/tasks/{task['id']}/comments/{comment['id']}/move",
+        {"target_task_id": target_task["id"]},
+        client=client,
+    )
+
+
 def acknowledge_comment(
     task: str | dict,
     comment: str | dict,

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1379,6 +1379,25 @@ class TaskTestCase(unittest.TestCase):
             self.assertEqual(result["id"], fakeid("comment-1"))
             self.assertTrue(result["acknowledged"])
 
+    def test_move_comment_to_task(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                f"actions/tasks/{fakeid('task-1')}/comments/{fakeid('comment-1')}/move",
+                text={
+                    "id": fakeid("comment-1"),
+                    "object_id": fakeid("task-2"),
+                },
+            )
+            result = gazu.task.move_comment_to_task(
+                fakeid("task-1"),
+                fakeid("comment-1"),
+                fakeid("task-2"),
+            )
+            self.assertEqual(result["id"], fakeid("comment-1"))
+            self.assertEqual(result["object_id"], fakeid("task-2"))
+
     def test_reply_to_comment(self):
         with requests_mock.mock() as mock:
             mock_route(


### PR DESCRIPTION
## Problems

- No client wrapper for zou's new `POST /actions/tasks/<task_id>/comments/<comment_id>/move` endpoint, so callers can't re-target a misposted comment without recreating it.

## Solutions

- Add `move_comment_to_task(task, comment, new_task)` in `gazu/task.py`, normalising dict-or-id inputs like the other comment helpers, with a matching `requests_mock` test.