### PR TITLE
[person] Add is_bot parameter to get_person_by_email

### DIFF
--- a/gazu/person.py
+++ b/gazu/person.py
@@ -162,17 +162,19 @@ def get_person_by_desktop_login(
 
 @cache
 def get_person_by_email(
-    email: str, client: KitsuClient = default
+    email: str, is_bot: bool = False, client: KitsuClient = default
 ) -> dict | None:
     """
     Args:
         email (str): User's email.
+        is_bot (bool): Whether to look up a bot account instead of a
+            regular person.
 
     Returns:
         dict:  Person corresponding to given email.
     """
     return raw.fetch_first(
-        "persons", {"email": email, "is_bot": False}, client=client
+        "persons", {"email": email, "is_bot": is_bot}, client=client
     )
 
 

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -164,6 +164,27 @@ class PersonTestCase(unittest.TestCase):
             person = gazu.person.get_person_by_email("john@gmail.com")
             self.assertEqual(person["id"], "person-01")
 
+    def test_get_person_by_email_is_bot(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                gazu.client.get_full_url(
+                    "data/persons?email=bot@gmail.com&is_bot=True"
+                ),
+                text=json.dumps(
+                    [
+                        {
+                            "first_name": "Bot",
+                            "last_name": "",
+                            "id": "person-02",
+                        }
+                    ]
+                ),
+            )
+            person = gazu.person.get_person_by_email(
+                "bot@gmail.com", is_bot=True
+            )
+            self.assertEqual(person["id"], "person-02")
+
     def test_new_person(self):
         with requests_mock.mock() as mock:
             result = {


### PR DESCRIPTION
**Problem**

- `get_person_by_email` hardcoded `is_bot: False`, so bot accounts could never be looked up by email.

**Solution**

- Added an `is_bot` parameter (default `False`, preserving current behavior) that's forwarded to the `persons` filter.
- Added a test covering the bot lookup case.