### PR TITLE
[projects] Add team member role wrappers

### DIFF
--- a/gazu/project.py
+++ b/gazu/project.py
@@ -577,7 +577,10 @@ def get_team(project: str | dict, client: KitsuClient = default) -> list[dict]:
 
 
 def add_person_to_team(
-    project: str | dict, person: str | dict, client: KitsuClient = default
+    project: str | dict,
+    person: str | dict,
+    role: str | None = None,
+    client: KitsuClient = default,
 ) -> dict:
     """
     Add a person to the team project.
@@ -585,6 +588,9 @@ def add_person_to_team(
     Args:
         project (dict / ID): The project dict or id.
         person (dict / ID): The person dict or id.
+        role (str): Role of the person on this project only (user,
+            supervisor, manager, client or vendor). None means the person
+            keeps their global role.
 
     Returns:
         dict: The project dictionary.
@@ -592,7 +598,36 @@ def add_person_to_team(
     project = normalize_model_parameter(project)
     person = normalize_model_parameter(person)
     data = {"person_id": person["id"]}
+    if role is not None:
+        data["role"] = role
     return raw.post(f"data/projects/{project['id']}/team", data, client=client)
+
+
+def update_team_member_role(
+    project: str | dict,
+    person: str | dict,
+    role: str | None,
+    client: KitsuClient = default,
+) -> dict:
+    """
+    Set the role a person has on given project only.
+
+    Args:
+        project (dict / ID): The project dict or id.
+        person (dict / ID): The person dict or id.
+        role (str): user, supervisor, manager, client or vendor. None
+            restores inheritance of the person's global role.
+
+    Returns:
+        dict: The updated team link (project_id, person_id and role).
+    """
+    project = normalize_model_parameter(project)
+    person = normalize_model_parameter(person)
+    return raw.put(
+        f"data/projects/{project['id']}/team/{person['id']}",
+        {"role": role},
+        client=client,
+    )
 
 
 def remove_person_from_team(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -636,6 +636,45 @@ class ProjectTestCase(unittest.TestCase):
                 },
             )
 
+    def test_add_person_to_team_with_role(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                f"data/projects/{fakeid('project-1')}/team",
+                text={
+                    "team": [fakeid("person-1")],
+                },
+            )
+            gazu.project.add_person_to_team(
+                fakeid("project-1"), fakeid("person-1"), role="supervisor"
+            )
+            self.assertEqual(
+                mock.last_request.json(),
+                {"person_id": fakeid("person-1"), "role": "supervisor"},
+            )
+
+    def test_update_team_member_role(self):
+        with requests_mock.mock() as mock:
+            project_id = fakeid("project-1")
+            person_id = fakeid("person-1")
+            path = f"data/projects/{project_id}/team/{person_id}"
+            mock_route(
+                mock,
+                "PUT",
+                path,
+                text={
+                    "project_id": project_id,
+                    "person_id": person_id,
+                    "role": "manager",
+                },
+            )
+            link = gazu.project.update_team_member_role(
+                project_id, person_id, "manager"
+            )
+            self.assertEqual(link["role"], "manager")
+            self.assertEqual(mock.last_request.json(), {"role": "manager"})
+
     def test_remove_person_from_team(self):
         with requests_mock.mock() as mock:
             project_id = fakeid("project-1")


### PR DESCRIPTION
**Problem**
- Zou supports a role per project on team members (cgwire/zou#1174) and the client has no wrapper for it

**Solution**
- `add_person_to_team` accepts an optional `role` argument
- New `update_team_member_role(project, person, role)` wrapper for `PUT /data/projects/<project_id>/team/<person_id>`; `None` restores inheritance of the global role