### PR TITLE
[events] Add get_last_login_logs wrapper

### DIFF
--- a/gazu/client.py
+++ b/gazu/client.py
@@ -365,7 +365,9 @@ def build_path_with_params(path: str, params: dict) -> str:
     if not params:
         return path
 
-    query_string = urlencode(params)
+    # doseq: encode list values as repeated params (?ids=a&ids=b), the form
+    # Zou's "append" query arguments expect.
+    query_string = urlencode(params, doseq=True)
 
     if query_string:
         # Support base paths that already contain query parameters.

--- a/gazu/events.py
+++ b/gazu/events.py
@@ -11,12 +11,14 @@ from typing import Any, Callable
 from engineio.base_client import signal_handler
 from .exception import AuthFailedException
 
+from . import client as raw
 from .client import (
     default_client,
     get_event_host,
     KitsuClient,
     make_auth_header,
 )
+from .helpers import normalize_model_parameter, validate_date_format
 
 logger = logging.getLogger("gazu.events")
 
@@ -94,6 +96,44 @@ def init(
 
     event_client.connect(get_event_host(client), auth_headers)
     return event_client
+
+
+def get_last_login_logs(
+    after: str | None = None,
+    before: str | None = None,
+    limit: int = 100,
+    cursor_login_log_id: str | None = None,
+    person_ids: list[str | dict] | None = None,
+    client: KitsuClient = default_client,
+) -> list[dict]:
+    """
+    Get last login logs. Requires admin permissions (login logs carry the IP
+    address of every person and cover the whole studio).
+
+    Args:
+        after (str): Get only logins occuring after given date.
+        before (str): Get only logins occuring before given date.
+        limit (int): Number of login logs to retrieve (server caps at 1000).
+        cursor_login_log_id (str): ID of the last login log from previous
+            page, for cursor-based pagination.
+        person_ids (list[str / dict]): Get only logins of given persons.
+
+    Returns:
+        list[dict]: Last login logs (person id, date, IP address and origin)
+        matching criterions, most recent first.
+    """
+    params = {"limit": limit}
+    if after is not None:
+        params["after"] = validate_date_format(after)
+    if before is not None:
+        params["before"] = validate_date_format(before)
+    if cursor_login_log_id is not None:
+        params["cursor_login_log_id"] = cursor_login_log_id
+    if person_ids:
+        params["person_ids"] = [
+            normalize_model_parameter(person)["id"] for person in person_ids
+        ]
+    return raw.get("data/events/login-logs/last", params=params, client=client)
 
 
 def connect_error(data: str) -> str:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,8 +1,12 @@
 import unittest
 from unittest import mock
 
+import requests_mock
+
 import gazu.client
 import gazu.events
+
+from utils import fakeid, mock_route
 
 
 class EventsInitTestCase(unittest.TestCase):
@@ -39,6 +43,35 @@ class EventsInitTestCase(unittest.TestCase):
             # Subsequent (reconnect) attempts refresh the token.
             headers_cb()
             refresh.assert_called_once()
+
+
+class EventsLoginLogsTestCase(unittest.TestCase):
+    def test_get_last_login_logs(self):
+        with requests_mock.mock() as mock:
+            mock_route(
+                mock,
+                "GET",
+                "data/events/login-logs/last",
+                text=[
+                    {"id": fakeid("log-1"), "person_id": fakeid("person-1")}
+                ],
+            )
+            result = gazu.events.get_last_login_logs(
+                after="2026-01-01",
+                limit=10,
+                person_ids=[fakeid("person-1"), {"id": fakeid("person-2")}],
+            )
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]["id"], fakeid("log-1"))
+            qs = mock.last_request.qs
+            self.assertEqual(qs["limit"], ["10"])
+            self.assertEqual(qs["after"], ["2026-01-01"])
+            # person_ids must be repeated params, one per person, with dicts
+            # and raw ids both accepted.
+            self.assertEqual(
+                qs["person_ids"],
+                [fakeid("person-1"), fakeid("person-2")],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Problem**

- No gazu function exposed `GET data/events/login-logs/last`, so retrieving users' last login dates required raw `gazu.client.get` calls.
- `build_path_with_params` encoded list values as a Python repr instead of repeated query params, breaking Zou's "append" arguments like `person_ids`.

**Solution**

- Add `gazu.events.get_last_login_logs` with `after`, `before`, `limit`, `cursor_login_log_id` and `person_ids` filters, plus a requests_mock test.
- Encode query params with `urlencode(doseq=True)` so list values become repeated params.