### PR TITLE
[client] Allow requesting specific fields in fetch_all

### DIFF
--- a/gazu/aio.py
+++ b/gazu/aio.py
@@ -330,7 +330,15 @@ async def fetch_all(
     client: AsyncKitsuClient = None,
     paginated: bool = False,
     limit: int | None = None,
+    fields: list[str] | str | None = None,
 ) -> list[dict]:
+    if fields is not None:
+        if not params:
+            params = {}
+        if not isinstance(fields, str):
+            fields = ",".join(fields)
+        params["fields"] = fields
+
     if paginated:
         if not params:
             params = {}

--- a/gazu/client.py
+++ b/gazu/client.py
@@ -721,6 +721,7 @@ def fetch_all(
     client: KitsuClient = default_client,
     paginated: bool = False,
     limit: int | None = None,
+    fields: list[str] | str | None = None,
 ) -> list[dict]:
     """
     Args:
@@ -729,11 +730,20 @@ def fetch_all(
         client (KitsuClient): The client to use for the request.
         paginated (bool): Will query entries page by page.
         limit (int): Limit the number of entries per page.
+        fields (list / str): Names of the attributes to return for each
+            entry (id and type are always included). Only honored by the
+            generic model list routes; older Kitsu API versions ignore it.
 
     Returns:
         list: All entries stored in database for a given model. You can add a
         filter to the model name like this: "tasks?project_id=project-id"
     """
+    if fields is not None:
+        if not params:
+            params = {}
+        if not isinstance(fields, str):
+            fields = ",".join(fields)
+        params["fields"] = fields
 
     if paginated:
         if not params:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -195,6 +195,26 @@ class BaseFuncTestCase(ClientTestCase):
                 raw.fetch_all("persons"), [{"first_name": "John"}]
             )
 
+    def test_fetch_all_with_fields(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/persons",
+                text=[{"first_name": "John"}],
+            )
+            self.assertEqual(
+                raw.fetch_all("persons", fields=["first_name", "last_name"]),
+                [{"first_name": "John"}],
+            )
+            self.assertEqual(
+                mock.last_request.qs, {"fields": ["first_name,last_name"]}
+            )
+            raw.fetch_all("persons", fields="first_name,last_name")
+            self.assertEqual(
+                mock.last_request.qs, {"fields": ["first_name,last_name"]}
+            )
+
     def test_fetch_first(self):
         with requests_mock.mock() as mock:
             mock_route(


### PR DESCRIPTION
**Problem**
- List calls always return full records: no way to request only the attributes a script needs, which slows down large fetches

**Solution**
- Add a `fields` parameter to `gazu.client.fetch_all` (sync and async) mapping to the Zou `fields` query parameter on generic list routes

Fix #279