### PR TITLE
[fix] Route assign_task task_ids as a list and surface validation errors

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -509,13 +509,33 @@ def get_message_from_response(
         str: The message to display to the user.
     """
     message = default_message
-    message_json = response.json()
+    try:
+        message_json = response.json()
+    except ValueError:
+        return message
 
     if isinstance(message_json, dict):
-        for key in ["error", "message"]:
-            if message_json.get(key):
-                message = message_json[key]
+        for key in ["message", "error"]:
+            value = message_json.get(key)
+            # Zou sends a boolean "error" flag alongside the human-readable
+            # "message", so only keep string values here.
+            if isinstance(value, str) and value:
+                message = value
                 break
+
+        # Pydantic validation failures carry field-level details in
+        # data.errors ([{"field": ..., "message": ...}]); surface them so the
+        # caller sees what was actually rejected.
+        data = message_json.get("data")
+        errors = data.get("errors") if isinstance(data, dict) else None
+        if isinstance(errors, list) and errors:
+            details = ", ".join(
+                f"{error.get('field')}: {error.get('message')}"
+                for error in errors
+                if isinstance(error, dict)
+            )
+            if details:
+                message = f"{message} ({details})"
 
     return message
 

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -1499,7 +1499,7 @@ def assign_task(
     person = normalize_model_parameter(person)
     task = normalize_model_parameter(task)
     path = f"/actions/persons/{person['id']}/assign"
-    return raw.put(path, {"task_ids": task["id"]}, client=client)
+    return raw.put(path, {"task_ids": [task["id"]]}, client=client)
 
 
 def clear_assignations(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -421,6 +421,42 @@ class BaseFuncTestCase(ClientTestCase):
             raw.check_status(Request422(), "/data/persons")
         self.assertIn("No additional information", str(context.exception))
 
+    def test_get_message_from_response_ignores_error_flag(self):
+        # Zou sends a boolean "error" flag next to the real "message"; the
+        # boolean must not be returned in place of the message.
+        class Response(object):
+            def json(self):
+                return {"error": True, "message": "Validation error."}
+
+        message = raw.get_message_from_response(Response())
+        self.assertEqual(message, "Validation error.")
+
+    def test_get_message_from_response_appends_field_errors(self):
+        class Response(object):
+            def json(self):
+                return {
+                    "error": True,
+                    "message": "Validation error.",
+                    "data": {
+                        "errors": [
+                            {"field": "task_ids", "message": "Tasks required."}
+                        ]
+                    },
+                }
+
+        message = raw.get_message_from_response(Response())
+        self.assertEqual(
+            message, "Validation error. (task_ids: Tasks required.)"
+        )
+
+    def test_get_message_from_response_non_json(self):
+        class Response(object):
+            def json(self):
+                raise ValueError("no json")
+
+        message = raw.get_message_from_response(Response())
+        self.assertEqual(message, "No additional information")
+
     def test_check_status_422_signature_expired_refreshes_token(self):
         class Request422(object):
             status_code = 422

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -528,6 +528,10 @@ class TaskTestCase(unittest.TestCase):
                 {"id": "task-01"}, {"id": "person-01"}
             )[0]
             self.assertIn("person-01", task["assignees"])
+            # The endpoint expects task_ids as a list, not a single string.
+            self.assertEqual(
+                mock.last_request.json(), {"task_ids": ["task-01"]}
+            )
 
     def test_new_task_type(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
## Problems

- assign_task sent task_ids as a single string, so Zou's AssignTasksSchema (List[str]) rejected it with a 400 (issue #410).
- get_message_from_response returned Zou's boolean "error" flag instead of the "message", and dropped data.errors, leaving callers with an opaque error.

## Solutions

- Wrap the task id in a list when calling /actions/persons/<id>/assign.
- Prefer the "message" key, ignore non-string values, and append field-level data.errors to the message.
- Cover the assign_task payload and the message parsing (boolean flag, field errors, non-JSON body) with tests.