### PR TITLE
Add remove_entities to delete entities in batch

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -43,7 +43,7 @@ classes, just functions that call `raw.get()`, `raw.post()`, etc.
 | `scene.py`            | Scenes              | 17        |
 | `edit.py`             | Edits               | 9         |
 | `concept.py`          | Concepts            | 8         |
-| `entity.py`           | Generic entities    | 11        |
+| `entity.py`           | Generic entities    | 12        |
 | `task.py`             | Tasks, comments, previews | 100 |
 | `files.py`            | Working/output/preview files | 76 |
 | `person.py`           | Persons, departments, orgs | 41 |

--- a/gazu/entity.py
+++ b/gazu/entity.py
@@ -5,7 +5,10 @@ from . import client as raw
 from .cache import cache
 from .client import KitsuClient
 from .sorting import sort_by_name
-from .helpers import normalize_model_parameter
+from .helpers import (
+    normalize_model_parameter,
+    normalize_list_of_models_for_links,
+)
 
 default = raw.default_client
 
@@ -172,6 +175,50 @@ def remove_entity(
     if force:
         params = {"force": True}
     return raw.delete(path, params, client=client)
+
+
+def remove_entities(
+    project: str | dict,
+    entities: list[str | dict],
+    force: bool = False,
+    client: KitsuClient = default,
+) -> list[str]:
+    """
+    Remove several entities (assets, shots, edits and concepts) of a given
+    project in a single request.
+
+    Without `force`, entities that have tasks linked to them are only marked
+    as canceled on a first call, and really removed on a second one. Concepts
+    are always really removed. With `force`, every entity and its tasks are
+    removed right away.
+
+    Only the creator of an entity or a project manager can remove it. For
+    managers, entities that don't exist, that belong to another project, or
+    that are neither an asset, a shot, an edit nor a concept are silently
+    ignored: they don't make the whole batch fail, they are simply absent
+    from the returned list. For other users, a single entity created by
+    someone else makes the whole request fail and nothing is removed.
+
+    Entities are removed one by one by the API: if an error occurs
+    mid-batch, entities already processed remain deleted even though no
+    list is returned.
+
+    Args:
+        project (str / dict): The project the entities belong to.
+        entities (list): Entities to remove, as IDs or dicts. Every ID must
+            be a valid UUID, otherwise the whole batch is rejected.
+        force (bool): Whether to force deletion of the entities regardless of
+            whether they have links to tasks.
+
+    Returns:
+        list: IDs of the entities effectively processed by the API.
+    """
+    project = normalize_model_parameter(project)
+    entity_ids = normalize_list_of_models_for_links(entities)
+    path = f"actions/projects/{project['id']}/delete-entities"
+    if force:
+        path += "?force=true"
+    return raw.post(path, entity_ids, client=client)
 
 
 def all_entities_with_tasks_linked_to_entity(

--- a/tests/fixtures/zou_routes.json
+++ b/tests/fixtures/zou_routes.json
@@ -23,6 +23,7 @@
  "/actions/production-schedule-versions/<production_schedule_version_id>/set-task-links-from-production-schedule-version",
  "/actions/projects/<project_id>/asset-types/<asset_type_id>/assets/share",
  "/actions/projects/<project_id>/assets/share",
+ "/actions/projects/<project_id>/delete-entities",
  "/actions/projects/<project_id>/delete-tasks",
  "/actions/projects/<project_id>/set-file-tree",
  "/actions/projects/<project_id>/task-types/<task_type_id>/assets/create-tasks",

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -131,6 +131,74 @@ class AssetTestCase(unittest.TestCase):
             )
             gazu.entity.remove_entity(fakeid("entity-1"), True)
 
+    def test_remove_entities(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                f"actions/projects/{fakeid('project-1')}/delete-entities",
+                text=[fakeid("asset-1"), fakeid("shot-1")],
+            )
+            entity_ids = gazu.entity.remove_entities(
+                fakeid("project-1"),
+                [fakeid("asset-1"), fakeid("shot-1")],
+            )
+            self.assertEqual(entity_ids, [fakeid("asset-1"), fakeid("shot-1")])
+            self.assertEqual(
+                mock.last_request.json(),
+                [fakeid("asset-1"), fakeid("shot-1")],
+            )
+            self.assertNotIn("force", mock.last_request.qs)
+
+    def test_remove_entities_with_force(self):
+        with requests_mock.mock() as mock:
+            path = (
+                f"actions/projects/{fakeid('project-1')}"
+                "/delete-entities?force=true"
+            )
+            mock_route(mock, "POST", path, text=[fakeid("asset-1")])
+            entity_ids = gazu.entity.remove_entities(
+                fakeid("project-1"), [fakeid("asset-1")], force=True
+            )
+            self.assertEqual(entity_ids, [fakeid("asset-1")])
+            self.assertEqual(
+                mock.last_request.url, gazu.client.get_full_url(path)
+            )
+            self.assertEqual(mock.last_request.json(), [fakeid("asset-1")])
+
+    def test_remove_entities_with_dicts(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                f"actions/projects/{fakeid('project-1')}/delete-entities",
+                text=[fakeid("asset-1"), fakeid("shot-1")],
+            )
+            entity_ids = gazu.entity.remove_entities(
+                {"id": fakeid("project-1"), "name": "Project 01"},
+                [
+                    {"id": fakeid("asset-1"), "name": "Asset 01"},
+                    {"id": fakeid("shot-1"), "name": "Shot 01"},
+                ],
+            )
+            self.assertEqual(entity_ids, [fakeid("asset-1"), fakeid("shot-1")])
+            self.assertEqual(
+                mock.last_request.json(),
+                [fakeid("asset-1"), fakeid("shot-1")],
+            )
+
+    def test_remove_entities_with_empty_list(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "POST",
+                f"actions/projects/{fakeid('project-1')}/delete-entities",
+                text=[],
+            )
+            entity_ids = gazu.entity.remove_entities(fakeid("project-1"), [])
+            self.assertEqual(entity_ids, [])
+            self.assertEqual(mock.last_request.json(), [])
+
     def test_remove_entity_type(self):
         with requests_mock.mock() as mock:
             mock.delete(


### PR DESCRIPTION
**Problem**
- There was no way to delete several entities at once: callers had to loop
  over `remove_entity`, paying one HTTP request per entity, even though Zou
  exposes a batch deletion endpoint.

**Solution**
- Add `gazu.entity.remove_entities` to delete entities of a project in a
  single request, with documentation and tests.
