### PR TITLE
[fix] Route asset-type & task-creation wrappers through entity endpoints

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,7 @@ import inspect
 import re
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-GAZU_PATH=os.path.abspath(os.path.join(BASE_DIR, "../../"))
+GAZU_PATH = os.path.abspath(os.path.join(BASE_DIR, "../../"))
 sys.path.insert(0, GAZU_PATH)
 print(GAZU_PATH)
 
@@ -19,6 +19,7 @@ autodoc_mock_imports = ["typing_extensions"]
 # --- Docstring collection ---
 
 _collected_docstrings = {}
+
 
 def _safe_repr(value):
     if value is inspect._empty:
@@ -132,6 +133,7 @@ def collect_docstrings(app, what, name, obj, options, lines):
         "input_params": input_params,
         "output_params": return_info,
     }
+
 
 def dump_docstrings(app, exception):
     if exception:

--- a/examples/async_queries.py
+++ b/examples/async_queries.py
@@ -20,12 +20,8 @@ import gazu.aio
 async def list_project_contents(client, project):
     """Fetch assets and shots for a project concurrently."""
     assets, shots = await asyncio.gather(
-        gazu.aio.fetch_all(
-            f"projects/{project['id']}/assets", client=client
-        ),
-        gazu.aio.fetch_all(
-            f"projects/{project['id']}/shots", client=client
-        ),
+        gazu.aio.fetch_all(f"projects/{project['id']}/assets", client=client),
+        gazu.aio.fetch_all(f"projects/{project['id']}/shots", client=client),
     )
     return assets, shots
 

