### PR TITLE
[project] Support task-type-scoped metadata descriptors

### DIFF
--- a/gazu/project.py
+++ b/gazu/project.py
@@ -353,6 +353,7 @@ def add_metadata_descriptor(
     choices: list[str] | None = None,
     for_client: bool = False,
     departments: list[str | dict] | None = None,
+    task_type_id: str | dict | None = None,
     client: KitsuClient = default,
 ) -> dict:
     """
@@ -362,11 +363,13 @@ def add_metadata_descriptor(
         project (dict / ID): The project dict or id.
         name (str): The name of the metadata descriptor
         entity_type (str): One of "Asset", "Shot", "Edit", "Episode",
-            "Sequence", "Project".
+            "Sequence", "Project", "Task".
         data_type (str): The value type, defaults to "string".
         choices (list): A list of possible values, empty list for free values.
         for_client (bool) : Wheter it should be displayed in Kitsu or not.
         departments (list): A list of departments dict or id.
+        task_type_id (dict / ID): The task type the descriptor is scoped to.
+            Required when entity_type is "Task", forbidden otherwise.
 
     Returns:
         dict: Created metadata descriptor.
@@ -384,6 +387,8 @@ def add_metadata_descriptor(
         "entity_type": entity_type,
         "departments": normalize_list_of_models_for_links(departments),
     }
+    if task_type_id is not None:
+        data["task_type_id"] = normalize_model_parameter(task_type_id)["id"]
     return raw.post(
         f"data/projects/{project['id']}/metadata-descriptors",
         data,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -288,6 +288,33 @@ class ProjectTestCase(unittest.TestCase):
                 result,
             )
 
+    def test_add_task_metadata_descriptor(self):
+        result = {
+            "id": fakeid("metadata-descriptor-1"),
+            "name": "metadata-descriptor-1",
+            "task_type_id": fakeid("task-type-1"),
+        }
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                f"data/projects/{fakeid('project-1')}/metadata-descriptors",
+                text=result,
+            )
+            self.assertEqual(
+                gazu.project.add_metadata_descriptor(
+                    fakeid("project-1"),
+                    "metadata-descriptor-1",
+                    "Task",
+                    task_type_id=fakeid("task-type-1"),
+                ),
+                result,
+            )
+            self.assertEqual(
+                mock.last_request.json()["task_type_id"],
+                fakeid("task-type-1"),
+            )
+
     def test_get_metadata_descriptor(self):
         with requests_mock.mock() as mock:
             mock_route(


### PR DESCRIPTION
**Problem**
- gazu could not create metadata descriptors scoped to a task type: `add_metadata_descriptor` had no way to pass a task type.

**Solution**
- Add an optional `task_type_id` parameter to `add_metadata_descriptor`, matching the task-scoped descriptors added in zou (cgwire/zou#1173).