### PR TITLE
[fix] Harden client edge cases, add async tests, refresh docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,18 @@ jobs:
       - name: Run tests 🧪
         run: >-
           py.test
+
+  audit:
+    name: Audit dependencies for known vulnerabilities 🔒
+    runs-on: ubuntu-latest
+    # Advisory only: a new CVE in a dependency should not block the build.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install pip-audit 📦
+        run: python -m pip install --upgrade pip pip-audit
+      - name: Run pip-audit 🔍
+        run: pip-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `gazu.scene` and `gazu.search` are now importable from the top-level package.
 - `events` connections verify SSL certificates by default (`ssl_verify=True`).
+- `files.get_last_entity_output_revision` and
+  `files.get_last_asset_instance_output_revision` return 0 (instead of 1)
+  when no output file exists yet.
 - Deduplicated the avatar, sync id-map and JWT-refresh helpers.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- `context.all_assets_for_project` / `all_scenes_for_project` /
+  `all_sequences_for_episode` no longer raise `AttributeError` when
+  `user_context=True` (the missing `gazu.user` functions were added).
+- `batch_comments` and `create_multiple_comments` no longer crash when a
+  `progress_callback` is provided.
+- `gazu.aio.check_status` no longer raises a raw decode error on a non-JSON
+  400/401 response body.
+- `extract_frame_from_preview` / `extract_tile_from_preview` no longer crash
+  when called without a `file_path` (the response is returned without saving).
+- `gazu.aio.AsyncKitsuClient.refresh_access_token` raises
+  `NotAuthenticatedException` when no refresh token is set.
+- `sort_by_name` tolerates entities whose `name` is `None`.
+- `person.update_person` guards the `departments` handling against string IDs.
+- `user.all_episodes_for_project` normalizes its `project` argument.
+- Synchronisation is resilient to ids not present in the mapping tables
+  (unmapped tasks/comments are skipped and logged instead of aborting).
+- `playlist.add_entity_to_playlist` no longer mutates the playlist argument.
+
+### Changed
+
+- `gazu.scene` and `gazu.search` are now importable from the top-level package.
+- `events` connections verify SSL certificates by default (`ssl_verify=True`).
+- Deduplicated the avatar, sync id-map and JWT-refresh helpers.
+
+### Security
+
+- Removed root-level scratch scripts that contained hard-coded credentials.
+
+### Documentation / CI
+
+- Documented the `async` extra and the top-level auth helpers.
+- Added the async, CLI and helper modules to the Sphinx reference.
+- Added a (non-blocking) `pip-audit` job to CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Gazu is a Python client for the Kitsu API (https://zou.cg-wire.com), a collabora
 
 ```bash
 # Install dependencies (dev mode)
-pip install -e .[dev,test]
+# Optional extras: dev, test, lint, async, cli
+pip install -e .[dev,test,lint]
 
 # Run all tests
 py.test
@@ -24,12 +25,14 @@ py.test tests/test_asset.py::AssetTestCase::test_get_asset
 # Run with coverage
 py.test --cov=gazu
 
-# Format code (requires Python 3.9+)
+# Format code (black is in the `lint` extra; requires Python 3.10+)
 black .
 
 # Install pre-commit hooks
 pre-commit install
 ```
+
+The package targets Python 3.7+ (tested up to 3.14).
 
 ## Architecture
 
@@ -48,15 +51,25 @@ Each module in `gazu/` corresponds to a Kitsu entity type and follows consistent
 - `remove_*()` - Delete entity
 
 Key modules:
-- `asset.py`, `shot.py`, `scene.py`, `edit.py`, `entity.py` - Production entities
+- `asset.py`, `shot.py`, `scene.py`, `edit.py`, `concept.py`, `entity.py` - Production entities
 - `task.py` - Task management and comments
 - `files.py` - File versioning and output files
 - `person.py` - User and time tracking
+- `user.py` - Data accessible to the currently logged user
 - `casting.py` - Asset-to-shot linking
 - `playlist.py` - Review playlists
 - `sync.py` - Data synchronization between instances
-- `project.py` - Project settings and data
-- `context.py` - Connected user data 
+- `project.py` / `project_template.py` - Project settings, data and templates
+- `studio.py` - Studios and departments
+- `search.py` - Cross-entity search
+- `context.py` - Connected user data
+- `helpers.py`, `sorting.py` - Shared utilities (id normalization, sorting)
+
+### Command-line Interface (`gazu/cli.py`)
+Exposed as the `gazu-cli` entry point (requires the `cli` extra, which pulls in `click`).
+
+### Async Support (`gazu/aio.py`)
+Async primitives for the Kitsu API built on `aiohttp` (requires the `async` extra).
 
 ### Caching (`gazu/cache.py`)
 Decorator-based caching system: use `@cache` decorator on functions, control with `gazu.cache.enable()` / `gazu.cache.disable()`.

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,12 @@ Install Gazu in your application environment via pip:
 
     pip install gazu
 
+For the asynchronous API (``gazu.aio``), install the ``async`` extra:
+
+.. code:: bash
+
+    pip install gazu[async]
+
 The client requires a few extra configurations before being used. It
 needs to know where is located the API server and to log in:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,12 +3,26 @@
 .. autofunction:: gazu.set_host
 .. autofunction:: gazu.send_email_otp
 .. autofunction:: gazu.log_out
-.. autofunction:: gazu.refresh_token
+.. autofunction:: gazu.refresh_access_token
 .. autofunction:: gazu.get_event_host
 .. autofunction:: gazu.set_event_host
+.. autofunction:: gazu.create_session
+.. autofunction:: gazu.set_token
+.. automodule:: gazu.aio
+    :members:
 .. automodule:: gazu.asset
     :members:
 .. automodule:: gazu.cache
+    :members:
+.. automodule:: gazu.cli
+    :members:
+.. automodule:: gazu.encoder
+    :members:
+.. automodule:: gazu.helpers
+    :members:
+.. automodule:: gazu.project_template
+    :members:
+.. automodule:: gazu.sorting
     :members:
 .. automodule:: gazu.casting
     :members:

--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -27,6 +27,8 @@ from . import files
 from . import project
 from . import project_template
 from . import person
+from . import scene
+from . import search
 from . import shot
 from . import studio
 from . import sync
@@ -44,10 +46,12 @@ from .__version__ import __version__
 
 
 def get_host(client=raw.default_client):
+    """Return the API host currently configured on the client."""
     return raw.get_host(client=client)
 
 
 def set_host(url, client=raw.default_client):
+    """Set the API host to query (e.g. "https://kitsu.example.com/api")."""
     raw.set_host(url, client=client)
 
 
@@ -60,6 +64,23 @@ def log_in(
     recovery_code=None,
     client=raw.default_client,
 ):
+    """
+    Log in and store the returned tokens on the client for later requests.
+
+    Args:
+        email (str): User email.
+        password (str): User password.
+        totp (str): TOTP code for 2FA.
+        email_otp (str): Email OTP code.
+        fido_authentication_response: FIDO authentication response.
+        recovery_code (str): Recovery code.
+
+    Returns:
+        dict: The authentication tokens returned by the API.
+
+    Raises:
+        AuthFailedException: when the credentials are rejected.
+    """
     tokens = {}
     try:
         tokens = raw.post(
@@ -85,10 +106,12 @@ def log_in(
 
 
 def send_email_otp(email, client=raw.default_client):
+    """Ask the API to send a one-time password to the given email."""
     return raw.get("auth/email-otp", params={"email": email}, client=client)
 
 
 def log_out(client=raw.default_client):
+    """Log out and clear the tokens stored on the client."""
     tokens = {}
     try:
         raw.get("auth/logout", client=client)
@@ -99,14 +122,17 @@ def log_out(client=raw.default_client):
 
 
 def refresh_access_token(client=raw.default_client):
+    """Refresh the access token using the stored refresh token."""
     return client.refresh_access_token()
 
 
 def get_event_host(client=raw.default_client):
+    """Return the event (websocket) host configured on the client."""
     return raw.get_event_host(client=client)
 
 
 def set_event_host(url, client=raw.default_client):
+    """Set the event (websocket) host used to listen to Kitsu events."""
     raw.set_event_host(url, client=client)
 
 

--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -46,12 +46,16 @@ from .__version__ import __version__
 
 
 def get_host(client=raw.default_client):
-    """Return the API host currently configured on the client."""
+    """
+    Return the API host currently configured on the client.
+    """
     return raw.get_host(client=client)
 
 
 def set_host(url, client=raw.default_client):
-    """Set the API host to query (e.g. "https://kitsu.example.com/api")."""
+    """
+    Set the API host to query (e.g. "https://kitsu.example.com/api").
+    """
     raw.set_host(url, client=client)
 
 
@@ -106,12 +110,16 @@ def log_in(
 
 
 def send_email_otp(email, client=raw.default_client):
-    """Ask the API to send a one-time password to the given email."""
+    """
+    Ask the API to send a one-time password to the given email.
+    """
     return raw.get("auth/email-otp", params={"email": email}, client=client)
 
 
 def log_out(client=raw.default_client):
-    """Log out and clear the tokens stored on the client."""
+    """
+    Log out and clear the tokens stored on the client.
+    """
     tokens = {}
     try:
         raw.get("auth/logout", client=client)
@@ -122,17 +130,23 @@ def log_out(client=raw.default_client):
 
 
 def refresh_access_token(client=raw.default_client):
-    """Refresh the access token using the stored refresh token."""
+    """
+    Refresh the access token using the stored refresh token.
+    """
     return client.refresh_access_token()
 
 
 def get_event_host(client=raw.default_client):
-    """Return the event (websocket) host configured on the client."""
+    """
+    Return the event (websocket) host configured on the client.
+    """
     return raw.get_event_host(client=client)
 
 
 def set_event_host(url, client=raw.default_client):
-    """Set the event (websocket) host used to listen to Kitsu events."""
+    """
+    Set the event (websocket) host used to listen to Kitsu events.
+    """
     raw.set_event_host(url, client=client)
 
 

--- a/gazu/__init__.py
+++ b/gazu/__init__.py
@@ -1,16 +1,22 @@
+import logging
+
 from . import client as raw
 from . import cache
 from . import helpers
 
+_logger = logging.getLogger("gazu")
+
+# events and aio rely on optional dependencies; log the cause instead of
+# hiding every ImportError.
 try:
     from . import events
-except ImportError:
-    pass
+except ImportError as exc:
+    _logger.debug("gazu.events unavailable: %s", exc)
 
 try:
     from . import aio
-except ImportError:
-    pass
+except ImportError as exc:
+    _logger.debug("gazu.aio unavailable: %s", exc)
 
 from . import asset
 from . import casting

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -24,7 +24,7 @@ from .__version__ import __version__
 from .client import (
     url_path_join,
     build_path_with_params,
-    get_message_from_response as _sync_get_message,
+    MAX_AUTH_RETRIES,
 )
 from .encoder import CustomJSONEncoder
 from .exception import (
@@ -117,8 +117,7 @@ class AsyncKitsuClient:
             await check_status(response, "auth/refresh-token")
             tokens = await response.json()
         self.access_token = tokens["access_token"]
-        # Keep the existing refresh token unless the server returns a new one,
-        # so automatic refresh keeps working on the next expiry.
+        # Keep the current refresh token unless the server returns a new one.
         self.refresh_token = tokens.get("refresh_token", self.refresh_token)
         return tokens
 
@@ -254,8 +253,7 @@ async def get(
 ) -> Any:
     logger.debug("GET %s", get_full_url(path, client))
     path = build_path_with_params(path, params)
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         async with client.session.get(
             get_full_url(path, client),
             headers=client.make_auth_header(),
@@ -266,12 +264,12 @@ async def get(
                     return await response.json()
                 else:
                     return await response.text()
+    raise NotAuthenticatedException(path)
 
 
 async def post(path: str, data: Any, client: AsyncKitsuClient = None) -> Any:
     logger.debug("POST %s", get_full_url(path, client))
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         async with client.session.post(
             get_full_url(path, client),
             json=data,
@@ -285,12 +283,12 @@ async def post(path: str, data: Any, client: AsyncKitsuClient = None) -> Any:
                     text = await response.text()
                     logger.error("Failed to decode JSON response: %s", text)
                     raise
+    raise NotAuthenticatedException(path)
 
 
 async def put(path: str, data: dict, client: AsyncKitsuClient = None) -> Any:
     logger.debug("PUT %s", get_full_url(path, client))
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         async with client.session.put(
             get_full_url(path, client),
             json=data,
@@ -299,6 +297,7 @@ async def put(path: str, data: dict, client: AsyncKitsuClient = None) -> Any:
             _, retry = await check_status(response, path, client=client)
             if not retry:
                 return await response.json()
+    raise NotAuthenticatedException(path)
 
 
 async def delete(
@@ -308,8 +307,7 @@ async def delete(
 ) -> str:
     logger.debug("DELETE %s", get_full_url(path, client))
     path = build_path_with_params(path, params)
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         async with client.session.delete(
             get_full_url(path, client),
             headers=client.make_auth_header(),
@@ -317,6 +315,7 @@ async def delete(
             _, retry = await check_status(response, path, client=client)
             if not retry:
                 return await response.text()
+    raise NotAuthenticatedException(path)
 
 
 async def fetch_all(
@@ -438,8 +437,7 @@ async def upload(
         form.add_field(f"file-{i}", f, filename=os.path.basename(extra_path))
 
     try:
-        retry = True
-        while retry:
+        for _ in range(MAX_AUTH_RETRIES):
             async with client.session.post(
                 url,
                 data=form,
@@ -455,6 +453,9 @@ async def upload(
                             "Failed to decode JSON response: %s", text
                         )
                         raise
+                    break
+        else:
+            raise NotAuthenticatedException(path)
     finally:
         for f in files_to_close:
             f.close()

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -5,7 +5,7 @@ Usage::
 
     import gazu.aio
 
-    async with gazu.aio.create_session(host, email, password) as client:
+    async with await gazu.aio.create_session(host, email, password) as client:
         data = await gazu.aio.get("data/projects", client=client)
 
 No default client is provided -- always pass an explicit ``client``.
@@ -40,6 +40,18 @@ from .exception import (
 )
 
 logger = logging.getLogger("gazu.aio")
+
+
+def _message_from_data(
+    data: Any, default: str = "No additional information"
+) -> str:
+    """Extract Zou's error/message string from a parsed JSON body."""
+    if isinstance(data, dict):
+        for key in ("error", "message"):
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return default
 
 
 class AsyncKitsuClient:
@@ -152,13 +164,7 @@ async def check_status(
         raise NotAllowedException(path)
     elif status_code == 400:
         data = await response.json()
-        message = "No additional information"
-        if isinstance(data, dict):
-            for key in ["error", "message"]:
-                if data.get(key):
-                    message = data[key]
-                    break
-        raise ParameterException(path, message)
+        raise ParameterException(path, _message_from_data(data))
     elif status_code == 405:
         raise MethodNotAllowedException(path)
     elif status_code == 413:
@@ -171,12 +177,6 @@ async def check_status(
             data = await response.json()
         except Exception:
             data = {}
-        message = "No additional information"
-        if isinstance(data, dict):
-            for key in ["error", "message"]:
-                if data.get(key):
-                    message = data[key]
-                    break
         jwt_expired = (
             isinstance(data, dict)
             and data.get("message") == "Signature has expired"
@@ -199,7 +199,7 @@ async def check_status(
                     if retry:
                         return status_code, True
                 raise
-        raise ValidationException(path, message)
+        raise ValidationException(path, _message_from_data(data))
     elif status_code == 401:
         try:
             data = await response.json()
@@ -225,12 +225,9 @@ async def check_status(
             stacktrace = data.get(
                 "stacktrace", "No stacktrace sent by the server"
             )
-            message = "No message sent by the server"
-            if isinstance(data, dict):
-                for key in ["error", "message"]:
-                    if data.get(key):
-                        message = data[key]
-                        break
+            message = _message_from_data(
+                data, default="No message sent by the server"
+            )
             logger.error(
                 "A server error occurred!\n"
                 "Server stacktrace:\n%s\n"
@@ -460,12 +457,7 @@ async def upload(
         for f in files_to_close:
             f.close()
 
-    message = ""
-    if isinstance(result, dict):
-        for key in ["error", "message"]:
-            if result.get(key):
-                message = result[key]
-                break
+    message = _message_from_data(result, default="")
     if message:
         raise UploadFailedException(message)
 

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -24,6 +24,7 @@ from .__version__ import __version__
 from .client import (
     url_path_join,
     build_path_with_params,
+    get_message_from_data,
     MAX_AUTH_RETRIES,
 )
 from .encoder import CustomJSONEncoder
@@ -40,20 +41,6 @@ from .exception import (
 )
 
 logger = logging.getLogger("gazu.aio")
-
-
-def _message_from_data(
-    data: Any, default: str = "No additional information"
-) -> str:
-    """
-    Extract Zou's error/message string from a parsed JSON body.
-    """
-    if isinstance(data, dict):
-        for key in ("error", "message"):
-            value = data.get(key)
-            if isinstance(value, str) and value:
-                return value
-    return default
 
 
 class AsyncKitsuClient:
@@ -156,6 +143,39 @@ def get_full_url(path: str, client: AsyncKitsuClient) -> str:
     return url_path_join(client.host, path)
 
 
+async def _handle_auth_expiry(
+    client: AsyncKitsuClient | None, path: str, can_refresh: bool
+) -> bool:
+    """
+    Handle an expired/invalid JWT: refresh the access token when possible,
+    otherwise fall back to the not-authenticated callback.
+
+    Async mirror of ``client._handle_auth_expiry``.
+
+    Returns:
+        bool: True when the request should be retried.
+
+    Raises:
+        NotAuthenticatedException: when the token can't be refreshed and no
+            callback authorizes a retry.
+    """
+    try:
+        if (
+            can_refresh
+            and client
+            and client.refresh_token
+            and client.use_refresh_token
+        ):
+            await client.refresh_access_token()
+            return True
+        raise NotAuthenticatedException(path)
+    except NotAuthenticatedException:
+        if client and client.callback_not_authenticated:
+            if client.callback_not_authenticated(client, path):
+                return True
+        raise
+
+
 async def check_status(
     response: aiohttp.ClientResponse,
     path: str,
@@ -171,7 +191,7 @@ async def check_status(
             data = await response.json()
         except Exception:
             data = {}
-        raise ParameterException(path, _message_from_data(data))
+        raise ParameterException(path, get_message_from_data(data))
     elif status_code == 405:
         raise MethodNotAllowedException(path)
     elif status_code == 413:
@@ -191,51 +211,29 @@ async def check_status(
         # flask-jwt-extended returns 422 with this message when the JWT
         # signature has expired -- this is an auth case, not a validation one.
         if jwt_expired:
-            try:
-                if (
-                    client
-                    and client.refresh_token
-                    and client.use_refresh_token
-                ):
-                    await client.refresh_access_token()
-                    return status_code, True
-                raise NotAuthenticatedException(path)
-            except NotAuthenticatedException:
-                if client and client.callback_not_authenticated:
-                    retry = client.callback_not_authenticated(client, path)
-                    if retry:
-                        return status_code, True
-                raise
-        raise ValidationException(path, _message_from_data(data))
+            return status_code, await _handle_auth_expiry(
+                client, path, can_refresh=True
+            )
+        raise ValidationException(path, get_message_from_data(data))
     elif status_code == 401:
         try:
-            try:
-                data = await response.json()
-            except Exception:
-                data = {}
-            if (
-                client
-                and client.refresh_token
-                and client.use_refresh_token
-                and data.get("message") == "Signature has expired"
-            ):
-                await client.refresh_access_token()
-                return status_code, True
-            else:
-                raise NotAuthenticatedException(path)
-        except NotAuthenticatedException:
-            if client and client.callback_not_authenticated:
-                retry = client.callback_not_authenticated(client, path)
-                if retry:
-                    return status_code, True
-            raise
+            data = await response.json()
+        except Exception:
+            data = {}
+        signature_expired = (
+            isinstance(data, dict)
+            and data.get("message") == "Signature has expired"
+        )
+        return status_code, await _handle_auth_expiry(
+            client, path, can_refresh=signature_expired
+        )
     elif status_code in [500, 502]:
         try:
             data = await response.json()
             stacktrace = data.get(
                 "stacktrace", "No stacktrace sent by the server"
             )
-            message = _message_from_data(
+            message = get_message_from_data(
                 data, default="No message sent by the server"
             )
             logger.error(
@@ -424,30 +422,33 @@ async def upload(
         extra_files = []
     url = get_full_url(path, client)
 
-    form = aiohttp.FormData()
-    for key, value in data.items():
-        form.add_field(key, str(value))
-
     files_to_close = []
-    total_size = 0
+    file_fields = []
     if file_path is not None:
         f = open(file_path, "rb")
         files_to_close.append(f)
-        size = os.fstat(f.fileno()).st_size
-        total_size += size
-        form.add_field("file", f, filename=os.path.basename(file_path))
+        file_fields.append(("file", f, os.path.basename(file_path)))
     for i, extra_path in enumerate(extra_files, start=1):
         f = open(extra_path, "rb")
         files_to_close.append(f)
-        size = os.fstat(f.fileno()).st_size
-        total_size += size
-        form.add_field(f"file-{i}", f, filename=os.path.basename(extra_path))
+        file_fields.append((f"file-{i}", f, os.path.basename(extra_path)))
+
+    def build_form():
+        # aiohttp forbids re-sending a processed FormData: rebuild it (and
+        # rewind the file parts) for every attempt.
+        form = aiohttp.FormData()
+        for key, value in data.items():
+            form.add_field(key, str(value))
+        for name, f, filename in file_fields:
+            f.seek(0)
+            form.add_field(name, f, filename=filename)
+        return form
 
     try:
         for _ in range(MAX_AUTH_RETRIES):
             async with client.session.post(
                 url,
-                data=form,
+                data=build_form(),
                 headers=client.make_auth_header(),
             ) as response:
                 _, retry = await check_status(response, path, client=client)
@@ -467,7 +468,7 @@ async def upload(
         for f in files_to_close:
             f.close()
 
-    message = _message_from_data(result, default="")
+    message = get_message_from_data(result, default="")
     if message:
         raise UploadFailedException(message)
 

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -167,6 +167,7 @@ async def _handle_auth_expiry(
             and client.use_refresh_token
         ):
             await client.refresh_access_token()
+            logger.debug("token refreshed for %s", path)
             return True
         raise NotAuthenticatedException(path)
     except NotAuthenticatedException:

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -117,7 +117,9 @@ class AsyncKitsuClient:
             await check_status(response, "auth/refresh-token")
             tokens = await response.json()
         self.access_token = tokens["access_token"]
-        self.refresh_token = None
+        # Keep the existing refresh token unless the server returns a new one,
+        # so automatic refresh keeps working on the next expiry.
+        self.refresh_token = tokens.get("refresh_token", self.refresh_token)
         return tokens
 
     async def __aenter__(self) -> "AsyncKitsuClient":

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -120,6 +120,8 @@ class AsyncKitsuClient:
         return headers
 
     async def refresh_access_token(self) -> dict[str, str]:
+        if not self.refresh_token:
+            raise NotAuthenticatedException("auth/refresh-token")
         url = get_full_url("auth/refresh-token", client=self)
         headers = {
             "User-Agent": "CGWire Gazu " + __version__,
@@ -163,7 +165,10 @@ async def check_status(
     elif status_code == 403:
         raise NotAllowedException(path)
     elif status_code == 400:
-        data = await response.json()
+        try:
+            data = await response.json()
+        except Exception:
+            data = {}
         raise ParameterException(path, _message_from_data(data))
     elif status_code == 405:
         raise MethodNotAllowedException(path)
@@ -202,7 +207,10 @@ async def check_status(
         raise ValidationException(path, _message_from_data(data))
     elif status_code == 401:
         try:
-            data = await response.json()
+            try:
+                data = await response.json()
+            except Exception:
+                data = {}
             if (
                 client
                 and client.refresh_token

--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -45,7 +45,9 @@ logger = logging.getLogger("gazu.aio")
 def _message_from_data(
     data: Any, default: str = "No additional information"
 ) -> str:
-    """Extract Zou's error/message string from a parsed JSON body."""
+    """
+    Extract Zou's error/message string from a parsed JSON body.
+    """
     if isinstance(data, dict):
         for key in ("error", "message"):
             value = data.get(key)

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -128,17 +128,10 @@ def get_asset_by_name(
     """
     project = normalize_model_parameter(project)
 
-    path = "assets/all"
-    if asset_type is None:
-        params = {"project_id": project["id"], "name": name}
-    else:
-        asset_type = normalize_model_parameter(asset_type)
-        params = {
-            "project_id": project["id"],
-            "name": name,
-            "entity_type_id": asset_type["id"],
-        }
-    return raw.fetch_first(path, params, client=client)
+    params = {"project_id": project["id"], "name": name}
+    if asset_type is not None:
+        params["entity_type_id"] = normalize_model_parameter(asset_type)["id"]
+    return raw.fetch_first("assets/all", params, client=client)
 
 
 @cache
@@ -388,7 +381,7 @@ def all_asset_types_for_shot(
 def get_asset_type(asset_type_id: str, client: KitsuClient = default) -> dict:
     """
     Args:
-        asset_type_id (str): ID of claimed asset type.
+        asset_type_id (str / dict): The asset type dict or its ID.
 
     Returns:
         dict: Asset Type matching given ID.
@@ -580,8 +573,8 @@ def new_asset_asset_instance(
     automatically generated (increment highest number).
 
     Args:
-        asset (str / dict): The asset dict or the shot ID.
-        asset_to_instantiate (str / dict): The asset instance dict or ID.
+        asset (str / dict): The asset dict or the asset ID.
+        asset_to_instantiate (str / dict): The asset dict or ID to instantiate.
         description (str): Additional information (optional)
 
     Returns:

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -15,7 +15,7 @@ from .cache import cache
 
 from .client import KitsuClient
 
-from .shot import get_episode
+from . import shot as gazu_shot
 
 default = raw.default_client
 
@@ -686,7 +686,7 @@ def get_episode_from_asset(
     if asset["parent_id"] is None:
         return None
     else:
-        return get_episode(asset["parent_id"], client=client)
+        return gazu_shot.get_episode(asset["parent_id"], client=client)
 
 
 @cache

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from urllib.parse import urlencode
 
+import requests
+
 from .helpers import normalize_model_parameter
 
 from . import client as raw

--- a/gazu/asset.py
+++ b/gazu/asset.py
@@ -17,7 +17,6 @@ from .client import KitsuClient
 
 from .shot import get_episode
 
-
 default = raw.default_client
 
 

--- a/gazu/cache.py
+++ b/gazu/cache.py
@@ -65,14 +65,13 @@ def get_cache_key(args: Any, kwargs: Any) -> str:
     kwargscopy = kwargs.copy()
     if "client" in kwargscopy:
         kwargscopy["client"] = kwargscopy["client"].host
-    if len(args) == 0 and len(kwargscopy) == 0:
+    if not args and not kwargscopy:
         return ""
-    elif len(args) == 0:
-        return json.dumps(kwargscopy)
-    elif len(kwargscopy.keys()) == 0:
+    if not kwargscopy:
         return json.dumps(args)
-    else:
-        return json.dumps([args, kwargscopy])
+    if not args:
+        return json.dumps(kwargscopy)
+    return json.dumps([args, kwargscopy])
 
 
 def insert_value(

--- a/gazu/cache.py
+++ b/gazu/cache.py
@@ -45,17 +45,13 @@ def remove_oldest_entry(memo: dict, maxsize: int) -> Any:
         maxsize (int): Maximum number of entries for the cache.
 
     Returns:
-        Oldest entry for given cache.
+        The removed entry key, or None if nothing was removed.
     """
-    oldest_entry = None
     if maxsize > 0 and len(memo) > maxsize:
-        oldest_entry_key = list(memo.keys())[0]
-        for entry_key in memo.keys():
-            oldest_date = memo[oldest_entry_key]["date_accessed"]
-            if memo[entry_key]["date_accessed"] < oldest_date:
-                oldest_entry_key = entry_key
-        memo.pop(oldest_entry_key)
-    return oldest_entry
+        oldest_key = min(memo, key=lambda key: memo[key]["date_accessed"])
+        memo.pop(oldest_key)
+        return oldest_key
+    return None
 
 
 def get_cache_key(args: Any, kwargs: Any) -> str:

--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -124,7 +124,7 @@ def get_sequence_casting(
     return raw.get(path, client=client)
 
 
-def get_shot_casting(shot: dict, client: KitsuClient = default) -> dict:
+def get_shot_casting(shot: dict, client: KitsuClient = default) -> list[dict]:
     """
     Return casting for given shot.
 
@@ -140,7 +140,7 @@ def get_shot_casting(shot: dict, client: KitsuClient = default) -> dict:
     return raw.get(path, client=client)
 
 
-def get_asset_casting(asset: dict, client: KitsuClient = default) -> dict:
+def get_asset_casting(asset: dict, client: KitsuClient = default) -> list[dict]:
     """
     Return casting for given asset.
     `[{"asset_id": "asset-1", "nb_occurences": 3}]}`
@@ -159,10 +159,12 @@ def get_asset_casting(asset: dict, client: KitsuClient = default) -> dict:
     return raw.get(path, client=client)
 
 
-def get_episode_casting(episode: dict, client: KitsuClient = default) -> dict:
+def get_episode_casting(
+    episode: dict, client: KitsuClient = default
+) -> list[dict]:
     """
     Return casting for given episode.
-    `[{"episode_id": "episode-1", "nb_occurences": 3}]}`
+    `[{"asset_id": "asset-1", "nb_occurences": 3}]}`
 
     Args:
         episode (dict): The episode dict

--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -140,7 +140,9 @@ def get_shot_casting(shot: dict, client: KitsuClient = default) -> list[dict]:
     return raw.get(path, client=client)
 
 
-def get_asset_casting(asset: dict, client: KitsuClient = default) -> list[dict]:
+def get_asset_casting(
+    asset: dict, client: KitsuClient = default
+) -> list[dict]:
     """
     Return casting for given asset.
     `[{"asset_id": "asset-1", "nb_occurences": 3}]}`

--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -45,7 +45,7 @@ def update_asset_casting(
     displayed into the asset).
 
     Args:
-        project (str / dict): The project dict or asset ID.
+        project (str / dict): The project dict or the project ID.
         asset (str / dict): The asset dict or the asset ID.
         casting (dict): The casting description.
 

--- a/gazu/casting.py
+++ b/gazu/casting.py
@@ -204,26 +204,25 @@ def all_entity_links_for_project(
     page: int | None = None,
     limit: int | None = None,
     client: KitsuClient = default,
-) -> dict:
+) -> list[dict] | dict:
     """
     Args:
         project (dict | str): The project dict or ID.
 
     Returns:
-        dict: A dictionary containing entity links for the project. If pagination
-            is used, contains "data" (list of entity link dicts) and pagination
-            metadata. Otherwise, returns a list of entity link dictionaries directly.
-            Each entity link dict contains "entity_in_id", "entity_out_id", and
-            other link-related fields.
+        By default (no ``page``), the full list of entity link dicts for the
+        project. When an explicit ``page`` is given, a single paginated dict
+        with "data" and pagination metadata is returned. Each entity link dict
+        contains "entity_in_id", "entity_out_id" and other link-related fields.
     """
     project = normalize_model_parameter(project)
-    path = f"data/projects/{project['id']}/entity-links"
+    path = f"projects/{project['id']}/entity-links"
     params = {}
     if page is not None:
         params["page"] = page
         if limit is not None:
             params["limit"] = limit
-    return raw.get(path, params=params, client=client)
+    return raw.fetch_all(path, params=params, client=client)
 
 
 def get_episodes_casting(

--- a/gazu/cli.py
+++ b/gazu/cli.py
@@ -65,7 +65,8 @@ def clear_config():
 
 
 def print_table(rows, columns):
-    """Print a list of dicts as aligned columns.
+    """
+    Print a list of dicts as aligned columns.
 
     Args:
         rows: list of dicts
@@ -102,7 +103,9 @@ def _truncate(text, max_len):
 
 
 def output(ctx, data, columns):
-    """Output data as JSON or table depending on context flag."""
+    """
+    Output data as JSON or table depending on context flag.
+    """
     if ctx.obj.get("json"):
         click.echo(json.dumps(data, indent=2, default=str))
     else:
@@ -135,7 +138,9 @@ def resolve_project(name_or_id):
 
 
 def get_project_from_option(project_opt):
-    """Resolve project from CLI option or GAZU_PROJECT env var."""
+    """
+    Resolve project from CLI option or GAZU_PROJECT env var.
+    """
     name_or_id = project_opt or os.environ.get("GAZU_PROJECT")
     if not name_or_id:
         click.echo(
@@ -150,7 +155,9 @@ def get_project_from_option(project_opt):
 
 
 def setup_client():
-    """Load config and configure the gazu default client."""
+    """
+    Load config and configure the gazu default client.
+    """
     config = load_config()
     host = config.get("host")
     tokens = config.get("tokens")
@@ -165,7 +172,9 @@ def setup_client():
 
 
 def handle_errors(fn):
-    """Decorator to catch common gazu exceptions."""
+    """
+    Decorator to catch common gazu exceptions.
+    """
 
     def wrapper(*args, **kwargs):
         try:
@@ -199,7 +208,9 @@ def handle_errors(fn):
 @click.version_option(version=gazu.__version__, prog_name="gazu-cli")
 @click.pass_context
 def cli(ctx, use_json):
-    """Gazu CLI - Command-line client for the Kitsu API."""
+    """
+    Gazu CLI - Command-line client for the Kitsu API.
+    """
     ctx.ensure_object(dict)
     ctx.obj["json"] = use_json
 
@@ -215,7 +226,9 @@ def cli(ctx, use_json):
 )
 @handle_errors
 def login(host, email, password):
-    """Log in to a Kitsu instance and store credentials."""
+    """
+    Log in to a Kitsu instance and store credentials.
+    """
     if not host.endswith("/api"):
         host = host.rstrip("/") + "/api"
     gazu.set_host(host)
@@ -227,7 +240,9 @@ def login(host, email, password):
 @cli.command()
 @handle_errors
 def logout():
-    """Log out and clear stored credentials."""
+    """
+    Log out and clear stored credentials.
+    """
     try:
         setup_client()
         gazu.log_out()
@@ -241,7 +256,9 @@ def logout():
 @click.pass_context
 @handle_errors
 def status(ctx):
-    """Show current connection status."""
+    """
+    Show current connection status.
+    """
     setup_client()
     user = raw.get_current_user()
     version = raw.get_api_version()
@@ -275,7 +292,9 @@ def status(ctx):
 @click.pass_context
 @handle_errors
 def projects(ctx, show_all):
-    """List projects."""
+    """
+    List projects.
+    """
     setup_client()
     if show_all:
         data = gazu_project.all_projects()
@@ -298,7 +317,9 @@ def projects(ctx, show_all):
 @click.pass_context
 @handle_errors
 def project(ctx, name_or_id):
-    """Show details for a project."""
+    """
+    Show details for a project.
+    """
     setup_client()
     data = resolve_project(name_or_id)
     output(
@@ -323,7 +344,9 @@ def project(ctx, name_or_id):
 @click.pass_context
 @handle_errors
 def assets(ctx, project_opt, asset_type):
-    """List assets for a project."""
+    """
+    List assets for a project.
+    """
     setup_client()
     proj = get_project_from_option(project_opt)
     if asset_type:
@@ -352,7 +375,9 @@ def assets(ctx, project_opt, asset_type):
 @click.pass_context
 @handle_errors
 def asset(ctx, name_or_id, project_opt):
-    """Show details for an asset."""
+    """
+    Show details for an asset.
+    """
     setup_client()
     if _is_uuid(name_or_id):
         data = gazu_asset.get_asset(name_or_id)
@@ -385,7 +410,9 @@ def asset(ctx, name_or_id, project_opt):
 @click.pass_context
 @handle_errors
 def shots(ctx, project_opt, sequence, episode):
-    """List shots for a project."""
+    """
+    List shots for a project.
+    """
     setup_client()
     proj = get_project_from_option(project_opt)
     if sequence:
@@ -421,7 +448,9 @@ def shots(ctx, project_opt, sequence, episode):
 @click.pass_context
 @handle_errors
 def sequences(ctx, project_opt, episode):
-    """List sequences for a project."""
+    """
+    List sequences for a project.
+    """
     setup_client()
     proj = get_project_from_option(project_opt)
     if episode:
@@ -448,7 +477,9 @@ def sequences(ctx, project_opt, episode):
 @click.pass_context
 @handle_errors
 def episodes(ctx, project_opt):
-    """List episodes for a project."""
+    """
+    List episodes for a project.
+    """
     setup_client()
     proj = get_project_from_option(project_opt)
     data = gazu_shot.all_episodes_for_project(proj)
@@ -469,7 +500,9 @@ def episodes(ctx, project_opt):
 @click.pass_context
 @handle_errors
 def tasks(ctx, project_opt, task_type, task_status):
-    """List tasks for a project."""
+    """
+    List tasks for a project.
+    """
     setup_client()
     proj = get_project_from_option(project_opt)
     if task_type and task_status:
@@ -510,7 +543,9 @@ def tasks(ctx, project_opt, task_type, task_status):
 @click.pass_context
 @handle_errors
 def task(ctx, task_id):
-    """Show details for a task (by ID)."""
+    """
+    Show details for a task (by ID).
+    """
     setup_client()
     data = gazu_task.get_task(task_id)
     output(
@@ -540,7 +575,9 @@ def task(ctx, task_id):
 @click.option("--message", "-m", default="", help="Comment text.")
 @handle_errors
 def comment(task_id, status_short, message):
-    """Post a comment on a task (with status change)."""
+    """
+    Post a comment on a task (with status change).
+    """
     setup_client()
     ts = gazu_task.get_task_status_by_short_name(status_short)
     if ts is None:
@@ -557,7 +594,9 @@ def comment(task_id, status_short, message):
 @click.pass_context
 @handle_errors
 def persons(ctx):
-    """List all persons."""
+    """
+    List all persons.
+    """
     setup_client()
     data = gazu_person.all_persons()
     output(
@@ -581,7 +620,9 @@ def persons(ctx):
 @click.pass_context
 @handle_errors
 def my_tasks(ctx, done):
-    """List tasks assigned to current user."""
+    """
+    List tasks assigned to current user.
+    """
     setup_client()
     if done:
         data = gazu_user.all_done_tasks()
@@ -609,7 +650,9 @@ def my_tasks(ctx, done):
 @click.pass_context
 @handle_errors
 def search(ctx, query, project_opt):
-    """Search for entities across the Kitsu instance."""
+    """
+    Search for entities across the Kitsu instance.
+    """
     setup_client()
     proj = None
     if project_opt:
@@ -635,7 +678,9 @@ def search(ctx, query, project_opt):
 @click.pass_context
 @handle_errors
 def shot_casting(ctx, shot_id):
-    """Show casting (assets linked) for a shot."""
+    """
+    Show casting (assets linked) for a shot.
+    """
     setup_client()
     data = gazu_casting.get_shot_casting(shot_id)
     if ctx.obj["json"]:
@@ -658,7 +703,9 @@ def shot_casting(ctx, shot_id):
 @click.pass_context
 @handle_errors
 def asset_types(ctx, project_opt):
-    """List asset types."""
+    """
+    List asset types.
+    """
     setup_client()
     if project_opt:
         proj = resolve_project(project_opt)
@@ -673,7 +720,9 @@ def asset_types(ctx, project_opt):
 @click.pass_context
 @handle_errors
 def task_types(ctx, project_opt):
-    """List task types."""
+    """
+    List task types.
+    """
     setup_client()
     if project_opt:
         proj = resolve_project(project_opt)
@@ -692,7 +741,9 @@ def task_types(ctx, project_opt):
 @click.pass_context
 @handle_errors
 def task_statuses(ctx, project_opt):
-    """List task statuses."""
+    """
+    List task statuses.
+    """
     setup_client()
     if project_opt:
         proj = resolve_project(project_opt)

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -26,13 +26,17 @@ from .exception import (
 from urllib.parse import urlencode
 
 logger = logging.getLogger("gazu")
+# Library convention: no output unless the host app configures logging.
+logger.addHandler(logging.NullHandler())
 
 # Bound the auth-recovery retries to avoid an infinite loop.
 MAX_AUTH_RETRIES = 3
 
 if os.getenv("GAZU_DEBUG", "false").lower() == "true":
-    logging.basicConfig(level=logging.DEBUG)
+    # Debug opt-in: only touch the "gazu" logger, never the root logger
+    # (configuring the host application's logging is not gazu's business).
     logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.StreamHandler())
 
 
 class KitsuClient(object):

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -27,6 +27,9 @@ from urllib.parse import urlencode
 
 logger = logging.getLogger("gazu")
 
+# Bound the auth-recovery retries to avoid an infinite loop.
+MAX_AUTH_RETRIES = 3
+
 if os.getenv("GAZU_DEBUG", "false").lower() == "true":
     logging.basicConfig(level=logging.DEBUG)
     logger.setLevel(logging.DEBUG)
@@ -94,9 +97,7 @@ class KitsuClient(object):
         tokens = response.json()
 
         self.access_token = tokens["access_token"]
-        # The refresh endpoint usually returns only a new access token. Keep the
-        # existing refresh token so automatic refresh still works on the next
-        # expiry; only replace it when the server sends a new one.
+        # Keep the current refresh token unless the server returns a new one.
         self.refresh_token = tokens.get("refresh_token", self.refresh_token)
 
         return tokens
@@ -388,13 +389,16 @@ def get(
     """
     logger.debug("GET %s", get_full_url(path, client))
     path = build_path_with_params(path, params)
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         response = client.session.get(
             get_full_url(path, client=client),
             headers=make_auth_header(client=client),
         )
         _, retry = check_status(response, path, client=client)
+        if not retry:
+            break
+    else:
+        raise NotAuthenticatedException(path)
 
     if json_response:
         return response.json()
@@ -424,8 +428,7 @@ def post(path: str, data: Any, client: KitsuClient = default_client) -> Any:
     }
     if not any(field in data for field in sensitive_fields):
         logger.debug("Body: %s", data)
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         headers = make_auth_header(client=client)
         headers["Content-Type"] = "application/json"
         response = client.session.post(
@@ -434,6 +437,10 @@ def post(path: str, data: Any, client: KitsuClient = default_client) -> Any:
             headers=headers,
         )
         _, retry = check_status(response, path, client=client)
+        if not retry:
+            break
+    else:
+        raise NotAuthenticatedException(path)
     try:
         result = response.json()
     except json.JSONDecodeError:
@@ -456,8 +463,7 @@ def put(path: str, data: dict, client: KitsuClient = default_client) -> Any:
     """
     logger.debug("PUT %s", get_full_url(path, client))
     logger.debug("Body: %s", data)
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         headers = make_auth_header(client=client)
         headers["Content-Type"] = "application/json"
         response = client.session.put(
@@ -466,6 +472,10 @@ def put(path: str, data: dict, client: KitsuClient = default_client) -> Any:
             headers=headers,
         )
         _, retry = check_status(response, path, client=client)
+        if not retry:
+            break
+    else:
+        raise NotAuthenticatedException(path)
     return response.json()
 
 
@@ -486,12 +496,15 @@ def delete(
     logger.debug("DELETE %s", get_full_url(path, client))
     path = build_path_with_params(path, params)
 
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         response = client.session.delete(
             get_full_url(path, client), headers=make_auth_header(client=client)
         )
         _, retry = check_status(response, path, client=client)
+        if not retry:
+            break
+    else:
+        raise NotAuthenticatedException(path)
     return response.text
 
 
@@ -852,8 +865,7 @@ def upload(
             offset += os.fstat(f.fileno()).st_size
         files = wrapped
     try:
-        retry = True
-        while retry:
+        for _ in range(MAX_AUTH_RETRIES):
             response = client.session.post(
                 url,
                 data=data,
@@ -861,6 +873,10 @@ def upload(
                 files=files,
             )
             _, retry = check_status(response, path, client=client)
+            if not retry:
+                break
+        else:
+            raise NotAuthenticatedException(path)
     finally:
         if opened_files:
             for f in opened_files.values():
@@ -960,14 +976,17 @@ def get_file_data_from_url(
     """
     if not full:
         url = get_full_url(url)
-    retry = True
-    while retry:
+    for _ in range(MAX_AUTH_RETRIES):
         response = client.session.get(
             url,
             stream=True,
             headers=make_auth_header(client=client),
         )
         _, retry = check_status(response, url, client=client)
+        if not retry:
+            break
+    else:
+        raise NotAuthenticatedException(url)
     return response.content
 
 

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -86,6 +86,8 @@ class KitsuClient(object):
         Returns:
             dict: The new access token.
         """
+        if not self.refresh_token:
+            raise NotAuthenticatedException("auth/refresh-token")
         response = self.session.get(
             get_full_url("auth/refresh-token", client=self),
             headers={

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -558,6 +558,37 @@ def get_message_from_response(
     return message
 
 
+def _handle_auth_expiry(
+    client: KitsuClient, path: str, can_refresh: bool
+) -> bool:
+    """
+    Handle an expired/invalid JWT: refresh the access token when possible,
+    otherwise fall back to the not-authenticated callback.
+
+    Returns:
+        bool: True when the request should be retried.
+
+    Raises:
+        NotAuthenticatedException: when the token can't be refreshed and no
+            callback authorizes a retry.
+    """
+    try:
+        if (
+            can_refresh
+            and client
+            and client.refresh_token
+            and client.use_refresh_token
+        ):
+            client.refresh_access_token()
+            return True
+        raise NotAuthenticatedException(path)
+    except NotAuthenticatedException:
+        if client and client.callback_not_authenticated:
+            if client.callback_not_authenticated(client, path):
+                return True
+        raise
+
+
 def check_status(
     request: requests.Response, path: str, client: KitsuClient = None
 ) -> tuple[int, bool]:
@@ -610,40 +641,22 @@ def check_status(
         # flask-jwt-extended returns 422 with this message when the JWT
         # signature has expired -- this is an auth case, not a validation one.
         if jwt_expired:
-            try:
-                if (
-                    client
-                    and client.refresh_token
-                    and client.use_refresh_token
-                ):
-                    client.refresh_access_token()
-                    return status_code, True
-                raise NotAuthenticatedException(path)
-            except NotAuthenticatedException:
-                if client and client.callback_not_authenticated:
-                    retry = client.callback_not_authenticated(client, path)
-                    if retry:
-                        return status_code, True
-                raise
+            return status_code, _handle_auth_expiry(
+                client, path, can_refresh=True
+            )
         raise ValidationException(path, get_message_from_response(request))
     elif status_code == 401:
         try:
-            if (
-                client
-                and client.refresh_token
-                and client.use_refresh_token
-                and request.json().get("message") == "Signature has expired"
-            ):
-                client.refresh_access_token()
-                return status_code, True
-            else:
-                raise NotAuthenticatedException(path)
-        except NotAuthenticatedException:
-            if client and client.callback_not_authenticated:
-                retry = client.callback_not_authenticated(client, path)
-                if retry:
-                    return status_code, True
-            raise
+            body = request.json()
+        except Exception:
+            body = {}
+        signature_expired = (
+            isinstance(body, dict)
+            and body.get("message") == "Signature has expired"
+        )
+        return status_code, _handle_auth_expiry(
+            client, path, can_refresh=signature_expired
+        )
     elif status_code in [500, 502]:
         try:
             stacktrace = request.json().get(
@@ -852,13 +865,19 @@ def upload(
         files = _build_file_dict(file_path, extra_files)
         opened_files = files
     if progress_callback is not None:
-        total = sum(os.fstat(f.fileno()).st_size for f in files.values())
+        # files may hold non-file parts (e.g. JSON tuples); size only files.
+        file_values = [f for f in files.values() if hasattr(f, "fileno")]
+        total = sum(os.fstat(f.fileno()).st_size for f in file_values)
         offset = 0
         wrapped = {}
         for key, f in files.items():
-            wrapper = _ProgressFileWrapper(f, progress_callback, offset, total)
-            wrapped[key] = wrapper
-            offset += os.fstat(f.fileno()).st_size
+            if hasattr(f, "fileno"):
+                wrapped[key] = _ProgressFileWrapper(
+                    f, progress_callback, offset, total
+                )
+                offset += os.fstat(f.fileno()).st_size
+            else:
+                wrapped[key] = f
         files = wrapped
     try:
         for _ in range(MAX_AUTH_RETRIES):
@@ -943,6 +962,10 @@ def download(
         headers=make_auth_header(client=client),
         stream=True,
     ) as response:
+        if file_path is None:
+            # No destination: materialize the body and return the response.
+            response.content
+            return response
         with open(file_path, "wb") as target_file:
             if progress_callback is not None:
                 total = int(response.headers.get("content-length", 0))
@@ -975,7 +998,6 @@ def get_file_data_from_url(
     for _ in range(MAX_AUTH_RETRIES):
         response = client.session.get(
             url,
-            stream=True,
             headers=make_auth_header(client=client),
         )
         _, retry = check_status(response, url, client=client)

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -602,6 +602,7 @@ def _handle_auth_expiry(
             and client.use_refresh_token
         ):
             client.refresh_access_token()
+            logger.debug("token refreshed for %s", path)
             return True
         raise NotAuthenticatedException(path)
     except NotAuthenticatedException:

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -603,12 +603,6 @@ def check_status(
             body = request.json()
         except Exception:
             body = {}
-        message = "No additional information"
-        if isinstance(body, dict):
-            for key in ["error", "message"]:
-                if body.get(key):
-                    message = body[key]
-                    break
         jwt_expired = (
             isinstance(body, dict)
             and body.get("message") == "Signature has expired"
@@ -631,7 +625,7 @@ def check_status(
                     if retry:
                         return status_code, True
                 raise
-        raise ValidationException(path, message)
+        raise ValidationException(path, get_message_from_response(request))
     elif status_code == 401:
         try:
             if (

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -510,28 +510,23 @@ def delete(
     return response.text
 
 
-def get_message_from_response(
-    response: requests.Response,
+def get_message_from_data(
+    message_json: Any,
     default_message: str = "No additional information",
 ) -> str:
     """
-    A utility function that handles Zou's inconsistent message keys.
-    For a given request, checks if any error messages or regular messages were given and returns their value.
-    If no messages are found, returns a default message.
+    Extract Zou's error/message string from a parsed JSON body.
+    Handles Zou's inconsistent message keys and surfaces Pydantic
+    field-level validation details when present.
 
     Args:
-        response: requests.Response - A response to check.
-        default_message: str - An optional default value to revert to if no message is detected.
+        message_json: The parsed JSON body (any type).
+        default_message: Value returned when no message is found.
 
     Returns:
         str: The message to display to the user.
     """
     message = default_message
-    try:
-        message_json = response.json()
-    except ValueError:
-        return message
-
     if isinstance(message_json, dict):
         for key in ["message", "error"]:
             value = message_json.get(key)
@@ -556,6 +551,29 @@ def get_message_from_response(
                 message = f"{message} ({details})"
 
     return message
+
+
+def get_message_from_response(
+    response: requests.Response,
+    default_message: str = "No additional information",
+) -> str:
+    """
+    A utility function that handles Zou's inconsistent message keys.
+    For a given request, checks if any error messages or regular messages were given and returns their value.
+    If no messages are found, returns a default message.
+
+    Args:
+        response: requests.Response - A response to check.
+        default_message: str - An optional default value to revert to if no message is detected.
+
+    Returns:
+        str: The message to display to the user.
+    """
+    try:
+        message_json = response.json()
+    except ValueError:
+        return default_message
+    return get_message_from_data(message_json, default_message)
 
 
 def _handle_auth_expiry(
@@ -882,7 +900,13 @@ def upload(
                 wrapped[key] = f
         files = wrapped
     try:
-        for _ in range(MAX_AUTH_RETRIES):
+        for attempt in range(MAX_AUTH_RETRIES):
+            if attempt:
+                # The previous attempt consumed the file handles: rewind
+                # them, else the retry would upload empty file parts.
+                for f in files.values():
+                    if hasattr(f, "seek"):
+                        f.seek(0)
             response = client.session.post(
                 url,
                 data=data,
@@ -996,7 +1020,7 @@ def get_file_data_from_url(
         bytes: The data found at the given url.
     """
     if not full:
-        url = get_full_url(url)
+        url = get_full_url(url, client=client)
     for _ in range(MAX_AUTH_RETRIES):
         response = client.session.get(
             url,

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -94,7 +94,10 @@ class KitsuClient(object):
         tokens = response.json()
 
         self.access_token = tokens["access_token"]
-        self.refresh_token = None
+        # The refresh endpoint usually returns only a new access token. Keep the
+        # existing refresh token so automatic refresh still works on the next
+        # expiry; only replace it when the server sends a new one.
+        self.refresh_token = tokens.get("refresh_token", self.refresh_token)
 
         return tokens
 

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -811,7 +811,9 @@ def update(
 
 
 class _ProgressFileWrapper:
-    """Wraps a file object to track read progress via a callback."""
+    """
+    Wraps a file object to track read progress via a callback.
+    """
 
     def __init__(self, file_obj, callback, offset, total):
         self._file = file_obj

--- a/gazu/concept.py
+++ b/gazu/concept.py
@@ -126,6 +126,7 @@ def new_concept(
     Args:
         project (str / dict): The project dict or the project ID.
         name (str): The name of the concept to create.
+        description (str): Description of the concept.
         data (dict): Free field to set metadata of any kind.
         entity_concept_links (list): List of entities to tag, as either
             ID strings or model dicts.

--- a/gazu/context.py
+++ b/gazu/context.py
@@ -16,7 +16,7 @@ def all_open_projects(
     user_context: bool = False, client: KitsuClient = default
 ) -> list[dict]:
     """
-    Return the list of projects for which the user has a task.
+    Return open projects (only the current user's when user_context is True).
     """
     if user_context:
         return gazu_user.all_open_projects(client=client)
@@ -30,7 +30,8 @@ def all_assets_for_project(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of assets for which the user has a task.
+    Return the project's assets (only the current user's when user_context is
+    True).
     """
     if user_context:
         return gazu_user.all_assets_for_project(project, client=client)
@@ -44,7 +45,8 @@ def all_asset_types_for_project(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of asset types for which the user has a task.
+    Return the project's asset types (only the current user's when
+    user_context is True).
     """
     if user_context:
         return gazu_user.all_asset_types_for_project(project, client=client)
@@ -59,8 +61,8 @@ def all_assets_for_asset_type_and_project(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of assets for given project and asset_type and for which
-    the user has a task.
+    Return the assets for given project and asset type (only the current
+    user's when user_context is True).
     """
     if user_context:
         return gazu_user.all_assets_for_asset_type_and_project(
@@ -78,7 +80,8 @@ def all_task_types_for_asset(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of tasks for given asset and current user.
+    Return the task types for given asset (only the current user's when
+    user_context is True).
     """
     if user_context:
         return gazu_user.all_task_types_for_asset(asset, client=client)
@@ -92,7 +95,8 @@ def all_task_types_for_shot(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of tasks for given shot and current user.
+    Return the task types for given shot (only the current user's when
+    user_context is True).
     """
     if user_context:
         return gazu_user.all_task_types_for_shot(shot, client=client)
@@ -106,7 +110,8 @@ def all_task_types_for_scene(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of tasks for given scene and current user.
+    Return the task types for given scene (only the current user's when
+    user_context is True).
     """
     if user_context:
         return gazu_user.all_task_types_for_scene(scene, client=client)
@@ -120,7 +125,8 @@ def all_task_types_for_sequence(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of tasks for given sequence and current user.
+    Return the task types for given sequence (only the current user's when
+    user_context is True).
     """
     if user_context:
         return gazu_user.all_task_types_for_sequence(sequence, client=client)
@@ -134,7 +140,8 @@ def all_sequences_for_project(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of sequences for given project and current user.
+    Return the project's sequences (only the current user's when user_context
+    is True).
     """
     if user_context:
         return gazu_user.all_sequences_for_project(project, client=client)
@@ -148,7 +155,8 @@ def all_scenes_for_project(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of scenes for given project and current user.
+    Return the project's scenes (only the current user's when user_context is
+    True).
     """
     if user_context:
         return gazu_user.all_scenes_for_project(project, client=client)
@@ -162,7 +170,8 @@ def all_shots_for_sequence(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of shots for given sequence and current user.
+    Return the sequence's shots (only the current user's when user_context is
+    True).
     """
     if user_context:
         return gazu_user.all_shots_for_sequence(sequence, client=client)
@@ -176,7 +185,8 @@ def all_scenes_for_sequence(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of scenes for given sequence and current user.
+    Return the sequence's scenes (only the current user's when user_context is
+    True).
     """
     if user_context:
         return gazu_user.all_scenes_for_sequence(sequence, client=client)
@@ -190,7 +200,8 @@ def all_sequences_for_episode(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of sequences for given episode and current user.
+    Return the episode's sequences (only the current user's when user_context
+    is True).
     """
     if user_context:
         return gazu_user.all_sequences_for_episode(episode, client=client)
@@ -204,7 +215,8 @@ def all_episodes_for_project(
     client: KitsuClient = default,
 ) -> list[dict]:
     """
-    Return the list of episodes for given project and current user.
+    Return the project's episodes (only the current user's when user_context
+    is True).
     """
     if user_context:
         return gazu_user.all_episodes_for_project(project, client=client)

--- a/gazu/edit.py
+++ b/gazu/edit.py
@@ -32,7 +32,7 @@ def get_edit_by_name(
         edit_name (str): Name of claimed edit.
 
     Returns:
-        dict: Edit corresponding to given name and sequence.
+        dict: Edit corresponding to given name and project.
     """
     project = normalize_model_parameter(project)
     return raw.fetch_first(

--- a/gazu/encoder.py
+++ b/gazu/encoder.py
@@ -11,7 +11,8 @@ class CustomJSONEncoder(json.JSONEncoder):
     """
 
     def default(self, obj: Any) -> Any:
-        if isinstance(obj, datetime.datetime):
+        # datetime.date covers both date and datetime (datetime subclasses date).
+        if isinstance(obj, datetime.date):
             return obj.isoformat()
 
         return json.JSONEncoder.default(self, obj)

--- a/gazu/events.py
+++ b/gazu/events.py
@@ -46,7 +46,7 @@ class EventsNamespace(socketio.ClientNamespace):
 
 def init(
     client: KitsuClient = default_client,
-    ssl_verify: bool = False,
+    ssl_verify: bool = True,
     reconnection: bool = True,
     logger: bool = False,
     **kwargs: Any,

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -1322,6 +1322,39 @@ def download_preview_file_cover(
     )
 
 
+def _download_avatar(
+    kind: str,
+    model: str | dict,
+    file_path: str,
+    client: KitsuClient = default,
+    progress_callback=None,
+) -> requests.Response:
+    """Download the avatar of given model kind (persons/projects/...)."""
+    model = normalize_model_parameter(model)
+    return raw.download(
+        f"pictures/thumbnails/{kind}/{model['id']}.png",
+        file_path,
+        client=client,
+        progress_callback=progress_callback,
+    )
+
+
+def _upload_avatar(
+    kind: str,
+    model: str | dict,
+    file_path: str,
+    client: KitsuClient = default,
+    progress_callback=None,
+) -> dict[Literal["thumbnail_path"], str]:
+    """Upload given file as the avatar of given model kind."""
+    path = (
+        f"/pictures/thumbnails/{kind}/{normalize_model_parameter(model)['id']}"
+    )
+    return raw.upload(
+        path, file_path, client=client, progress_callback=progress_callback
+    )
+
+
 def download_person_avatar(
     person: str | dict,
     file_path: str,
@@ -1335,12 +1368,8 @@ def download_person_avatar(
         person (str / dict): The person dict or ID.
         file_path (str): Location on hard drive where to save the file.
     """
-    person = normalize_model_parameter(person)
-    return raw.download(
-        f"pictures/thumbnails/persons/{person['id']}.png",
-        file_path,
-        client=client,
-        progress_callback=progress_callback,
+    return _download_avatar(
+        "persons", person, file_path, client, progress_callback
     )
 
 
@@ -1361,9 +1390,8 @@ def upload_person_avatar(
         dict: Dictionary with a key of 'thumbnail_path' and a value of the
             path to the static image file, relative to the host url.
     """
-    path = f"/pictures/thumbnails/persons/{normalize_model_parameter(person)['id']}"
-    return raw.upload(
-        path, file_path, client=client, progress_callback=progress_callback
+    return _upload_avatar(
+        "persons", person, file_path, client, progress_callback
     )
 
 
@@ -1380,12 +1408,8 @@ def download_project_avatar(
         project (str / dict): The project dict or ID.
         file_path (str): Location on hard drive where to save the file.
     """
-    project = normalize_model_parameter(project)
-    return raw.download(
-        f"pictures/thumbnails/projects/{project['id']}.png",
-        file_path,
-        client=client,
-        progress_callback=progress_callback,
+    return _download_avatar(
+        "projects", project, file_path, client, progress_callback
     )
 
 
@@ -1406,9 +1430,8 @@ def upload_project_avatar(
         dict: Dictionary with a key of 'thumbnail_path' and a value of the
             path to the static image file, relative to the host url.
     """
-    path = f"/pictures/thumbnails/projects/{normalize_model_parameter(project)['id']}"
-    return raw.upload(
-        path, file_path, client=client, progress_callback=progress_callback
+    return _upload_avatar(
+        "projects", project, file_path, client, progress_callback
     )
 
 
@@ -1425,12 +1448,8 @@ def download_organisation_avatar(
         organisation (str / dict): The organisation dict or ID.
         file_path (str): Location on hard drive where to save the file.
     """
-    organisation = normalize_model_parameter(organisation)
-    return raw.download(
-        f"pictures/thumbnails/organisations/{organisation['id']}.png",
-        file_path,
-        client=client,
-        progress_callback=progress_callback,
+    return _download_avatar(
+        "organisations", organisation, file_path, client, progress_callback
     )
 
 
@@ -1451,9 +1470,8 @@ def upload_organisation_avatar(
         dict: Dictionary with a key of 'thumbnail_path' and a value of the
             path to the static image file, relative to the host url.
     """
-    path = f"/pictures/thumbnails/organisations/{normalize_model_parameter(organisation)['id']}"
-    return raw.upload(
-        path, file_path, client=client, progress_callback=progress_callback
+    return _upload_avatar(
+        "organisations", organisation, file_path, client, progress_callback
     )
 
 

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -14,7 +14,9 @@ default = raw.default_client
 
 
 def _format_path(folder: str, name: str, sep: str) -> str:
-    """Join a folder and file name, replacing spaces with underscores."""
+    """
+    Join a folder and file name, replacing spaces with underscores.
+    """
     return f"{folder.replace(' ', '_')}{sep}{name.replace(' ', '_')}"
 
 
@@ -1329,7 +1331,9 @@ def _download_avatar(
     client: KitsuClient = default,
     progress_callback=None,
 ) -> requests.Response:
-    """Download the avatar of given model kind (persons/projects/...)."""
+    """
+    Download the avatar of given model kind (persons/projects/...).
+    """
     model = normalize_model_parameter(model)
     return raw.download(
         f"pictures/thumbnails/{kind}/{model['id']}.png",
@@ -1346,7 +1350,9 @@ def _upload_avatar(
     client: KitsuClient = default,
     progress_callback=None,
 ) -> dict[Literal["thumbnail_path"], str]:
-    """Upload given file as the avatar of given model kind."""
+    """
+    Upload given file as the avatar of given model kind.
+    """
     path = (
         f"/pictures/thumbnails/{kind}/{normalize_model_parameter(model)['id']}"
     )

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -13,6 +13,11 @@ from .helpers import normalize_model_parameter
 default = raw.default_client
 
 
+def _format_path(folder: str, name: str, sep: str) -> str:
+    """Join a folder and file name, replacing spaces with underscores."""
+    return f"{folder.replace(' ', '_')}{sep}{name.replace(' ', '_')}"
+
+
 def _output_file_filters(
     output_type: str | dict | None = None,
     task_type: str | dict | None = None,
@@ -392,7 +397,7 @@ def all_softwares(client: KitsuClient = default) -> list[dict]:
 def get_software(software_id: str, client: KitsuClient = default) -> dict:
     """
     Args:
-        software_id (str): ID of claimed output type.
+        software_id (str): ID of claimed software.
 
     Returns:
         dict: Software object corresponding to given ID.
@@ -406,7 +411,7 @@ def get_software_by_name(
 ) -> dict | None:
     """
     Args:
-        software_name (str): Name of claimed output type.
+        software_name (str): Name of claimed software.
 
     Returns:
         dict: Software object corresponding to given name.
@@ -495,7 +500,7 @@ def build_working_file_path(
     result = raw.post(
         f"data/tasks/{task['id']}/working-file-path", data, client=client
     )
-    return f"{result['path'].replace(' ', '_')}{sep}{result['name'].replace(' ', '_')}"
+    return _format_path(result["path"], result["name"], sep)
 
 
 @cache
@@ -547,7 +552,7 @@ def build_entity_output_file_path(
     }
     path = f"data/entities/{entity['id']}/output-file-path"
     result = raw.post(path, data, client=client)
-    return f"{result['folder_path'].replace(' ', '_')}{sep}{result['file_name'].replace(' ', '_')}"
+    return _format_path(result["folder_path"], result["file_name"], sep)
 
 
 @cache
@@ -603,7 +608,7 @@ def build_asset_instance_output_file_path(
     }
     path = f"data/asset-instances/{asset_instance['id']}/entities/{temporal_entity['id']}/output-file-path"
     result = raw.post(path, data, client=client)
-    return f"{result['folder_path'].replace(' ', '_')}{sep}{result['file_name'].replace(' ', '_')}"
+    return _format_path(result["folder_path"], result["file_name"], sep)
 
 
 def new_working_file(
@@ -812,8 +817,8 @@ def get_next_entity_output_revision(
     """
     Args:
         entity (str / dict): The entity dict or ID.
-        output_type (str / dict): The entity dict or ID.
-        task_type (str / dict): The entity dict or ID.
+        output_type (str / dict): The output type dict or ID.
+        task_type (str / dict): The task type dict or ID.
         name (str): Get version for output file with the given name.
 
     Returns:
@@ -844,8 +849,8 @@ def get_next_asset_instance_output_revision(
     Args:
         asset_instance (str / dict): The asset instance dict or ID.
         temporal_entity (str / dict): The temporal entity dict or ID.
-        output_type (str / dict): The entity dict or ID.
-        task_type (str / dict): The entity dict or ID.
+        output_type (str / dict): The output type dict or ID.
+        task_type (str / dict): The task type dict or ID.
 
     Returns:
         int: Next revision of ouput files available for given asset insance
@@ -874,8 +879,8 @@ def get_last_entity_output_revision(
     """
     Args:
         entity (str / dict): The entity dict or ID.
-        output_type (str / dict): The entity dict or ID.
-        task_type (str / dict): The entity dict or ID.
+        output_type (str / dict): The output type dict or ID.
+        task_type (str / dict): The task type dict or ID.
         name (str): The output name
 
     Returns:

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -13,6 +13,38 @@ from .helpers import normalize_model_parameter
 default = raw.default_client
 
 
+def _output_file_filters(
+    output_type: str | dict | None = None,
+    task_type: str | dict | None = None,
+    name: str | None = None,
+    representation: str | None = None,
+    file_status: str | dict | None = None,
+    temporal_entity: str | dict | None = None,
+) -> dict:
+    """
+    Build the query params shared by all the ``*output_files_for_*`` helpers.
+    """
+    output_type = normalize_model_parameter(output_type)
+    task_type = normalize_model_parameter(task_type)
+    file_status = normalize_model_parameter(file_status)
+    temporal_entity = normalize_model_parameter(temporal_entity)
+
+    params = {}
+    if temporal_entity:
+        params["temporal_entity_id"] = temporal_entity["id"]
+    if output_type:
+        params["output_type_id"] = output_type["id"]
+    if task_type:
+        params["task_type_id"] = task_type["id"]
+    if representation:
+        params["representation"] = representation
+    if name:
+        params["name"] = name
+    if file_status:
+        params["file_status_id"] = file_status["id"]
+    return params
+
+
 @cache
 def all_output_types(client: KitsuClient = default) -> list[dict]:
     """
@@ -271,23 +303,10 @@ def all_output_files_for_entity(
             task_type, name and representation
     """
     entity = normalize_model_parameter(entity)
-    output_type = normalize_model_parameter(output_type)
-    task_type = normalize_model_parameter(task_type)
-    file_status = normalize_model_parameter(file_status)
     path = f"entities/{entity['id']}/output-files"
-
-    params = {}
-    if output_type:
-        params["output_type_id"] = output_type["id"]
-    if task_type:
-        params["task_type_id"] = task_type["id"]
-    if representation:
-        params["representation"] = representation
-    if name:
-        params["name"] = name
-    if file_status:
-        params["file_status_id"] = file_status["id"]
-
+    params = _output_file_filters(
+        output_type, task_type, name, representation, file_status
+    )
     return raw.fetch_all(path, params, client=client)
 
 
@@ -317,26 +336,15 @@ def all_output_files_for_asset_instance(
         output type, task_type, name and representation
     """
     asset_instance = normalize_model_parameter(asset_instance)
-    temporal_entity = normalize_model_parameter(temporal_entity)
-    task_type = normalize_model_parameter(task_type)
-    output_type = normalize_model_parameter(output_type)
-    file_status = normalize_model_parameter(file_status)
     path = f"asset-instances/{asset_instance['id']}/output-files"
-
-    params = {}
-    if temporal_entity:
-        params["temporal_entity_id"] = temporal_entity["id"]
-    if output_type:
-        params["output_type_id"] = output_type["id"]
-    if task_type:
-        params["task_type_id"] = task_type["id"]
-    if representation:
-        params["representation"] = representation
-    if name:
-        params["name"] = name
-    if file_status:
-        params["file_status_id"] = file_status["id"]
-
+    params = _output_file_filters(
+        output_type,
+        task_type,
+        name,
+        representation,
+        file_status,
+        temporal_entity,
+    )
     return raw.fetch_all(path, params, client=client)
 
 
@@ -364,23 +372,10 @@ def all_output_files_for_project(
             task_type, name and representation
     """
     project = normalize_model_parameter(project)
-    output_type = normalize_model_parameter(output_type)
-    task_type = normalize_model_parameter(task_type)
-    file_status = normalize_model_parameter(file_status)
     path = f"projects/{project['id']}/output-files"
-
-    params = {}
-    if output_type:
-        params["output_type_id"] = output_type["id"]
-    if task_type:
-        params["task_type_id"] = task_type["id"]
-    if representation:
-        params["representation"] = representation
-    if name:
-        params["name"] = name
-    if file_status:
-        params["file_status_id"] = file_status["id"]
-
+    params = _output_file_filters(
+        output_type, task_type, name, representation, file_status
+    )
     return raw.fetch_all(path, params, client=client)
 
 
@@ -951,23 +946,10 @@ def get_last_output_files_for_entity(
             task_type, name and representation
     """
     entity = normalize_model_parameter(entity)
-    output_type = normalize_model_parameter(output_type)
-    task_type = normalize_model_parameter(task_type)
-    file_status = normalize_model_parameter(file_status)
     path = f"entities/{entity['id']}/output-files/last-revisions"
-
-    params = {}
-    if output_type:
-        params["output_type_id"] = output_type["id"]
-    if task_type:
-        params["task_type_id"] = task_type["id"]
-    if representation:
-        params["representation"] = representation
-    if name:
-        params["name"] = name
-    if file_status:
-        params["file_status_id"] = file_status["id"]
-
+    params = _output_file_filters(
+        output_type, task_type, name, representation, file_status
+    )
     return raw.fetch_all(path, params, client=client)
 
 
@@ -998,23 +980,10 @@ def get_last_output_files_for_asset_instance(
     """
     asset_instance = normalize_model_parameter(asset_instance)
     temporal_entity = normalize_model_parameter(temporal_entity)
-    output_type = normalize_model_parameter(output_type)
-    task_type = normalize_model_parameter(task_type)
-    file_status = normalize_model_parameter(file_status)
     path = f"asset-instances/{asset_instance['id']}/entities/{temporal_entity['id']}/output-files/last-revisions"
-
-    params = {}
-    if output_type:
-        params["output_type_id"] = output_type["id"]
-    if task_type:
-        params["task_type_id"] = task_type["id"]
-    if representation:
-        params["representation"] = representation
-    if name:
-        params["name"] = name
-    if file_status:
-        params["file_status_id"] = file_status["id"]
-
+    params = _output_file_filters(
+        output_type, task_type, name, representation, file_status
+    )
     return raw.fetch_all(path, params, client=client)
 
 

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -886,8 +886,8 @@ def get_last_entity_output_revision(
         name (str): The output name
 
     Returns:
-        int: Last revision of ouput files for given entity, output type and task
-        type.
+        int: Last revision of output files for given entity, output type and
+        task type. 0 when no output file exists yet.
     """
     entity = normalize_model_parameter(entity)
     output_type = normalize_model_parameter(output_type)
@@ -909,6 +909,10 @@ def get_last_asset_instance_output_revision(
 ) -> int:
     """
     Generate last output revision for given asset instance.
+
+    Returns:
+        int: Last revision of output files for given asset instance.
+        0 when no output file exists yet.
     """
     asset_instance = normalize_model_parameter(asset_instance)
     temporal_entity = normalize_model_parameter(temporal_entity)

--- a/gazu/files.py
+++ b/gazu/files.py
@@ -888,9 +888,8 @@ def get_last_entity_output_revision(
     revision = get_next_entity_output_revision(
         entity, output_type, task_type, name, client=client
     )
-    if revision != 1:
-        revision -= 1
-    return revision
+    # next_revision is 1 when no output file exists yet, so last is 0.
+    return revision - 1
 
 
 def get_last_asset_instance_output_revision(
@@ -916,9 +915,8 @@ def get_last_asset_instance_output_revision(
         name=name,
         client=client,
     )
-    if revision != 1:
-        revision -= 1
-    return revision
+    # next_revision is 1 when no output file exists yet, so last is 0.
+    return revision - 1
 
 
 @cache

--- a/gazu/helpers.py
+++ b/gazu/helpers.py
@@ -87,7 +87,7 @@ def download_file(
     url: str, file_path: str | None = None, headers: dict | None = None
 ) -> str:
     """
-    Download file located at *file_path* to given url *url*.
+    Download the file at *url* and store it at *file_path*.
 
     Args:
         url (str): The url path to download file from.

--- a/gazu/helpers.py
+++ b/gazu/helpers.py
@@ -13,7 +13,7 @@ from gazu.exception import DownloadFileException
 import urllib.parse as urlparse
 
 _UUID_RE = re.compile(
-    "([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}"
+    "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 )
 
 

--- a/gazu/helpers.py
+++ b/gazu/helpers.py
@@ -112,7 +112,7 @@ def download_file(
             if os.path.isdir(file_path):
                 file_path = file_path + os.sep
 
-            (dir, filename) = os.path.split(file_path)
+            dir, filename = os.path.split(file_path)
 
             if not filename:
                 url_parts = urlparse.urlparse(url)

--- a/gazu/helpers.py
+++ b/gazu/helpers.py
@@ -39,7 +39,7 @@ def normalize_model_parameter(
         except Exception:
             raise ValueError("Failed to cast argument to str")
 
-        if _UUID_RE.match(id_str):
+        if _UUID_RE.fullmatch(id_str):
             return {"id": id_str}
         else:
             raise ValueError("Wrong format: expected ID string or Data dict")

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -52,7 +52,7 @@ def get_time_spents_range(
     client: KitsuClient = default,
 ) -> list:
     """
-    Gets the time spents of the current user for the given date range.
+    Gets the time spents of the given person for the given date range.
 
     Args:
         person_id (str): An uuid identifying a person.

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -13,7 +13,6 @@ from .helpers import (
 from .cache import cache
 from .client import KitsuClient
 
-
 default = raw.default_client
 
 

--- a/gazu/person.py
+++ b/gazu/person.py
@@ -361,7 +361,7 @@ def update_person(person: dict, client: KitsuClient = default) -> dict:
         dict: The updated person.
     """
 
-    if "departments" in person:
+    if isinstance(person, dict) and "departments" in person:
         person["departments"] = normalize_list_of_models_for_links(
             person["departments"]
         )

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -314,7 +314,7 @@ def delete_playlist(
         playlist (str / dict): The playlist dict or id.
 
     Returns:
-        Response: Request response object.
+        str: The API response text.
     """
     playlist = normalize_model_parameter(playlist)
     return raw.delete(f"data/playlists/{playlist['id']}", client=client)

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -207,7 +207,8 @@ def add_entity_to_playlist(
     to review.
 
     Args:
-        playlist (dict): Playlist object to modify.
+        playlist (dict): The playlist to add the entity to. The argument is
+            not mutated: use the returned playlist.
         entity (str / dict): The entity to add or its ID.
         preview_file (str / dict): Set it to force a give revision to review.
         persist (bool): Set it to True to save the result to the API.

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -235,16 +235,17 @@ def add_entity_to_playlist(
         preview_file = normalize_model_parameter(preview_file)
         entry["preview_file_id"] = preview_file["id"]
 
-    if playlist.get("shots") is None:
-        playlist["shots"] = []
-    playlist["shots"].append(entry)
     if persist:
-        playlist = raw.post(
+        return raw.post(
             f"actions/playlists/{playlist['id']}/add-entity",
             entry,
             client=client,
         )
-    return playlist
+
+    updated = dict(playlist)
+    updated["shots"] = list(updated.get("shots") or [])
+    updated["shots"].append(entry)
+    return updated
 
 
 def remove_entity_from_playlist(

--- a/gazu/playlist.py
+++ b/gazu/playlist.py
@@ -73,6 +73,10 @@ def all_playlists_for_episode(
     Returns:
         list: All playlists for the given episode.
     """
+    episode = normalize_model_parameter(episode)
+    # Fetch the episode when only an ID was given, to get its project_id.
+    if "project_id" not in episode:
+        episode = raw.fetch_one("episodes", episode["id"], client=client)
     project = normalize_model_parameter(episode["project_id"])
     return sort_by_name(
         raw.fetch_all(
@@ -214,7 +218,7 @@ def add_entity_to_playlist(
     entity = normalize_model_parameter(entity)
 
     if preview_file is None:
-        preview_files = get_entity_preview_files(entity)
+        preview_files = get_entity_preview_files(entity, client=client)
         for task_type_id in preview_files.keys():
             task_type_files = preview_files[task_type_id]
             if not task_type_files:

--- a/gazu/project.py
+++ b/gazu/project.py
@@ -357,6 +357,7 @@ def add_metadata_descriptor(
         project (dict / ID): The project dict or id.
         name (str): The name of the metadata descriptor
         entity_type (str): asset, shot or scene.
+        data_type (str): The value type, defaults to "string".
         choices (list): A list of possible values, empty list for free values.
         for_client (bool) : Wheter it should be displayed in Kitsu or not.
         departments (list): A list of departments dict or id.
@@ -419,7 +420,7 @@ def get_metadata_descriptor_by_field_name(
         field_name (str): The name of the metadata field.
 
     Returns:
-        dict: The metadata descriptor matchind the ID.
+        dict: The metadata descriptor matching the given field name.
     """
     project = normalize_model_parameter(project)
     return raw.fetch_first(

--- a/gazu/scene.py
+++ b/gazu/scene.py
@@ -45,13 +45,13 @@ def all_scenes(
     return sort_by_name(scenes)
 
 
-@cache
 def all_scenes_for_project(
     project: str | dict, client: KitsuClient = default
 ) -> list[dict]:
     """
     Retrieve all scenes for given project.
     """
+    # No @cache here: all_scenes already caches.
     return all_scenes(project, client=client)
 
 

--- a/gazu/scene.py
+++ b/gazu/scene.py
@@ -52,9 +52,7 @@ def all_scenes_for_project(
     """
     Retrieve all scenes for given project.
     """
-    project = normalize_model_parameter(project)
-    scenes = raw.fetch_all(f"projects/{project['id']}/scenes", client=client)
-    return sort_by_name(scenes)
+    return all_scenes(project, client=client)
 
 
 @cache
@@ -86,12 +84,11 @@ def get_scene_by_name(
     Returns scene corresponding to given sequence and name.
     """
     sequence = normalize_model_parameter(sequence)
-    result = raw.fetch_all(
+    return raw.fetch_first(
         "scenes/all",
         {"parent_id": sequence["id"], "name": scene_name},
         client=client,
     )
-    return next(iter(result or []), None)
 
 
 def update_scene(scene: dict, client: KitsuClient = default) -> dict:

--- a/gazu/scene.py
+++ b/gazu/scene.py
@@ -6,7 +6,7 @@ from .sorting import sort_by_name
 from .cache import cache
 from .client import KitsuClient
 from .helpers import normalize_model_parameter
-from .shot import get_sequence
+from . import shot as gazu_shot
 
 default = raw.default_client
 
@@ -225,4 +225,4 @@ def get_sequence_from_scene(
     Return sequence which is parent of given scene.
     """
     scene = normalize_model_parameter(scene)
-    return get_sequence(scene["parent_id"], client=client)
+    return gazu_shot.get_sequence(scene["parent_id"], client=client)

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -703,7 +703,6 @@ def remove_sequence(
     return raw.delete(path, params=params, client=client)
 
 
-@cache
 def all_asset_instances_for_shot(
     shot: str | dict, client: KitsuClient = default
 ) -> list[dict]:
@@ -715,6 +714,7 @@ def all_asset_instances_for_shot(
         list: Asset instances linked to given shot.
     """
     # Kept as an alias of get_asset_instances_for_shot for backward compat.
+    # No @cache here: the delegate already caches.
     return get_asset_instances_for_shot(shot, client=client)
 
 

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -415,8 +415,10 @@ def new_shot(
         project (str / dict): The project dict or the project ID.
         sequence (str / dict): The sequence dict or the sequence ID.
         name (str): The name of the shot to create.
+        nb_frames (int): Number of frames of the shot.
         frame_in (int): Frame in value for the shot.
         frame_out (int): Frame out value for the shot.
+        description (str): Description of the shot.
         data (dict): Free field to set metadata of any kind.
 
     Returns:
@@ -553,7 +555,7 @@ def remove_shot(
 
     Args:
         shot (str / dict): Shot to remove.
-        force (bool): Whether to force deletion of the asset regardless of
+        force (bool): Whether to force deletion of the shot regardless of
             whether it has links to tasks.
     """
     shot = normalize_model_parameter(shot)
@@ -846,7 +848,7 @@ def export_shots_with_csv(
             exists it will be overwritten.
         episode (str | dict | None):
             Only export Shots that are linked to the given Episode, which can
-            be provided as an ID string or model dict. If None, all assets will
+            be provided as an ID string or model dict. If None, all shots will
             be exported.
         assigned_to (str | dict | None):
             Only export Shots that have one or more Tasks assigned to the

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -422,8 +422,8 @@ def new_shot(
     Returns:
         dict: Created shot.
     """
-    if data is None:
-        data = {}
+    # Copy to avoid mutating the dict provided by the caller.
+    data = dict(data) if data else {}
     project = normalize_model_parameter(project)
     sequence = normalize_model_parameter(sequence)
 

--- a/gazu/shot.py
+++ b/gazu/shot.py
@@ -534,13 +534,9 @@ def update_sequence_data(
         data = {}
     sequence = normalize_model_parameter(sequence)
     current_sequence = get_sequence(sequence["id"], client=client)
-
-    if not current_sequence.get("data"):
-        current_sequence["data"] = {}
-
     updated_sequence = {
         "id": current_sequence["id"],
-        "data": {**current_sequence["data"], **data},
+        "data": {**(current_sequence.get("data") or {}), **data},
     }
     return update_sequence(updated_sequence, client=client)
 
@@ -716,8 +712,8 @@ def all_asset_instances_for_shot(
     Returns:
         list: Asset instances linked to given shot.
     """
-    shot = normalize_model_parameter(shot)
-    return raw.get(f"data/shots/{shot['id']}/asset-instances", client=client)
+    # Kept as an alias of get_asset_instances_for_shot for backward compat.
+    return get_asset_instances_for_shot(shot, client=client)
 
 
 def add_asset_instance_to_shot(

--- a/gazu/sorting.py
+++ b/gazu/sorting.py
@@ -11,4 +11,4 @@ def sort_by_name(dicts: list[dict]) -> list[dict]:
     Returns:
         Sorted list.
     """
-    return sorted(dicts, key=lambda k: k.get("name", "").lower())
+    return sorted(dicts, key=lambda k: (k.get("name") or "").lower())

--- a/gazu/sync.py
+++ b/gazu/sync.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
+
+from typing import Callable
 
 from . import client as raw
 from . import asset as asset_module
@@ -14,6 +17,8 @@ from . import task as task_module
 
 from .client import KitsuClient
 from .helpers import normalize_model_parameter, validate_date_format
+
+logger = logging.getLogger("gazu.sync")
 
 default = raw.default_client
 
@@ -189,14 +194,14 @@ def get_id_map_by_id(
 ) -> dict:
     """
     Args:
-        source_list (list): List of links to compare.
-        target_list (list): List of links for which we want a diff.
+        source_list (list): Source models to map from.
+        target_list (list): Target models to map to.
+        field (str): Field used to match models across lists (default "name").
 
     Returns:
-        dict: A dict where keys are the source model names and the values are
-        the IDs of the target models with same name.
-        It's useful to match a model from the source list to its relative in
-        the target list based on its name.
+        dict: A dict where keys are the source model IDs and values are the
+        IDs of the target models matched on the given field. Useful to match a
+        model from the source list to its counterpart in the target list.
     """
     link_map = {}
     name_map = {}
@@ -223,6 +228,29 @@ def is_changed(source_model: dict, target_model: dict) -> bool:
     return source_date > target_date
 
 
+def _get_sync_id_map(
+    source_client: KitsuClient,
+    target_client: KitsuClient,
+    fetch_all: Callable,
+    field: str = "name",
+) -> dict:
+    """
+    Build an id map between two instances for a given model.
+
+    Args:
+        source_client (KitsuClient): client to get data from source API
+        target_client (KitsuClient): client to push data to target API
+        fetch_all (Callable): function returning all models for a client.
+        field (str): field used to match models (default "name").
+
+    Returns:
+        dict: A dict matching source model ids with target model ids.
+    """
+    source = fetch_all(client=source_client)
+    target = fetch_all(client=target_client)
+    return get_id_map_by_id(source, target, field=field)
+
+
 def get_sync_department_id_map(
     source_client: KitsuClient, target_client: KitsuClient
 ) -> dict:
@@ -234,9 +262,9 @@ def get_sync_department_id_map(
     Returns:
         dict: A dict matching source departments ids with target department ids
     """
-    departments_source = person_module.all_departments(client=source_client)
-    departments_target = person_module.all_departments(client=target_client)
-    return get_id_map_by_id(departments_source, departments_target)
+    return _get_sync_id_map(
+        source_client, target_client, person_module.all_departments
+    )
 
 
 def get_sync_asset_type_id_map(
@@ -250,9 +278,9 @@ def get_sync_asset_type_id_map(
     Returns:
         dict: A dict matching source asset type ids with target asset type ids
     """
-    asset_types_source = asset_module.all_asset_types(client=source_client)
-    asset_types_target = asset_module.all_asset_types(client=target_client)
-    return get_id_map_by_id(asset_types_source, asset_types_target)
+    return _get_sync_id_map(
+        source_client, target_client, asset_module.all_asset_types
+    )
 
 
 def get_sync_project_id_map(
@@ -266,9 +294,9 @@ def get_sync_project_id_map(
     Returns:
         dict: A dict matching source project ids with target project ids
     """
-    projects_source = project_module.all_projects(client=source_client)
-    projects_target = project_module.all_projects(client=target_client)
-    return get_id_map_by_id(projects_source, projects_target)
+    return _get_sync_id_map(
+        source_client, target_client, project_module.all_projects
+    )
 
 
 def get_sync_task_type_id_map(
@@ -282,9 +310,9 @@ def get_sync_task_type_id_map(
     Returns:
         dict: A dict matching source task type ids with target task type ids
     """
-    task_types_source = task_module.all_task_types(client=source_client)
-    task_types_target = task_module.all_task_types(client=target_client)
-    return get_id_map_by_id(task_types_source, task_types_target)
+    return _get_sync_id_map(
+        source_client, target_client, task_module.all_task_types
+    )
 
 
 def get_sync_task_status_id_map(
@@ -299,9 +327,9 @@ def get_sync_task_status_id_map(
         dict: A dict matching source task status ids with target task status
               ids
     """
-    task_statuses_source = task_module.all_task_statuses(client=source_client)
-    task_statuses_target = task_module.all_task_statuses(client=target_client)
-    return get_id_map_by_id(task_statuses_source, task_statuses_target)
+    return _get_sync_id_map(
+        source_client, target_client, task_module.all_task_statuses
+    )
 
 
 def get_sync_person_id_map(
@@ -315,9 +343,12 @@ def get_sync_person_id_map(
     Returns:
         dict: A dict matching source person ids with target person ids
     """
-    persons_source = person_module.all_persons(client=source_client)
-    persons_target = person_module.all_persons(client=target_client)
-    return get_id_map_by_id(persons_source, persons_target, field="email")
+    return _get_sync_id_map(
+        source_client,
+        target_client,
+        person_module.all_persons,
+        field="email",
+    )
 
 
 def push_assets(
@@ -532,16 +563,26 @@ def push_tasks(
     tasks = task_module.all_tasks_for_project(
         project_source, client=client_source
     )
+    mapped_tasks = []
     for task in tasks:
+        if task["task_type_id"] not in task_type_map:
+            logger.warning(
+                "Skipping task %s: task type %s is not mapped to the target.",
+                task.get("id"),
+                task["task_type_id"],
+            )
+            continue
         task["task_type_id"] = task_type_map[task["task_type_id"]]
         task["task_status_id"] = default_status_id
-        task["assigner_id"] = person_map[task["assigner_id"]]
+        task["assigner_id"] = person_map.get(task["assigner_id"])
         task["project_id"] = project_target["id"]
-
         task["assignees"] = [
-            person_map[person_id] for person_id in task["assignees"]
+            person_map[person_id]
+            for person_id in task["assignees"]
+            if person_id in person_map
         ]
-    return import_tasks(tasks, client=client_target)
+        mapped_tasks.append(task)
+    return import_tasks(mapped_tasks, client=client_target)
 
 
 def push_tasks_comments(
@@ -608,7 +649,8 @@ def push_task_comments(
             client_source,
             client_target,
         )
-        comments_target.append(comment_target)
+        if comment_target is not None:
+            comments_target.append(comment_target)
     return comments_target
 
 
@@ -685,9 +727,16 @@ def push_task_comment(
                 }
             )
 
+    if comment["task_status_id"] not in task_status_map:
+        logger.warning(
+            "Skipping comment %s: task status %s is not mapped to the target.",
+            comment.get("id"),
+            comment["task_status_id"],
+        )
+        return
     task_status = {"id": task_status_map[comment["task_status_id"]]}
     if author_id is None:
-        author_id = person_map[comment["person_id"]]
+        author_id = person_map.get(comment["person_id"])
     person = {"id": author_id}
 
     comment_target = task_module.add_comment(

--- a/gazu/sync.py
+++ b/gazu/sync.py
@@ -215,8 +215,8 @@ def is_changed(source_model: dict, target_model: dict) -> bool:
         target_model (dict): Matching model from the target API.
 
     Returns:
-        bool: True if the source model is older than the target model (based on
-        `updated_at` field)
+        bool: True if the source model is more recent than the target model
+        (based on the `updated_at` field)
     """
     source_date = source_model["updated_at"]
     target_date = target_model["updated_at"]

--- a/gazu/sync.py
+++ b/gazu/sync.py
@@ -574,7 +574,15 @@ def push_tasks(
             continue
         task["task_type_id"] = task_type_map[task["task_type_id"]]
         task["task_status_id"] = default_status_id
-        task["assigner_id"] = person_map.get(task["assigner_id"])
+        assigner_id = task["assigner_id"]
+        if assigner_id is not None and assigner_id not in person_map:
+            logger.warning(
+                "Task %s: assigner %s is not mapped to the target, "
+                "importing the task without an assigner.",
+                task.get("id"),
+                assigner_id,
+            )
+        task["assigner_id"] = person_map.get(assigner_id)
         task["project_id"] = project_target["id"]
         task["assignees"] = [
             person_map[person_id]
@@ -737,7 +745,14 @@ def push_task_comment(
     task_status = {"id": task_status_map[comment["task_status_id"]]}
     if author_id is None:
         author_id = person_map.get(comment["person_id"])
-    person = {"id": author_id}
+        if author_id is None:
+            logger.warning(
+                "Comment %s: author %s is not mapped to the target, "
+                "the comment will be attributed to the current user.",
+                comment.get("id"),
+                comment["person_id"],
+            )
+    person = {"id": author_id} if author_id is not None else None
 
     comment_target = task_module.add_comment(
         task,

--- a/gazu/sync.py
+++ b/gazu/sync.py
@@ -97,7 +97,7 @@ def import_entity_links(
         links (list): Entity links to import.
 
     Returns:
-        dict: Entity links created.
+        list: Entity links created.
     """
     return raw.post("import/kitsu/entity-links", links, client=client)
 
@@ -165,8 +165,8 @@ def get_id_map_by_name(
 ) -> dict:
     """
     Args:
-        source_list (list): List of links to compare.
-        target_list (list): List of links for which we want a diff.
+        source_list (list): Source models to map.
+        target_list (list): Target models to match against by name.
 
     Returns:
         dict: A dict where keys are the source model names and the values are
@@ -523,7 +523,7 @@ def push_tasks(
         client_target (KitsuClient): client to push data to target API
 
     Returns:
-        list: Pushed entity links
+        list: Pushed tasks
     """
     default_status_id = normalize_model_parameter(default_status)["id"]
     task_type_map = get_sync_task_type_id_map(client_source, client_target)
@@ -560,7 +560,7 @@ def push_tasks_comments(
         client_target (KitsuClient): client to push data to target API
 
     Returns:
-        list: Created comments
+        list: Source tasks whose comments were pushed
     """
     task_status_map = get_sync_task_status_id_map(client_source, client_target)
     person_map = get_sync_person_id_map(client_source, client_target)

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -43,6 +43,25 @@ def _all_tasks_for_entity(
     return sort_by_name(tasks)
 
 
+def _open_comment_files(comments: list[dict]) -> tuple[dict, list]:
+    """
+    Open the attachment/preview files referenced by a batch of comments.
+
+    Returns the multipart ``files`` dict (including the JSON ``comments``
+    part) and the list of opened files -- the caller must close them.
+    """
+    files = {}
+    opened_files = []
+    for x, comment in enumerate(comments):
+        for kind in ("attachment_files", "preview_files"):
+            for y, file_path in enumerate(comment.get(kind) or []):
+                f = open(file_path, "rb")
+                opened_files.append(f)
+                files[f"{kind[:-1]}-{x}-{y}"] = f
+    files["comments"] = (None, json.dumps(comments), "application/json")
+    return files, opened_files
+
+
 @cache
 def all_task_statuses(client: KitsuClient = default) -> list[dict]:
     """
@@ -282,7 +301,7 @@ def all_tasks_for_task_type(
     Args:
         project (str / dict): The project dict or the project ID.
         task_type (str / dict): The task type dict or ID.
-        episode_id (str / dict): The episode dict or ID.
+        episode (str / dict): The episode dict or ID.
 
     Returns:
         list: Tasks for given project and task type.
@@ -589,7 +608,7 @@ def get_task_status_by_name(
 ) -> dict | None:
     """
     Args:
-        name (str / dict): The name of claimed task status.
+        name (str): The name of claimed task status.
 
     Returns:
         dict: Task status matching given name.
@@ -603,7 +622,7 @@ def get_task_status_by_short_name(
 ) -> dict | None:
     """
     Args:
-        short_name (str / dict): The short name of claimed task status.
+        task_status_short_name (str): The short name of claimed task status.
 
     Returns:
         dict: Task status matching given short name.
@@ -1112,7 +1131,7 @@ def upload_preview_file(
     progress_callback=None,
 ) -> dict:
     """
-    Create a preview into given comment.
+    Upload the file content for a given preview file.
 
     Args:
         preview_file (str / dict): The preview_file dict or the preview_file ID.
@@ -1300,26 +1319,8 @@ def batch_comments(
     if task is not None:
         task = normalize_model_parameter(task)
 
-    files = {}
-    opened_files = []
+    files, opened_files = _open_comment_files(comments)
     try:
-        for x, comment in enumerate(comments):
-            if comment.get("attachment_files"):
-                for y, file_path in enumerate(comment["attachment_files"]):
-                    f = open(file_path, "rb")
-                    opened_files.append(f)
-                    files[f"attachment_file-{x}-{y}"] = f
-            if comment.get("preview_files"):
-                for y, file_path in enumerate(comment["preview_files"]):
-                    f = open(file_path, "rb")
-                    opened_files.append(f)
-                    files[f"preview_file-{x}-{y}"] = f
-
-        files["comments"] = (
-            None,
-            json.dumps(comments),
-            "application/json",
-        )
         return raw.upload(
             f"actions/tasks/{task['id'] + '/' if task else ''}batch-comment",
             file_path=None,
@@ -1356,26 +1357,8 @@ def create_multiple_comments(
         comments = []
     project = normalize_model_parameter(project)
 
-    files = {}
-    opened_files = []
+    files, opened_files = _open_comment_files(comments)
     try:
-        for x, comment in enumerate(comments):
-            if comment.get("attachment_files"):
-                for y, file_path in enumerate(comment["attachment_files"]):
-                    f = open(file_path, "rb")
-                    opened_files.append(f)
-                    files[f"attachment_file-{x}-{y}"] = f
-            if comment.get("preview_files"):
-                for y, file_path in enumerate(comment["preview_files"]):
-                    f = open(file_path, "rb")
-                    opened_files.append(f)
-                    files[f"preview_file-{x}-{y}"] = f
-
-        files["comments"] = (
-            None,
-            json.dumps(comments),
-            "application/json",
-        )
         return raw.upload(
             f"actions/projects/{project['id']}/tasks/comment-many",
             file_path=None,

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -170,7 +170,7 @@ def all_tasks_for_sequence(
     Args:
         sequence (str / dict): The sequence dict or the sequence ID.
 
-    Returns
+    Returns:
         list: Tasks linked to given sequence.
     """
     return _all_tasks_for_entity(
@@ -326,7 +326,7 @@ def all_task_types_for_shot(
     Args:
         shot (str / dict): The shot dict or the shot ID.
 
-    Returns
+    Returns:
         list: Task types of task linked to given shot.
     """
     shot = normalize_model_parameter(shot)
@@ -343,7 +343,7 @@ def all_task_types_for_concept(
     Args:
         concept (str / dict): The concept dict or the concept ID.
 
-    Returns
+    Returns:
         list: Task types of task linked to given concept.
     """
     concept = normalize_model_parameter(concept)
@@ -744,7 +744,9 @@ def new_task(
         assignees (list): List of people assigned to the task.
 
     Returns:
-        Created task.
+        The created task, or the existing one if a task with the same entity,
+        task type and name already exists (in which case the requested
+        task_status/assignees are not re-applied).
     """
     entity = normalize_model_parameter(entity)
     task_type = normalize_model_parameter(task_type)

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -52,12 +52,17 @@ def _open_comment_files(comments: list[dict]) -> tuple[dict, list]:
     """
     files = {}
     opened_files = []
-    for x, comment in enumerate(comments):
-        for kind in ("attachment_files", "preview_files"):
-            for y, file_path in enumerate(comment.get(kind) or []):
-                f = open(file_path, "rb")
-                opened_files.append(f)
-                files[f"{kind[:-1]}-{x}-{y}"] = f
+    try:
+        for x, comment in enumerate(comments):
+            for kind in ("attachment_files", "preview_files"):
+                for y, file_path in enumerate(comment.get(kind) or []):
+                    f = open(file_path, "rb")
+                    opened_files.append(f)
+                    files[f"{kind[:-1]}-{x}-{y}"] = f
+    except Exception:
+        for f in opened_files:
+            f.close()
+        raise
     files["comments"] = (None, json.dumps(comments), "application/json")
     return files, opened_files
 

--- a/gazu/task.py
+++ b/gazu/task.py
@@ -24,6 +24,25 @@ from .cache import cache
 default = raw.default_client
 
 
+def _all_tasks_for_entity(
+    entity: str | dict,
+    collection: str,
+    suffix: str = "tasks",
+    relations: bool = False,
+    client: KitsuClient = default,
+) -> list[dict]:
+    """
+    Fetch and sort the tasks listed at ``<collection>/<entity id>/<suffix>``
+    for the given entity. Shared body of all the ``all_*tasks_for_*`` helpers.
+    """
+    entity = normalize_model_parameter(entity)
+    params = {"relations": True} if relations else {}
+    tasks = raw.fetch_all(
+        f"{collection}/{entity['id']}/{suffix}", params, client=client
+    )
+    return sort_by_name(tasks)
+
+
 @cache
 def all_task_statuses(client: KitsuClient = default) -> list[dict]:
     """
@@ -85,12 +104,9 @@ def all_tasks_for_shot(
     Returns:
         list: Tasks linked to given shot.
     """
-    shot = normalize_model_parameter(shot)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    tasks = raw.fetch_all(f"shots/{shot['id']}/tasks", params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        shot, "shots", relations=relations, client=client
+    )
 
 
 @cache
@@ -104,14 +120,9 @@ def all_tasks_for_concept(
     Returns:
         list: Tasks linked to given concept.
     """
-    concept = normalize_model_parameter(concept)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    tasks = raw.fetch_all(
-        f"concepts/{concept['id']}/tasks", params, client=client
+    return _all_tasks_for_entity(
+        concept, "concepts", relations=relations, client=client
     )
-    return sort_by_name(tasks)
 
 
 @cache
@@ -125,12 +136,9 @@ def all_tasks_for_edit(
     Returns:
         list: Tasks linked to given edit.
     """
-    edit = normalize_model_parameter(edit)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    tasks = raw.fetch_all(f"edits/{edit['id']}/tasks", params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        edit, "edits", relations=relations, client=client
+    )
 
 
 @cache
@@ -146,13 +154,9 @@ def all_tasks_for_sequence(
     Returns
         list: Tasks linked to given sequence.
     """
-    sequence = normalize_model_parameter(sequence)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    path = f"sequences/{sequence['id']}/tasks"
-    tasks = raw.fetch_all(path, params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        sequence, "sequences", relations=relations, client=client
+    )
 
 
 @cache
@@ -166,13 +170,9 @@ def all_tasks_for_scene(
     Returns:
         list: Tasks linked to given scene.
     """
-    scene = normalize_model_parameter(scene)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    path = f"scenes/{scene['id']}/tasks"
-    tasks = raw.fetch_all(path, params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        scene, "scenes", relations=relations, client=client
+    )
 
 
 @cache
@@ -186,13 +186,9 @@ def all_tasks_for_asset(
     Returns:
         list: Tasks directly linked to given asset.
     """
-    asset = normalize_model_parameter(asset)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    path = f"assets/{asset['id']}/tasks"
-    tasks = raw.fetch_all(path, params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        asset, "assets", relations=relations, client=client
+    )
 
 
 @cache
@@ -202,13 +198,9 @@ def all_tasks_for_episode(
     """
     Retrieve all tasks directly linked to given episode.
     """
-    episode = normalize_model_parameter(episode)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    path = f"episodes/{episode['id']}/tasks"
-    tasks = raw.fetch_all(path, params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        episode, "episodes", relations=relations, client=client
+    )
 
 
 @cache
@@ -220,13 +212,9 @@ def all_shot_tasks_for_sequence(
     """
     Retrieve all tasks directly linked to all shots of given sequence.
     """
-    sequence = normalize_model_parameter(sequence)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    path = f"sequences/{sequence['id']}/shot-tasks"
-    tasks = raw.fetch_all(path, params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        sequence, "sequences", "shot-tasks", relations, client
+    )
 
 
 @cache
@@ -236,13 +224,9 @@ def all_shot_tasks_for_episode(
     """
     Retrieve all tasks directly linked to all shots of given episode.
     """
-    episode = normalize_model_parameter(episode)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    path = f"episodes/{episode['id']}/shot-tasks"
-    tasks = raw.fetch_all(path, params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        episode, "episodes", "shot-tasks", relations, client
+    )
 
 
 @cache
@@ -252,13 +236,9 @@ def all_assets_tasks_for_episode(
     """
     Retrieve all tasks directly linked to all assets of given episode.
     """
-    episode = normalize_model_parameter(episode)
-    params = {}
-    if relations:
-        params = {"relations": True}
-    path = f"episodes/{episode['id']}/asset-tasks"
-    tasks = raw.fetch_all(path, params, client=client)
-    return sort_by_name(tasks)
+    return _all_tasks_for_entity(
+        episode, "episodes", "asset-tasks", relations, client
+    )
 
 
 @cache

--- a/gazu/user.py
+++ b/gazu/user.py
@@ -122,7 +122,7 @@ def all_tasks_for_sequence(
     sequence: str | dict, client: KitsuClient = default
 ) -> list[dict]:
     """
-    Return the list of tasks for given asset and current user.
+    Return the list of tasks for given sequence and current user.
     """
     sequence = normalize_model_parameter(sequence)
     path = f"user/sequences/{sequence['id']}/tasks"
@@ -187,7 +187,7 @@ def all_task_types_for_sequence(
 ) -> list[dict]:
     """
     Returns:
-        list: Task types for given asset and current user.
+        list: Task types for given sequence and current user.
     """
     sequence = normalize_model_parameter(sequence)
     path = f"user/sequences/{sequence['id']}/task-types"

--- a/gazu/user.py
+++ b/gazu/user.py
@@ -356,7 +356,9 @@ def new_filter(
         dict: Created filter.
     """
     project_id = (
-        normalize_model_parameter(project) if project is not None else None
+        normalize_model_parameter(project)["id"]
+        if project is not None
+        else None
     )
 
     return raw.post(

--- a/gazu/user.py
+++ b/gazu/user.py
@@ -223,6 +223,7 @@ def all_episodes_for_project(
     Returns:
         list: Episodes for which user has tasks assigned for given project.
     """
+    project = normalize_model_parameter(project)
     path = f"user/projects/{project['id']}/episodes"
     asset_types = raw.fetch_all(path, client=client)
     return sort_by_name(asset_types)
@@ -260,6 +261,57 @@ def all_scenes_for_sequence(
     path = f"user/sequences/{sequence['id']}/scenes"
     scenes = raw.fetch_all(path, client=client)
     return sort_by_name(scenes)
+
+
+@cache
+def all_assets_for_project(
+    project: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    Args:
+        project (str / dict): The project dict or the project ID.
+
+    Returns:
+        list: Assets for which user has tasks assigned for given project.
+    """
+    project = normalize_model_parameter(project)
+    path = f"user/projects/{project['id']}/assets"
+    assets = raw.fetch_all(path, client=client)
+    return sort_by_name(assets)
+
+
+@cache
+def all_scenes_for_project(
+    project: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    Args:
+        project (str / dict): The project dict or the project ID.
+
+    Returns:
+        list: Scenes for which user has tasks assigned for given project.
+    """
+    project = normalize_model_parameter(project)
+    path = f"user/projects/{project['id']}/scenes"
+    scenes = raw.fetch_all(path, client=client)
+    return sort_by_name(scenes)
+
+
+@cache
+def all_sequences_for_episode(
+    episode: str | dict, client: KitsuClient = default
+) -> list[dict]:
+    """
+    Args:
+        episode (str / dict): The episode dict or the episode ID.
+
+    Returns:
+        list: Sequences for which user has tasks assigned for given episode.
+    """
+    episode = normalize_model_parameter(episode)
+    path = f"user/episodes/{episode['id']}/sequences"
+    sequences = raw.fetch_all(path, client=client)
+    return sort_by_name(sequences)
 
 
 @cache
@@ -328,7 +380,7 @@ def is_authenticated(client: KitsuClient = default) -> bool:
 
 def all_filters(client: KitsuClient = default) -> list[dict]:
     """
-    Return:
+    Returns:
         list: all filters for current user.
     """
     return raw.fetch_all("user/filters", client=client)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
-    "Framework :: Flask",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Programming Language :: Python :: 3.7",
@@ -56,7 +55,7 @@ lint = [
     "black==26.1.0; python_version >= '3.10'",
     "pre-commit==4.5.1; python_version >= '3.10'",
 ]
-cli = ["click>=7.0"]
+cli = ["click>=8.0"]
 
 [project.scripts]
 gazu-cli = "gazu.cli:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import gazu.client
+import gazu.cache
 
 
 @pytest.fixture(autouse=True)
@@ -9,7 +10,9 @@ def reset_client_state():
     original_host = client.host
     original_event_host = client.event_host
     original_tokens = client.tokens.copy()
+    original_cache_enabled = gazu.cache.cache_settings["enabled"]
     yield
     client.host = original_host
     client.event_host = original_event_host
     client.tokens = original_tokens
+    gazu.cache.cache_settings["enabled"] = original_cache_enabled

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,6 +1,10 @@
 import asyncio
 import unittest
 
+import pytest
+
+pytest.importorskip("aiohttp")  # async extra is optional; skip if absent
+
 import gazu.aio
 from gazu.exception import (
     RouteNotFoundException,

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,0 +1,123 @@
+import asyncio
+import unittest
+
+import gazu.aio
+from gazu.exception import (
+    RouteNotFoundException,
+    NotAllowedException,
+    ParameterException,
+    MethodNotAllowedException,
+    TooBigFileException,
+    ValidationException,
+    NotAuthenticatedException,
+    ServerErrorException,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeResponse:
+    """Minimal stand-in for an aiohttp response in check_status tests."""
+
+    def __init__(self, status, body=None, raise_json=False):
+        self.status = status
+        self._body = body if body is not None else {}
+        self._raise_json = raise_json
+
+    async def json(self):
+        if self._raise_json:
+            raise ValueError("not json")
+        return self._body
+
+    async def text(self):
+        return str(self._body)
+
+
+class AioCheckStatusTestCase(unittest.TestCase):
+    def test_404_raises_route_not_found(self):
+        with self.assertRaises(RouteNotFoundException):
+            run(gazu.aio.check_status(FakeResponse(404), "/"))
+
+    def test_403_raises_not_allowed(self):
+        with self.assertRaises(NotAllowedException):
+            run(gazu.aio.check_status(FakeResponse(403), "/"))
+
+    def test_400_raises_parameter(self):
+        with self.assertRaises(ParameterException):
+            run(
+                gazu.aio.check_status(
+                    FakeResponse(400, {"message": "bad"}), "/"
+                )
+            )
+
+    def test_400_non_json_body_does_not_crash(self):
+        # Regression (BUG-4): a non-JSON 400 body must still raise
+        # ParameterException, not a raw JSON decode error.
+        with self.assertRaises(ParameterException):
+            run(gazu.aio.check_status(FakeResponse(400, raise_json=True), "/"))
+
+    def test_405_raises_method_not_allowed(self):
+        with self.assertRaises(MethodNotAllowedException):
+            run(gazu.aio.check_status(FakeResponse(405), "/"))
+
+    def test_413_raises_too_big_file(self):
+        with self.assertRaises(TooBigFileException):
+            run(gazu.aio.check_status(FakeResponse(413), "/"))
+
+    def test_422_raises_validation(self):
+        with self.assertRaises(ValidationException):
+            run(
+                gazu.aio.check_status(
+                    FakeResponse(422, {"message": "invalid"}), "/"
+                )
+            )
+
+    def test_401_raises_not_authenticated(self):
+        with self.assertRaises(NotAuthenticatedException):
+            run(
+                gazu.aio.check_status(
+                    FakeResponse(401, {"message": "nope"}), "/"
+                )
+            )
+
+    def test_401_non_json_body_does_not_crash(self):
+        # Regression (BUG-4): a non-JSON 401 body must raise
+        # NotAuthenticatedException, not a raw JSON decode error.
+        with self.assertRaises(NotAuthenticatedException):
+            run(gazu.aio.check_status(FakeResponse(401, raise_json=True), "/"))
+
+    def test_500_raises_server_error(self):
+        with self.assertRaises(ServerErrorException):
+            run(gazu.aio.check_status(FakeResponse(500), "/"))
+
+    def test_success_returns_status_and_no_retry(self):
+        status, retry = run(gazu.aio.check_status(FakeResponse(200), "/"))
+        self.assertEqual(status, 200)
+        self.assertFalse(retry)
+
+
+class AioClientTestCase(unittest.TestCase):
+    def test_refresh_access_token_without_token_raises(self):
+        # Regression (BUG-8): refreshing without a refresh token must raise
+        # a typed exception instead of building a "Bearer None" header.
+        client = gazu.aio.AsyncKitsuClient("http://localhost/api")
+        with self.assertRaises(NotAuthenticatedException):
+            run(client.refresh_access_token())
+
+    def test_make_auth_header_includes_bearer_when_logged_in(self):
+        client = gazu.aio.AsyncKitsuClient(
+            "http://localhost/api", access_token="abc"
+        )
+        headers = client.make_auth_header()
+        self.assertEqual(headers["Authorization"], "Bearer abc")
+
+    def test_make_auth_header_without_token_has_no_authorization(self):
+        client = gazu.aio.AsyncKitsuClient("http://localhost/api")
+        headers = client.make_auth_header()
+        self.assertNotIn("Authorization", headers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -346,6 +346,37 @@ class BaseFuncTestCase(ClientTestCase):
                     extra_files=["./tests/fixtures/v1.png"],
                 )
 
+    def test_upload_with_progress_callback_and_json_part(self):
+        # Regression: a non-file multipart part (a JSON tuple, as produced for
+        # batch comments) used to make the progress-callback path call
+        # os.fstat() on the tuple and raise AttributeError.
+        progress = []
+        with open("./tests/fixtures/v1.png", "rb") as test_file:
+            files = {
+                "file": test_file,
+                "comments": (
+                    None,
+                    json.dumps([{"x": 1}]),
+                    "application/json",
+                ),
+            }
+            with requests_mock.Mocker() as mock:
+                mock_route(
+                    mock,
+                    "POST",
+                    "data/new-file",
+                    text={"id": "person-01"},
+                )
+                result = raw.upload(
+                    "data/new-file",
+                    files=files,
+                    progress_callback=lambda read, total: progress.append(
+                        (read, total)
+                    ),
+                )
+            self.assertEqual(result["id"], "person-01")
+            self.assertTrue(len(progress) > 0)
+
     def test_check_status(self):
         class Request(object):
             def __init__(self, status_code):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -271,6 +271,51 @@ class CastingTestCase(unittest.TestCase):
                 gazu.shot.all_sequences_for_episode(episode),
             )
 
+    def test_all_assets_for_project_user_context(self):
+        # Regression: user_context=True used to call a missing user function.
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/user/projects/project-01/assets",
+                text=[{"name": "Asset 01", "id": "asset-01"}],
+            )
+            project = {"id": "project-01"}
+            self.assertEqual(
+                gazu.context.all_assets_for_project(project, True),
+                gazu.user.all_assets_for_project(project),
+            )
+
+    def test_all_scenes_for_project_user_context(self):
+        # Regression: user_context=True used to call a missing user function.
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/user/projects/project-01/scenes",
+                text=[{"name": "Scene 01", "id": "scene-01"}],
+            )
+            project = {"id": "project-01"}
+            self.assertEqual(
+                gazu.context.all_scenes_for_project(project, True),
+                gazu.user.all_scenes_for_project(project),
+            )
+
+    def test_all_sequences_for_episode_user_context(self):
+        # Regression: user_context=True used to call a missing user function.
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/user/episodes/episode-01/sequences",
+                text=[{"name": "sequence1", "id": "sequence-01"}],
+            )
+            episode = {"id": "episode-01"}
+            self.assertEqual(
+                gazu.context.all_sequences_for_episode(episode, True),
+                gazu.user.all_sequences_for_episode(episode),
+            )
+
     def test_all_task_types_for_shot(self):
         with requests_mock.mock() as mock:
             mock_route(

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1383,6 +1383,17 @@ class FilesTestCase(unittest.TestCase):
                 self.assertTrue(os.path.exists("./test.png"))
                 os.remove("./test.png")
 
+    def test_extract_frame_from_preview_without_file_path(self):
+        # Regression: file_path=None used to crash in open(None, "wb").
+        with open("./tests/fixtures/v1.png", "rb") as frame_file:
+            with requests_mock.mock() as mock:
+                path = f"pictures/preview-files/{fakeid('preview-1')}/extract-frame/100"
+                mock.get(gazu.client.get_full_url(path), body=frame_file)
+                response = gazu.files.extract_frame_from_preview(
+                    fakeid("preview-1"), 100
+                )
+                self.assertEqual(response.status_code, 200)
+
     def test_update_preview_position(self):
         with requests_mock.mock() as mock:
             path = f"data/preview-files/{fakeid('preview-1')}/position"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -216,6 +216,21 @@ class FilesTestCase(unittest.TestCase):
             )
             self.assertEqual(revision, 2)
 
+    def test_last_output_revision_no_output_files(self):
+        with requests_mock.mock() as mock:
+            path = "data/entities/entity-01/output-files/next-revision"
+            mock.post(
+                gazu.client.get_full_url(path),
+                text=json.dumps({"next_revision": 1}),
+            )
+            entity = {"id": "entity-01"}
+            output_type = {"id": "output-type-01"}
+            task_type = {"id": "task-type-01"}
+            revision = gazu.files.get_last_entity_output_revision(
+                entity, output_type, task_type
+            )
+            self.assertEqual(revision, 0)
+
     def test_get_working_file(self):
         with requests_mock.mock() as mock:
             path = "/data/working-files/working-file-1"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -74,7 +74,7 @@ class SyncestCase(unittest.TestCase):
         self.assertEqual(unexpected, [{"id": "asset-4", "name": "Asset 4"}])
         source_list = []
         target_list = []
-        (missing, unexpected) = gazu.sync.get_model_list_diff(
+        missing, unexpected = gazu.sync.get_model_list_diff(
             source_list, target_list
         )
         self.assertEqual(missing, [])
@@ -90,7 +90,7 @@ class SyncestCase(unittest.TestCase):
             {"entity_in_id": "shot-2", "entity_out_id": "asset-2"},
             {"entity_in_id": "shot-4", "entity_out_id": "asset-4"},
         ]
-        (missing, unexpected) = gazu.sync.get_link_list_diff(
+        missing, unexpected = gazu.sync.get_link_list_diff(
             source_list, target_list
         )
         self.assertEqual(
@@ -108,7 +108,7 @@ class SyncestCase(unittest.TestCase):
         )
         source_list = []
         target_list = []
-        (missing, unexpected) = gazu.sync.get_link_list_diff(
+        missing, unexpected = gazu.sync.get_link_list_diff(
             source_list, target_list
         )
         self.assertEqual(missing, [])


### PR DESCRIPTION
## Problems

- Edge-case bugs across client, entity, files, task, sync, casting, person, sorting, playlist and events (unbounded auth retries, string/null IDs, mutated arguments, missing SSL verification).
- aio.py drifted from client.py and lacked test coverage for JSON decoding and token refresh.
- user/context accessors missing; scene/search wrappers not exposed.
- Docs, docstrings and return types out of date; no CHANGELOG.
- No dependency-audit in CI; test cache not isolated; stale packaging metadata.

## Solutions

- Fix the confirmed edge-case bugs, bound auth retries, anchor the UUID regex and surface optional-import errors.
- Re-sync aio.py with client.py and add async tests covering JSON/token-refresh guards.
- Add the missing user-context accessors and expose scene/search.
- Update docstrings, CLAUDE.md, README, Sphinx entries and add a CHANGELOG.
- Add pip-audit CI, isolate the cache in tests, apply black, and clean metadata.