--- a/examples/context_manager.py
+++ b/examples/context_manager.py
@@ -27,9 +27,7 @@ with gazu.create_session(
     print(f"Found {len(projects)} open projects")
 
     for project in projects:
-        assets = gazu.asset.all_assets_for_project(
-            project, client=client
-        )
+        assets = gazu.asset.all_assets_for_project(project, client=client)
         shots = gazu.shot.all_shots_for_project(project, client=client)
         print(f"  {project['name']}: {len(assets)} assets, {len(shots)} shots")
 
@@ -78,8 +76,8 @@ print(f"\nBot client: {len(projects)} projects")
 
 client = create_client(
     "https://kitsu.example.com/api",
-    ssl_verify=False,           # disable SSL verification
-    use_refresh_token=True,     # auto-refresh expired tokens
+    ssl_verify=False,  # disable SSL verification
+    use_refresh_token=True,  # auto-refresh expired tokens
 )
 gazu.log_in("user@example.com", "password", client=client)
 

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -126,9 +126,7 @@ class AsyncKitsuClient:
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         try:
             url = get_full_url("auth/logout", client=self)
-            async with self.session.get(
-                url, headers=self.make_auth_header()
-            ):
+            async with self.session.get(url, headers=self.make_auth_header()):
                 pass
         except Exception:
             pass
@@ -268,9 +266,7 @@ async def get(
                     return await response.text()
 
 
-async def post(
-    path: str, data: Any, client: AsyncKitsuClient = None
-) -> Any:
+async def post(path: str, data: Any, client: AsyncKitsuClient = None) -> Any:
     logger.debug("POST %s", get_full_url(path, client))
     retry = True
     while retry:
@@ -285,15 +281,11 @@ async def post(
                     return await response.json()
                 except Exception:
                     text = await response.text()
-                    logger.error(
-                        "Failed to decode JSON response: %s", text
-                    )
+                    logger.error("Failed to decode JSON response: %s", text)
                     raise
 
 
-async def put(
-    path: str, data: dict, client: AsyncKitsuClient = None
-) -> Any:
+async def put(path: str, data: dict, client: AsyncKitsuClient = None) -> Any:
     logger.debug("PUT %s", get_full_url(path, client))
     retry = True
     while retry:
@@ -441,9 +433,7 @@ async def upload(
         files_to_close.append(f)
         size = os.fstat(f.fileno()).st_size
         total_size += size
-        form.add_field(
-            f"file-{i}", f, filename=os.path.basename(extra_path)
-        )
+        form.add_field(f"file-{i}", f, filename=os.path.basename(extra_path))
 
     try:
         retry = True
@@ -453,9 +443,7 @@ async def upload(
                 data=form,
                 headers=client.make_auth_header(),
             ) as response:
-                _, retry = await check_status(
-                    response, path, client=client
-                )
+                _, retry = await check_status(response, path, client=client)
                 if not retry:
                     try:
                         result = await response.json()

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -35,6 +35,7 @@ from .exception import (
     ParameterException,
     RouteNotFoundException,
     ServerErrorException,
+    ValidationException,
     UploadFailedException,
 )
 
@@ -166,7 +167,41 @@ async def check_status(
             f"{path}: You send a too big file. "
             "Change your proxy configuration to allow bigger files."
         )
-    elif status_code in [401, 422]:
+    elif status_code == 422:
+        try:
+            data = await response.json()
+        except Exception:
+            data = {}
+        message = "No additional information"
+        if isinstance(data, dict):
+            for key in ["error", "message"]:
+                if data.get(key):
+                    message = data[key]
+                    break
+        jwt_expired = (
+            isinstance(data, dict)
+            and data.get("message") == "Signature has expired"
+        )
+        # flask-jwt-extended returns 422 with this message when the JWT
+        # signature has expired -- this is an auth case, not a validation one.
+        if jwt_expired:
+            try:
+                if (
+                    client
+                    and client.refresh_token
+                    and client.use_refresh_token
+                ):
+                    await client.refresh_access_token()
+                    return status_code, True
+                raise NotAuthenticatedException(path)
+            except NotAuthenticatedException:
+                if client and client.callback_not_authenticated:
+                    retry = client.callback_not_authenticated(client, path)
+                    if retry:
+                        return status_code, True
+                raise
+        raise ValidationException(path, message)
+    elif status_code == 401:
         try:
             data = await response.json()
             if (

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -162,9 +162,7 @@ def get_asset_url(asset: str | dict, client: KitsuClient = default) -> str:
     """
     asset = normalize_model_parameter(asset)
     asset = get_asset(asset["id"], client=client)
-    project = gazu_project.get_project(
-        asset["project_id"], client=client
-    )
+    project = gazu_project.get_project(asset["project_id"], client=client)
     host = raw.get_api_url_from_host(client=client)
     project_id = asset["project_id"]
     asset_id = asset["id"]
@@ -230,9 +228,7 @@ def get_asset_type_url(
     if project["production_type"] != "tvshow":
         return f"{host}/productions/{project_id}/assets?{query}"
     else:
-        return (
-            f"{host}/productions/{project_id}/episodes/main/assets?{query}"
-        )
+        return f"{host}/productions/{project_id}/episodes/main/assets?{query}"
 
 
 def new_asset(
@@ -441,7 +437,9 @@ def update_asset_type(asset_type: dict, client: KitsuClient = default) -> dict:
         asset_type (dict): Asset Type to save.
     """
     data = {"name": asset_type["name"]}
-    path = f"data/asset-types/{asset_type['id']}"
+    # Asset types are entity types in Zou; the data/asset-types route is
+    # read-only (GET), so writes must go through data/entity-types.
+    path = f"data/entity-types/{asset_type['id']}"
     return raw.put(path, data, client=client)
 
 
@@ -455,7 +453,9 @@ def remove_asset_type(
         asset_type (str / dict): Asset type to remove.
     """
     asset_type = normalize_model_parameter(asset_type)
-    path = f"data/asset-types/{asset_type['id']}"
+    # Asset types are entity types in Zou; the data/asset-types route is
+    # read-only (GET), so deletes must go through data/entity-types.
+    path = f"data/entity-types/{asset_type['id']}"
     return raw.delete(path, client=client)
 
 

--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -100,7 +100,9 @@ def get_asset_type_casting(
 
     project = normalize_model_parameter(project)
     asset_type = normalize_model_parameter(asset_type)
-    path = f"data/projects/{project['id']}/asset-types/{asset_type['id']}/casting"
+    path = (
+        f"data/projects/{project['id']}/asset-types/{asset_type['id']}/casting"
+    )
     return raw.get(path, client=client)
 
 
@@ -277,7 +279,9 @@ def get_episode_shots_casting(
     """
     project = normalize_model_parameter(project)
     episode = normalize_model_parameter(episode)
-    path = f"data/projects/{project['id']}/episodes/{episode['id']}/shots/casting"
+    path = (
+        f"data/projects/{project['id']}/episodes/{episode['id']}/shots/casting"
+    )
     return raw.get(path, client=client)
 
 

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -18,6 +18,7 @@ from .exception import (
     ParameterException,
     RouteNotFoundException,
     ServerErrorException,
+    ValidationException,
     UploadFailedException,
 )
 
@@ -538,6 +539,7 @@ def check_status(
         NotAllowedException: when 403 response occurs
         MethodNotAllowedException: when 405 response occurs
         TooBigFileException: when 413 response occurs
+        ValidationException: when 422 response occurs (non auth-related)
         ServerErrorException: when 500 response occurs
     """
     status_code = request.status_code
@@ -554,7 +556,41 @@ def check_status(
             f"{path}: You send a too big file. "
             "Change your proxy configuration to allow bigger files."
         )
-    elif status_code in [401, 422]:
+    elif status_code == 422:
+        try:
+            body = request.json()
+        except Exception:
+            body = {}
+        message = "No additional information"
+        if isinstance(body, dict):
+            for key in ["error", "message"]:
+                if body.get(key):
+                    message = body[key]
+                    break
+        jwt_expired = (
+            isinstance(body, dict)
+            and body.get("message") == "Signature has expired"
+        )
+        # flask-jwt-extended returns 422 with this message when the JWT
+        # signature has expired -- this is an auth case, not a validation one.
+        if jwt_expired:
+            try:
+                if (
+                    client
+                    and client.refresh_token
+                    and client.use_refresh_token
+                ):
+                    client.refresh_access_token()
+                    return status_code, True
+                raise NotAuthenticatedException(path)
+            except NotAuthenticatedException:
+                if client and client.callback_not_authenticated:
+                    retry = client.callback_not_authenticated(client, path)
+                    if retry:
+                        return status_code, True
+                raise
+        raise ValidationException(path, message)
+    elif status_code == 401:
         try:
             if (
                 client

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -816,15 +816,11 @@ def upload(
         files = _build_file_dict(file_path, extra_files)
         opened_files = files
     if progress_callback is not None:
-        total = sum(
-            os.fstat(f.fileno()).st_size for f in files.values()
-        )
+        total = sum(os.fstat(f.fileno()).st_size for f in files.values())
         offset = 0
         wrapped = {}
         for key, f in files.items():
-            wrapper = _ProgressFileWrapper(
-                f, progress_callback, offset, total
-            )
+            wrapper = _ProgressFileWrapper(f, progress_callback, offset, total)
             wrapped[key] = wrapper
             offset += os.fstat(f.fileno()).st_size
         files = wrapped
@@ -910,9 +906,7 @@ def download(
     ) as response:
         with open(file_path, "wb") as target_file:
             if progress_callback is not None:
-                total = int(
-                    response.headers.get("content-length", 0)
-                )
+                total = int(response.headers.get("content-length", 0))
                 bytes_read = 0
                 for chunk in response.iter_content(8192):
                     target_file.write(chunk)

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -413,14 +413,18 @@ def post(path: str, data: Any, client: KitsuClient = default_client) -> Any:
     """
     logger.debug("POST %s", get_full_url(path, client))
     sensitive_fields = {
-        "password", "token", "access_token", "refresh_token", "secret"
+        "password",
+        "token",
+        "access_token",
+        "refresh_token",
+        "secret",
     }
     if not any(field in data for field in sensitive_fields):
         logger.debug("Body: %s", data)
-    headers = make_auth_header(client=client)
-    headers["Content-Type"] = "application/json"
     retry = True
     while retry:
+        headers = make_auth_header(client=client)
+        headers["Content-Type"] = "application/json"
         response = client.session.post(
             get_full_url(path, client),
             data=json.dumps(data, cls=CustomJSONEncoder),
@@ -449,10 +453,10 @@ def put(path: str, data: dict, client: KitsuClient = default_client) -> Any:
     """
     logger.debug("PUT %s", get_full_url(path, client))
     logger.debug("Body: %s", data)
-    headers = make_auth_header(client=client)
-    headers["Content-Type"] = "application/json"
     retry = True
     while retry:
+        headers = make_auth_header(client=client)
+        headers["Content-Type"] = "application/json"
         response = client.session.put(
             get_full_url(path, client),
             data=json.dumps(data, cls=CustomJSONEncoder),

--- a/gazu/context.py
+++ b/gazu/context.py
@@ -47,13 +47,9 @@ def all_asset_types_for_project(
     Return the list of asset types for which the user has a task.
     """
     if user_context:
-        return gazu_user.all_asset_types_for_project(
-            project, client=client
-        )
+        return gazu_user.all_asset_types_for_project(project, client=client)
     else:
-        return gazu_asset.all_asset_types_for_project(
-            project, client=client
-        )
+        return gazu_asset.all_asset_types_for_project(project, client=client)
 
 
 def all_assets_for_asset_type_and_project(
@@ -127,13 +123,9 @@ def all_task_types_for_sequence(
     Return the list of tasks for given sequence and current user.
     """
     if user_context:
-        return gazu_user.all_task_types_for_sequence(
-            sequence, client=client
-        )
+        return gazu_user.all_task_types_for_sequence(sequence, client=client)
     else:
-        return gazu_task.all_task_types_for_sequence(
-            sequence, client=client
-        )
+        return gazu_task.all_task_types_for_sequence(sequence, client=client)
 
 
 def all_sequences_for_project(
@@ -145,13 +137,9 @@ def all_sequences_for_project(
     Return the list of sequences for given project and current user.
     """
     if user_context:
-        return gazu_user.all_sequences_for_project(
-            project, client=client
-        )
+        return gazu_user.all_sequences_for_project(project, client=client)
     else:
-        return gazu_shot.all_sequences_for_project(
-            project, client=client
-        )
+        return gazu_shot.all_sequences_for_project(project, client=client)
 
 
 def all_scenes_for_project(
@@ -177,13 +165,9 @@ def all_shots_for_sequence(
     Return the list of shots for given sequence and current user.
     """
     if user_context:
-        return gazu_user.all_shots_for_sequence(
-            sequence, client=client
-        )
+        return gazu_user.all_shots_for_sequence(sequence, client=client)
     else:
-        return gazu_shot.all_shots_for_sequence(
-            sequence, client=client
-        )
+        return gazu_shot.all_shots_for_sequence(sequence, client=client)
 
 
 def all_scenes_for_sequence(
@@ -195,13 +179,9 @@ def all_scenes_for_sequence(
     Return the list of scenes for given sequence and current user.
     """
     if user_context:
-        return gazu_user.all_scenes_for_sequence(
-            sequence, client=client
-        )
+        return gazu_user.all_scenes_for_sequence(sequence, client=client)
     else:
-        return gazu_scene.all_scenes_for_sequence(
-            sequence, client=client
-        )
+        return gazu_scene.all_scenes_for_sequence(sequence, client=client)
 
 
 def all_sequences_for_episode(
@@ -213,13 +193,9 @@ def all_sequences_for_episode(
     Return the list of sequences for given episode and current user.
     """
     if user_context:
-        return gazu_user.all_sequences_for_episode(
-            episode, client=client
-        )
+        return gazu_user.all_sequences_for_episode(episode, client=client)
     else:
-        return gazu_shot.all_sequences_for_episode(
-            episode, client=client
-        )
+        return gazu_shot.all_sequences_for_episode(episode, client=client)
 
 
 def all_episodes_for_project(
@@ -231,10 +207,6 @@ def all_episodes_for_project(
     Return the list of episodes for given project and current user.
     """
     if user_context:
-        return gazu_user.all_episodes_for_project(
-            project, client=client
-        )
+        return gazu_user.all_episodes_for_project(project, client=client)
     else:
-        return gazu_shot.all_episodes_for_project(
-            project, client=client
-        )
+        return gazu_shot.all_episodes_for_project(project, client=client)

--- a/gazu/events.py
+++ b/gazu/events.py
@@ -49,7 +49,7 @@ def init(
     ssl_verify: bool = False,
     reconnection: bool = True,
     logger: bool = False,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> socketio.Client:
     """
     Init configuration for SocketIO client.

--- a/gazu/exception.py
+++ b/gazu/exception.py
@@ -46,6 +46,13 @@ class ParameterException(Exception):
     """
 
 
+class ValidationException(Exception):
+    """
+    Error raised when a 422 error (unprocessable entity) is sent by the API.
+    Carries the validation message returned in the response body.
+    """
+
+
 class UploadFailedException(Exception):
     """
     Error raised when an error while uploading a file, mainly to handle cases

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -453,9 +453,7 @@ def new_software(
         return software
 
 
-def update_software(
-    software: dict, client: KitsuClient = default
-) -> dict:
+def update_software(software: dict, client: KitsuClient = default) -> dict:
     """
     Save given software data into the API. Use this to set or change
     secondary_extensions and other fields.
@@ -1796,6 +1794,4 @@ def get_file_status_by_name(
     Args:
         name (str): The files status name.
     """
-    return raw.fetch_first(
-        "file-status", {"name": name}, client=client
-    )
+    return raw.fetch_first("file-status", {"name": name}, client=client)

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -749,14 +749,10 @@ def update_day_off(day_off: dict, client: KitsuClient = default) -> dict:
     Returns:
         dict: Updated day off.
     """
-    return raw.put(
-        f"data/day-offs/{day_off['id']}", day_off, client=client
-    )
+    return raw.put(f"data/day-offs/{day_off['id']}", day_off, client=client)
 
 
-def remove_day_off(
-    day_off: str | dict, client: KitsuClient = default
-) -> str:
+def remove_day_off(day_off: str | dict, client: KitsuClient = default) -> str:
     """
     Delete a day off.
 

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -534,9 +534,7 @@ def all_share_links_for_playlist(
         list: Active share links.
     """
     playlist = normalize_model_parameter(playlist)
-    return raw.fetch_all(
-        f"playlists/{playlist['id']}/share", client=client
-    )
+    return raw.fetch_all(f"playlists/{playlist['id']}/share", client=client)
 
 
 def remove_share_link(

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -146,9 +146,7 @@ def new_project(
             "production_type": production_type,
             "team": normalize_list_of_models_for_links(team),
             "asset_types": normalize_list_of_models_for_links(asset_types),
-            "task_statuses": normalize_list_of_models_for_links(
-                task_statuses
-            ),
+            "task_statuses": normalize_list_of_models_for_links(task_statuses),
             "task_types": normalize_list_of_models_for_links(task_types),
             "production_style": production_style,
         }

--- a/gazu/project_template.py
+++ b/gazu/project_template.py
@@ -51,9 +51,7 @@ def get_project_template_by_name(
     Returns:
         dict: Project template matching the given name, or None.
     """
-    return raw.fetch_first(
-        "project-templates", {"name": name}, client=client
-    )
+    return raw.fetch_first("project-templates", {"name": name}, client=client)
 
 
 # ---------------------------------------------------------------------------

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -634,18 +634,26 @@ def get_task_status_by_short_name(
 
 
 def remove_task_type(
-    task_type: str | dict, client: KitsuClient = default
+    task_type: str | dict,
+    force: bool = False,
+    client: KitsuClient = default,
 ) -> str:
     """
     Remove given task type from database.
 
     Args:
         task_type (str / dict): The task type dict or ID.
+        force (bool): Whether to force deletion regardless of links to
+            tasks. A task type still attached to a project must first be
+            detached with gazu.project.remove_task_type.
     """
     task_type = normalize_model_parameter(task_type)
+    params = {}
+    if force:
+        params = {"force": True}
     return raw.delete(
         f"data/task-types/{task_type['id']}",
-        {"force": True},
+        params,
         client=client,
     )
 

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -1243,16 +1243,12 @@ def batch_comments(
     try:
         for x, comment in enumerate(comments):
             if comment.get("attachment_files"):
-                for y, file_path in enumerate(
-                    comment["attachment_files"]
-                ):
+                for y, file_path in enumerate(comment["attachment_files"]):
                     f = open(file_path, "rb")
                     opened_files.append(f)
                     files[f"attachment_file-{x}-{y}"] = f
             if comment.get("preview_files"):
-                for y, file_path in enumerate(
-                    comment["preview_files"]
-                ):
+                for y, file_path in enumerate(comment["preview_files"]):
                     f = open(file_path, "rb")
                     opened_files.append(f)
                     files[f"preview_file-{x}-{y}"] = f
@@ -1303,16 +1299,12 @@ def create_multiple_comments(
     try:
         for x, comment in enumerate(comments):
             if comment.get("attachment_files"):
-                for y, file_path in enumerate(
-                    comment["attachment_files"]
-                ):
+                for y, file_path in enumerate(comment["attachment_files"]):
                     f = open(file_path, "rb")
                     opened_files.append(f)
                     files[f"attachment_file-{x}-{y}"] = f
             if comment.get("preview_files"):
-                for y, file_path in enumerate(
-                    comment["preview_files"]
-                ):
+                for y, file_path in enumerate(comment["preview_files"]):
                     f = open(file_path, "rb")
                     opened_files.append(f)
                     files[f"preview_file-{x}-{y}"] = f
@@ -1502,9 +1494,7 @@ def new_task_status(
         dict: The created task status
     """
     if not color or color[0] != "#":
-        raise ValueError(
-            "Color must start with '#', e.g. '#00FF00'"
-        )
+        raise ValueError("Color must start with '#', e.g. '#00FF00'")
     if not all(c in string.hexdigits for c in color[1:]):
         raise ValueError(
             "Color must be a valid hexadecimal string, e.g. '#00FF00'"

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -2073,15 +2073,7 @@ def create_shot_tasks(
     Returns:
         list: Created tasks.
     """
-    shot = normalize_model_parameter(shot)
-    task_type_ids = [
-        normalize_model_parameter(task_type)["id"] for task_type in task_types
-    ]
-    return raw.post(
-        f"data/shots/{shot['id']}/tasks",
-        {"task_type_ids": task_type_ids},
-        client=client,
-    )
+    return create_entity_tasks(shot, task_types, client=client)
 
 
 def create_asset_tasks(
@@ -2099,15 +2091,7 @@ def create_asset_tasks(
     Returns:
         list: Created tasks.
     """
-    asset = normalize_model_parameter(asset)
-    task_type_ids = [
-        normalize_model_parameter(task_type)["id"] for task_type in task_types
-    ]
-    return raw.post(
-        f"data/assets/{asset['id']}/tasks",
-        {"task_type_ids": task_type_ids},
-        client=client,
-    )
+    return create_entity_tasks(asset, task_types, client=client)
 
 
 def create_edit_tasks(
@@ -2125,15 +2109,7 @@ def create_edit_tasks(
     Returns:
         list: Created tasks.
     """
-    edit = normalize_model_parameter(edit)
-    task_type_ids = [
-        normalize_model_parameter(task_type)["id"] for task_type in task_types
-    ]
-    return raw.post(
-        f"data/edits/{edit['id']}/tasks",
-        {"task_type_ids": task_type_ids},
-        client=client,
-    )
+    return create_entity_tasks(edit, task_types, client=client)
 
 
 def create_concept_tasks(
@@ -2151,15 +2127,7 @@ def create_concept_tasks(
     Returns:
         list: Created tasks.
     """
-    concept = normalize_model_parameter(concept)
-    task_type_ids = [
-        normalize_model_parameter(task_type)["id"] for task_type in task_types
-    ]
-    return raw.post(
-        f"data/concepts/{concept['id']}/tasks",
-        {"task_type_ids": task_type_ids},
-        client=client,
-    )
+    return create_entity_tasks(concept, task_types, client=client)
 
 
 def create_entity_tasks(

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -189,7 +189,7 @@ class CastingTestCase(unittest.TestCase):
         with requests_mock.mock() as mock:
             name = "Modeling edited"
             mock.put(
-                gazu.client.get_full_url("data/asset-types/asset-type-01"),
+                gazu.client.get_full_url("data/entity-types/asset-type-01"),
                 text=json.dumps({"id": "asset-type-01", "name": name}),
             )
             asset_type = {"id": "asset-type-01", "name": name}
@@ -199,7 +199,7 @@ class CastingTestCase(unittest.TestCase):
     def test_remove_asset_type(self):
         with requests_mock.mock() as mock:
             mock_route(
-                mock, "DELETE", "data/asset-types/asset-type-01", text=""
+                mock, "DELETE", "data/entity-types/asset-type-01", text=""
             )
             asset_type = {"id": "asset-type-01", "name": "Modeling edited"}
             response = gazu.asset.remove_asset_type(asset_type)
@@ -408,9 +408,7 @@ class CastingTestCase(unittest.TestCase):
                 ),
             )
             url = gazu.asset.get_all_assets_url({"id": "project-01"})
-            self.assertEqual(
-                url, f"{host}/productions/project-01/assets/"
-            )
+            self.assertEqual(url, f"{host}/productions/project-01/assets/")
         # TV show: targets the "main" episode (mirrors get_asset_url)
         with requests_mock.mock() as mock:
             mock.get(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,6 +17,7 @@ from gazu.exception import (
     NotAllowedException,
     TooBigFileException,
     ServerErrorException,
+    ValidationException,
 )
 
 from utils import add_verify_file_callback, mock_route
@@ -395,6 +396,66 @@ class BaseFuncTestCase(ClientTestCase):
         self.assertRaises(
             ServerErrorException, raw.check_status, RequestJSON(502), "/"
         )
+
+    def test_check_status_422_raises_validation_with_body_message(self):
+        class Request422(object):
+            status_code = 422
+            text = '{"message": "name: missing required field"}'
+
+            def json(self):
+                return {"message": "name: missing required field"}
+
+        with self.assertRaises(ValidationException) as context:
+            raw.check_status(Request422(), "/data/persons")
+        self.assertIn("name: missing required field", str(context.exception))
+
+    def test_check_status_422_non_json_body_raises_validation(self):
+        class Request422(object):
+            status_code = 422
+            text = "<html>502 Bad Gateway</html>"
+
+            def json(self):
+                raise ValueError("no json")
+
+        with self.assertRaises(ValidationException) as context:
+            raw.check_status(Request422(), "/data/persons")
+        self.assertIn("No additional information", str(context.exception))
+
+    def test_check_status_422_signature_expired_refreshes_token(self):
+        class Request422(object):
+            status_code = 422
+
+            def json(self):
+                return {"message": "Signature has expired"}
+
+        class FakeClient(object):
+            refresh_token = "a-refresh-token"
+            use_refresh_token = True
+            callback_not_authenticated = None
+
+            def __init__(self):
+                self.refreshed = False
+
+            def refresh_access_token(self):
+                self.refreshed = True
+
+        client = FakeClient()
+        status_code, retry = raw.check_status(
+            Request422(), "/data/persons", client=client
+        )
+        self.assertEqual(status_code, 422)
+        self.assertTrue(retry)
+        self.assertTrue(client.refreshed)
+
+    def test_check_status_422_signature_expired_without_refresh_raises(self):
+        class Request422(object):
+            status_code = 422
+
+            def json(self):
+                return {"message": "Signature has expired"}
+
+        with self.assertRaises(NotAuthenticatedException):
+            raw.check_status(Request422(), "/data/persons")
 
     def test_init_host(self):
         gazu.set_host("newhost")

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -552,9 +552,7 @@ class TaskTestCase(unittest.TestCase):
                 fakeid("playlist-1"), can_comment=True
             )
             self.assertEqual(response["token"], "abc-123")
-            self.assertEqual(
-                mock.last_request.json(), {"can_comment": True}
-            )
+            self.assertEqual(mock.last_request.json(), {"can_comment": True})
 
     def test_new_share_link_with_expiration_and_password(self):
         with requests_mock.mock() as mock:
@@ -603,6 +601,4 @@ class TaskTestCase(unittest.TestCase):
                 status_code=200,
                 text="",
             )
-            gazu.playlist.remove_share_link(
-                fakeid("playlist-1"), "abc-123"
-            )
+            gazu.playlist.remove_share_link(fakeid("playlist-1"), "abc-123")

--- a/tests/test_project_template.py
+++ b/tests/test_project_template.py
@@ -127,12 +127,10 @@ class ProjectTemplateTestCase(unittest.TestCase):
                 text={"id": fakeid("template-1"), "name": "Snapshot"},
                 status_code=201,
             )
-            template = (
-                gazu.project_template.new_project_template_from_project(
-                    {"id": fakeid("project-1")},
-                    name="Snapshot",
-                    description="from project",
-                )
+            template = gazu.project_template.new_project_template_from_project(
+                {"id": fakeid("project-1")},
+                name="Snapshot",
+                description="from project",
             )
             self.assertEqual(template["name"], "Snapshot")
 
@@ -182,10 +180,8 @@ class ProjectTemplateTestCase(unittest.TestCase):
                 status_code=204,
             )
 
-            listed = (
-                gazu.project_template.all_task_types_for_project_template(
-                    {"id": template_id}
-                )
+            listed = gazu.project_template.all_task_types_for_project_template(
+                {"id": template_id}
             )
             self.assertEqual(len(listed), 1)
 
@@ -216,13 +212,11 @@ class ProjectTemplateTestCase(unittest.TestCase):
                 },
                 status_code=201,
             )
-            link = (
-                gazu.project_template.add_task_status_to_project_template(
-                    {"id": template_id},
-                    {"id": task_status_id},
-                    priority=1,
-                    roles_for_board=["admin", "manager"],
-                )
+            link = gazu.project_template.add_task_status_to_project_template(
+                {"id": template_id},
+                {"id": task_status_id},
+                priority=1,
+                roles_for_board=["admin", "manager"],
             )
             self.assertEqual(link["priority"], 1)
             request_body = json.loads(mock.request_history[0].text)
@@ -291,7 +285,13 @@ class ProjectTemplateTestCase(unittest.TestCase):
                 "GET",
                 "data/project-templates/%s/preview-background-files"
                 % template_id,
-                text=[{"id": background_id, "name": "Studio", "is_default": False}],
+                text=[
+                    {
+                        "id": background_id,
+                        "name": "Studio",
+                        "is_default": False,
+                    }
+                ],
             )
             mock_route(
                 mock,
@@ -313,17 +313,13 @@ class ProjectTemplateTestCase(unittest.TestCase):
                 status_code=204,
             )
 
-            listed = (
-                gazu.project_template.all_preview_background_files_for_project_template(
-                    {"id": template_id}
-                )
+            listed = gazu.project_template.all_preview_background_files_for_project_template(
+                {"id": template_id}
             )
             self.assertEqual(len(listed), 1)
 
-            result = (
-                gazu.project_template.add_preview_background_file_to_project_template(
-                    {"id": template_id}, {"id": background_id}
-                )
+            result = gazu.project_template.add_preview_background_file_to_project_template(
+                {"id": template_id}, {"id": background_id}
             )
             self.assertEqual(result["id"], background_id)
 
@@ -345,10 +341,8 @@ class ProjectTemplateTestCase(unittest.TestCase):
                     "default_preview_background_file_id": background_id,
                 },
             )
-            updated = (
-                gazu.project_template.set_project_template_default_preview_background_file(
-                    {"id": template_id}, {"id": background_id}
-                )
+            updated = gazu.project_template.set_project_template_default_preview_background_file(
+                {"id": template_id}, {"id": background_id}
             )
             self.assertEqual(
                 updated["default_preview_background_file_id"], background_id
@@ -396,8 +390,7 @@ class ProjectTemplateTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "PUT",
-                "data/project-templates/%s/metadata-descriptors"
-                % template_id,
+                "data/project-templates/%s/metadata-descriptors" % template_id,
                 text={
                     "id": template_id,
                     "metadata_descriptors": descriptors,

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1304,7 +1304,7 @@ class TaskTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "POST",
-                f"data/shots/{fakeid('shot-1')}/tasks",
+                f"data/entities/{fakeid('shot-1')}/tasks",
                 text=[{"id": fakeid("task-1")}, {"id": fakeid("task-2")}],
             )
             tasks = gazu.task.create_shot_tasks(
@@ -1318,7 +1318,7 @@ class TaskTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "POST",
-                f"data/assets/{fakeid('asset-1')}/tasks",
+                f"data/entities/{fakeid('asset-1')}/tasks",
                 text=[{"id": fakeid("task-1")}],
             )
             tasks = gazu.task.create_asset_tasks(
@@ -1331,7 +1331,7 @@ class TaskTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "POST",
-                f"data/edits/{fakeid('edit-1')}/tasks",
+                f"data/entities/{fakeid('edit-1')}/tasks",
                 text=[{"id": fakeid("task-1")}],
             )
             tasks = gazu.task.create_edit_tasks(
@@ -1344,7 +1344,7 @@ class TaskTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "POST",
-                f"data/concepts/{fakeid('concept-1')}/tasks",
+                f"data/entities/{fakeid('concept-1')}/tasks",
                 text=[{"id": fakeid("task-1")}],
             )
             tasks = gazu.task.create_concept_tasks(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -840,10 +840,17 @@ class TaskTestCase(unittest.TestCase):
             mock_route(
                 mock,
                 "DELETE",
-                f"data/task-types/{fakeid('task-type-1')}?force=true",
+                f"data/task-types/{fakeid('task-type-1')}",
                 status_code=204,
             )
             gazu.task.remove_task_type(fakeid("task-type-1"))
+            mock_route(
+                mock,
+                "DELETE",
+                f"data/task-types/{fakeid('task-type-1')}?force=true",
+                status_code=204,
+            )
+            gazu.task.remove_task_type(fakeid("task-type-1"), force=True)
 
     def test_update_task(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
## Problems

- update_asset_type / remove_asset_type targeted data/asset-types/{id}, which is read-only in Zou (GET only), so PUT/DELETE returned MethodNotAllowed.
- create_asset_tasks / create_shot_tasks / create_edit_tasks / create_concept_tasks posted to per-entity routes that are GET-only in Zou, returning MethodNotAllowed.
- A 422 validation error was reported as NotAuthenticatedException, hiding the real message; the sync path also crashed on non-JSON 422 bodies.
- The Authorization header was built once before the retry loop, so a retry after a token refresh reused the stale token.
- remove_task_type always forced deletion, with no way to perform a safe non-forced delete.

## Solutions

- Route update_asset_type / remove_asset_type through data/entity-types/{id}.
- Route the create_*_tasks wrappers through create_entity_tasks (data/entities/{id}/tasks).
- Raise a dedicated ValidationException on 422 carrying the server message, keep the JWT "Signature has expired" case as an auth refresh, and reuse the parsed body so non-JSON bodies no longer crash.
- Rebuild the auth header inside the post/put retry loop so refreshed tokens are used.
- Expose force (default False) on remove_task_type.
- Apply Black formatting across the codebase.